### PR TITLE
(again) added support for SD card detection

### DIFF
--- a/sources/Adapters/picoTracker/audio/picoTrackerAudioDriver.cpp
+++ b/sources/Adapters/picoTracker/audio/picoTrackerAudioDriver.cpp
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "picoTrackerAudioDriver.h"
 #include "Adapters/picoTracker/platform/platform.h"
 #include "Adapters/picoTracker/utils/utils.h"

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -242,27 +242,33 @@ void picoTrackerFile::Close() { file_.close(); }
 
 int picoTrackerFile::Error() { return file_.getError(); }
 
+
 picoTrackerFileSystem::picoTrackerFileSystem() {
 
+  SDstatus_ = FSUnknown;
   // Check for the common case, FAT filesystem as first partition
   Trace::Log("FILESYSTEM", "Try to mount SD Card");
-  if (SD_.begin(SD_CONFIG)) {
+    if (SD_.begin(SD_CONFIG)) {
     Trace::Log("FILESYSTEM",
                "Mounted SD Card FAT Filesystem from first partition");
+    SDstatus_ = FSOK; 
     return;
   }
 
   // Do we have any kind of card?
   if (!SD_.card() || SD_.sdErrorCode() != 0) {
-    Trace::Log("FILESYSTEM", "No SD Card present");
+    Trace::Log("FILESYSTEM", "No SD Card present %d %d", SD_.card(), SD_.sdErrorCode());
+    SDstatus_ = FSNotPresent;
     return;
   }
   // Try to mount the whole card as FAT (without partition table)
   if (static_cast<FsVolume *>(&SD_)->begin(SD_.card(), true, 0)) {
     Trace::Log("FILESYSTEM",
                "Mounted SD Card FAT Filesystem without partition table");
+    SDstatus_ = FSOK;
     return;
   }
+  SDstatus_ = FSPartitionNotPresent;
 }
 
 I_File *picoTrackerFileSystem::Open(const char *path, const char *mode) {
@@ -326,4 +332,8 @@ FileType picoTrackerFileSystem::GetFileType(const char *path) {
 
 I_PagedDir *picoTrackerFileSystem::OpenPaged(const char *path) {
   return new picoTrackerPagedDir{path};
+}
+
+FileSystemStatus picoTrackerFileSystem::GetFSStatus() {
+  return SDstatus_;
 }

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -64,12 +64,14 @@ public:
   virtual I_File *Open(const char *path, const char *mode);
   virtual I_Dir *Open(const char *path);
   virtual I_PagedDir *OpenPaged(const char *path);
+  virtual FileSystemStatus GetFSStatus();
   virtual FileType GetFileType(const char *path);
   virtual Result MakeDir(const char *path);
   virtual void Delete(const char *){};
 
 private:
   SdFs SD_;
+  FileSystemStatus SDstatus_;
 };
 
 #endif

--- a/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
@@ -9,11 +9,7 @@
 #define LIST_SIZE 14
 #define LIST_WIDTH 26
 
-#ifndef NO_EXIT
-static const char *buttonText[3] = {"Load", "New", "Exit"};
-#else
 static const char *buttonText[2] = {"Load", "New"};
-#endif
 
 Path SelectProjectDialog::lastFolder_("root:");
 int SelectProjectDialog::lastProject_ = 0;
@@ -106,11 +102,7 @@ void SelectProjectDialog::DrawView() {
 
   SetColor(CD_NORMAL);
 
-#ifndef NO_EXIT
-  for (int i = 0; i < 3; i++) {
-#else
   for (int i = 0; i < 2; i++) {
-#endif
     const char *text = buttonText[i];
     x = offset * (i + 1) - strlen(text) / 2;
     props.invert_ = (i == selected_) ? true : false;
@@ -186,11 +178,6 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
         DoModal(npd, NewProjectCallback);
         break;
       }
-#ifndef NO_EXIT
-      case 2: // Exit ;
-        EndModal(0);
-        break;
-#endif
       }
     } else {
       // R Modifier
@@ -203,21 +190,12 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
           warpToNextProject(1);
         if (mask == EPBM_LEFT) {
           selected_--;
-#ifdef NO_EXIT
           if (selected_ < 0)
             selected_ += 2;
-#else
-          if (selected_ < 0)
-            selected_ += 3;
-#endif
           isDirty_ = true;
         }
         if (mask == EPBM_RIGHT) {
-#ifdef NO_EXIT
           selected_ = (selected_ + 1) % 2;
-#else
-          selected_ = (selected_ + 1) % 3;
-#endif
           isDirty_ = true;
         }
       }

--- a/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
+++ b/sources/Application/Views/ModalDialogs/SelectProjectDialog.cpp
@@ -9,7 +9,11 @@
 #define LIST_SIZE 14
 #define LIST_WIDTH 26
 
+#ifndef NO_EXIT
+static const char *buttonText[3] = {"Load", "New", "Exit"};
+#else
 static const char *buttonText[2] = {"Load", "New"};
+#endif
 
 Path SelectProjectDialog::lastFolder_("root:");
 int SelectProjectDialog::lastProject_ = 0;
@@ -102,7 +106,11 @@ void SelectProjectDialog::DrawView() {
 
   SetColor(CD_NORMAL);
 
+#ifndef NO_EXIT
+  for (int i = 0; i < 3; i++) {
+#else
   for (int i = 0; i < 2; i++) {
+#endif
     const char *text = buttonText[i];
     x = offset * (i + 1) - strlen(text) / 2;
     props.invert_ = (i == selected_) ? true : false;
@@ -178,6 +186,11 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
         DoModal(npd, NewProjectCallback);
         break;
       }
+#ifndef NO_EXIT
+      case 2: // Exit ;
+        EndModal(0);
+        break;
+#endif
       }
     } else {
       // R Modifier
@@ -190,12 +203,21 @@ void SelectProjectDialog::ProcessButtonMask(unsigned short mask, bool pressed) {
           warpToNextProject(1);
         if (mask == EPBM_LEFT) {
           selected_--;
+#ifdef NO_EXIT
           if (selected_ < 0)
             selected_ += 2;
+#else
+          if (selected_ < 0)
+            selected_ += 3;
+#endif
           isDirty_ = true;
         }
         if (mask == EPBM_RIGHT) {
+#ifdef NO_EXIT
           selected_ = (selected_ + 1) % 2;
+#else
+          selected_ = (selected_ + 1) % 3;
+#endif
           isDirty_ = true;
         }
       }
@@ -247,6 +269,26 @@ void SelectProjectDialog::setCurrentFolder(Path &path) {
   selected_ = 0;
   currentPath_ = path;
   content_.Empty();
+
+  #ifdef PICOBUILD
+  FileSystemStatus st = FileSystem::GetInstance()->GetFSStatus();
+  if (st != FSOK) {
+    std::string msg;
+    switch(st) {
+      case FSNotPresent:          msg = "**SD not present"; break;
+      case FSPartitionNotPresent: msg = "**SD no partition"; break;
+      case FSUnknown:
+      default:  
+        msg = "**Filesystem status unknown"; 
+        break;
+    }
+    content_.Insert(new Path(msg));
+    // reset & redraw screen
+    topIndex_ = 0;
+    currentProject_ = 0;
+    isDirty_ = true;
+  }
+  #endif
 
   // Let's read all the directory in the root
 

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -50,6 +50,11 @@ add_compile_options(
   -Wno-int-to-pointer-cast
 )
 
+# EP added the below
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-overloaded-virtual>)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-c++20-compat>)
+# add_definitions(-DPICO_FLASH_SIZE_BYTES=16777216)
+
 add_subdirectory(Adapters)
 add_subdirectory(UIFramework)
 add_subdirectory(System)

--- a/sources/System/FileSystem/FileSystem.h
+++ b/sources/System/FileSystem/FileSystem.h
@@ -18,6 +18,9 @@
 #define PAGED_PAGE_SIZE 18
 
 enum FileType { FT_UNKNOWN, FT_FILE, FT_DIR };
+#ifdef PICOBUILD
+enum FileSystemStatus { FSOK, FSNotPresent, FSPartitionNotPresent, FSUnknown };
+#endif
 
 struct FileListItem {
 public:
@@ -141,6 +144,7 @@ public:
   virtual I_Dir *Open(const char *path) = 0;
 #ifdef PICOBUILD
   virtual I_PagedDir *OpenPaged(const char *path) = 0;
+  virtual FileSystemStatus GetFSStatus() = 0;
 #endif
   virtual Result MakeDir(const char *path) = 0;
   virtual void Delete(const char *) = 0;


### PR DESCRIPTION
Thanks @maks for your comments. Please take a look if this PR makes more sense - I followed your advice and applied a patch to the head of the master branch. This was what I was trying to the last time around, but in the meantime there had been quite a few commits to master and I was also trying out things... Below the NO_EXIT definition tests coming back is a bit surprising, I will take a look.

Simple modifications to detect if an SD card is not in the picoTracker (based on existing code for SD card presence and filesystem mount). Between making my edits the master branch had a bunch of changes, among them there seems to be a change on the policy of how '#ifdef PICOSYSTEM' is used.

Fixes: #124 
