### PR TITLE
portomento for MIDI using the the PSL cmd

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -477,6 +477,7 @@ sends a program change command on the current channel. 0000 is program change 1
 **PitchSLide performs a linear pitch slide from previous note value to pitch bb at speed aa**
 - PSL is also time for the first two byte nibble
 - PITCH is linear pitch change
+For MIDI instruments, this plays as portomento the next note (ie. starts the next note *before* stopping this one)
 
 ## RTG aabb (RTRG in lgpt)
 

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -60,6 +60,8 @@ private:
   int remainingTicks_;
   bool playing_;
   bool retrig_;
+  bool porto_;
+  char porto_pending_[SONG_CHANNEL_COUNT];
   int retrigLoop_;
   char velocity_ = 127;
   TableSaveState tableState_;


### PR DESCRIPTION
Allows using the `PSL` command to set portomento for a subsequent MIDI note.

Fixes: #78 