### PR TITLE
Add a VU meter

### DIFF
--- a/sources/Application/Audio/DummyAudioOut.h
+++ b/sources/Application/Audio/DummyAudioOut.h
@@ -31,6 +31,9 @@ public:
 
   virtual int GetPlayedBufferPercentage() { return 0; };
 
+  virtual short GetLastPeakL() { return 0; };
+  virtual short GetLastPeakR() { return 0; };
+
   void SendPulse();
 
   virtual std::string GetAudioAPI();

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -171,6 +171,10 @@ int MixerService::GetPlayedBufferPercentage() {
   return out_->GetPlayedBufferPercentage();
 }
 
+int MixerService::GetAudioPeakL() { return out_->GetLastPeakL(); };
+
+int MixerService::GetAudioPeakR() { return out_->GetLastPeakR(); };
+
 void MixerService::toggleRendering(bool enable) {
   switch (mode_) {
   case MSM_AUDIO:

--- a/sources/Application/Mixer/MixerService.h
+++ b/sources/Application/Mixer/MixerService.h
@@ -49,6 +49,9 @@ public:
   void SetMasterVolume(int);
   int GetPlayedBufferPercentage();
 
+  int GetAudioPeakL();
+  int GetAudioPeakR();
+
   virtual void Execute(FourCC id, float value);
 
   AudioOut *GetAudioOut();

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -75,6 +75,10 @@ bool Player::IsChannelMuted(int channel) {
   return mixer_->IsChannelMuted(channel);
 };
 
+PlayerLevels *Player::GetLevels() {
+  return new PlayerLevels(mixer_->GetAudioLevelL(), mixer_->GetAudioLevelR());
+}
+
 void Player::Start(PlayMode mode, bool forceSongMode) {
 
   mixer_->Lock();

--- a/sources/Application/Player/Player.h
+++ b/sources/Application/Player/Player.h
@@ -21,6 +21,13 @@ enum QueueingMode {
   QM_TICKSTART
 };
 
+struct PlayerLevels {
+public:
+  const int Left;
+  const int Right;
+  PlayerLevels(int l, int r) : Left{l}, Right{r} {};
+};
+
 class PlayerEvent : public ViewEvent {
 public:
   PlayerEvent(PlayerEventType type, unsigned int tickCount = 0);
@@ -102,6 +109,9 @@ public:
   int GetAudioBufferSize();
   int GetAudioRequestedBufferSize();
   int GetAudioPreBufferCount();
+
+  // master out, last avg level while playing
+  PlayerLevels *GetLevels();
 
 protected:
   void updateSongPos(int position, int channel, int chainPos = 0, int hop = -1);

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -97,6 +97,10 @@ I_Instrument *PlayerMixer::GetLastInstrument(int channel) {
   return lastInstrument_[channel];
 };
 
+short PlayerMixer::GetAudioLevelL() { return peakL_; }
+
+short PlayerMixer::GetAudioLevelR() { return peakR_; }
+
 bool PlayerMixer::Clipped() { return clipped_; }
 
 void PlayerMixer::Update(Observable &o, I_ObservableData *d) {
@@ -111,6 +115,9 @@ void PlayerMixer::Update(Observable &o, I_ObservableData *d) {
   MixerService *ms = MixerService::GetInstance();
   ms->SetMasterVolume(project_->GetMasterVolume());
   clipped_ = ms->Clipped();
+
+  peakL_ = ms->GetAudioPeakL();
+  peakR_ = ms->GetAudioPeakR();
 };
 
 void PlayerMixer::StartInstrument(int channel, I_Instrument *instrument,

--- a/sources/Application/Player/PlayerMixer.h
+++ b/sources/Application/Player/PlayerMixer.h
@@ -49,6 +49,9 @@ public:
 
   bool Clipped();
 
+  short GetAudioLevelL();
+  short GetAudioLevelR();
+
   void Update(Observable &o, I_ObservableData *d);
   int GetPlayedBufferPercentage();
 
@@ -66,6 +69,8 @@ public:
 private:
   Project *project_;
   bool clipped_;
+  short peakL_;
+  short peakR_;
 
   I_Instrument *lastInstrument_[SONG_CHANNEL_COUNT];
   bool isChannelPlaying_[SONG_CHANNEL_COUNT];

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -245,3 +245,28 @@ void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
     DrawString(pos._x, pos._y, battText, props);
   }
 }
+
+void View::drawMasterVuMeter(Player *player, GUIPoint pos,
+                             GUITextProperties props) {
+  pos = GetAnchor();
+  pos._x += 24;
+  pos._y += 15;
+  auto playerLevels = player->GetLevels();
+  short lBars = playerLevels->Left / 1024;
+  short rBars = playerLevels->Right / 1024;
+
+  for (int i = 0; i < 16; i++) {
+    if (lBars > i) {
+      DrawString(pos._x, pos._y, "=", props);
+    } else {
+      DrawString(pos._x, pos._y, " ", props);
+    }
+    if (rBars > i) {
+      DrawString(pos._x + 1, pos._y, "=", props);
+    } else {
+      DrawString(pos._x + 1, pos._y, " ", props);
+    }
+    pos._y -= 1;
+  }
+  delete playerLevels;
+}

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -249,7 +249,7 @@ void View::drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props) {
 void View::drawMasterVuMeter(Player *player, GUIPoint pos,
                              GUITextProperties props) {
   pos = GetAnchor();
-  pos._x += 24;
+  pos._x += 25;
   pos._y += 15;
   auto playerLevels = player->GetLevels();
   short lBars = playerLevels->Left / 1024;

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -256,6 +256,7 @@ void View::drawMasterVuMeter(Player *player, GUIPoint pos,
   short rBars = playerLevels->Right / 1024;
 
   for (int i = 0; i < 16; i++) {
+    setVUMeterColor_(i);
     if (lBars > i) {
       DrawString(pos._x, pos._y, "=", props);
     } else {
@@ -269,4 +270,14 @@ void View::drawMasterVuMeter(Player *player, GUIPoint pos,
     pos._y -= 1;
   }
   delete playerLevels;
+}
+
+void View::setVUMeterColor_(int level) {
+  if (level > 13) {
+    SetColor(CD_ERROR);
+  } else if (level > 10) {
+    SetColor(CD_WARN);
+  } else {
+    SetColor(CD_INFO);
+  }
 }

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -154,6 +154,7 @@ private:
   static bool initPrivate_;
   ModalView *modalView_;
   ModalViewCallback modalViewCallback_;
+  void setVUMeterColor_(int level);
 
 public:
   static int margin_;

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -136,6 +136,8 @@ protected:
 
   void drawBattery(float voltage, GUIPoint &pos, GUITextProperties &props);
 
+  void drawMasterVuMeter(Player *player, GUIPoint pos, GUITextProperties props);
+
 public: // temp hack for modl windo constructors
   GUIWindow &w_;
   ViewData *viewData_;

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -797,6 +797,9 @@ void ChainView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
   pos = anchor;
   pos._x += 200;
+
+  // re-draw the VU meter
+  drawMasterVuMeter(player, pos, props);
 /*
 	if (player->Clipped()) {
            w_.DrawString("clip",pos,props); 

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -218,6 +218,10 @@ void GrooveView::OnPlayerUpdate(PlayerEventType, unsigned int tick) {
   };
 
   drawNotes();
+
+  Player *player = Player::GetInstance();
+  //  re-draw the VU meter
+  drawMasterVuMeter(player, pos, props);
 };
 
 void GrooveView::OnFocus(){};

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1307,6 +1307,9 @@ void PhraseView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   pos = anchor;
   pos._x += 200;
 
+  // re-draw the VU meter
+  drawMasterVuMeter(player, pos, props);
+
   /*	if (player->Clipped()) {
              w_.DrawString("clip",pos,props);
       } else {

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1018,6 +1018,9 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   }
 
   drawNotes();
+
+  // re-draw the VU meter
+  drawMasterVuMeter(player, pos, props);
 };
 
 void SongView::AnimationUpdate() {

--- a/sources/Services/Audio/AudioMixer.cpp
+++ b/sources/Services/Audio/AudioMixer.cpp
@@ -51,8 +51,7 @@ bool AudioMixer::Render(fixed *buffer, int samplecount) {
     }
   }
 
-  //  Aplply volume
-
+  //  Apply volume
   if (gotData) {
     fixed *c = buffer;
     if (volume_ != i2fp(1)) {

--- a/sources/Services/Audio/AudioOut.h
+++ b/sources/Services/Audio/AudioOut.h
@@ -30,6 +30,9 @@ public:
 
   virtual int GetPlayedBufferPercentage() = 0;
 
+  virtual short GetLastPeakL() = 0;
+  virtual short GetLastPeakR() = 0;
+
   virtual std::string GetAudioAPI() = 0;
   virtual std::string GetAudioDevice() = 0;
   virtual int GetAudioBufferSize() = 0;

--- a/sources/Services/Audio/AudioOutDriver.cpp
+++ b/sources/Services/Audio/AudioOutDriver.cpp
@@ -33,6 +33,10 @@ void AudioOutDriver::Stop() { driver_->Stop(); }
 
 bool AudioOutDriver::Clipped() { return clipped_; };
 
+short AudioOutDriver::GetLastPeakL() { return lastPeakVolumeL_; };
+
+short AudioOutDriver::GetLastPeakR() { return lastPeakVolumeR_; };
+
 void AudioOutDriver::Trigger() {
   prepareMixBuffers();
   hasSound_ = AudioMixer::Render(primarySoundBuffer_, sampleCount_);
@@ -67,6 +71,10 @@ void AudioOutDriver::clipToMix() {
     fixed f_32767 = i2fp(32767);
     fixed f_m32768 = i2fp(-32768);
 
+    short sampleVal = 0;
+    short peakL = 0;
+    short peakR = 0;
+
     for (int i = 0; i < sampleCount_; i++) {
       // Left
       v = *p++;
@@ -80,6 +88,11 @@ void AudioOutDriver::clipToMix() {
       *s1 = short(fp2i(v));
       s1 += offset;
 
+      sampleVal = short(fp2i(v));
+      if (sampleVal >= peakL) {
+        peakL = sampleVal;
+      }
+
       // Right
       v = *p++;
       if (v > f_32767) {
@@ -91,7 +104,15 @@ void AudioOutDriver::clipToMix() {
       }
       *s2 = short(fp2i(v));
       s2 += offset;
+
+      sampleVal = short(fp2i(v));
+      if (sampleVal >= peakR) {
+        peakR = sampleVal;
+      }
     };
+    lastPeakVolumeL_ = peakL;
+    lastPeakVolumeR_ = peakR;
+    peakL = peakR = 0;
   }
 };
 

--- a/sources/Services/Audio/AudioOutDriver.h
+++ b/sources/Services/Audio/AudioOutDriver.h
@@ -22,6 +22,9 @@ public:
 
   virtual bool Clipped();
 
+  virtual short GetLastPeakL();
+  virtual short GetLastPeakR();
+
   virtual int GetPlayedBufferPercentage();
 
   AudioDriver *GetDriver();
@@ -44,6 +47,8 @@ private:
   AudioDriver *driver_;
   bool clipped_;
   bool hasSound_;
+  short lastPeakVolumeL_ = 0;
+  short lastPeakVolumeR_ = 0;
 
   static fixed primarySoundBuffer_[MIX_BUFFER_SIZE];
   static short mixBuffer_[MIX_BUFFER_SIZE];


### PR DESCRIPTION
This adds a VU meter for the the master output, displayed on the far right hand side of the Song, Chain, Phrase and Groove screens (currently no space on the Table screen).
 
![PXL_20240407_080239839 MP_exported_967](https://github.com/democloid/picoTracker/assets/71999/c2c9716e-6077-4f34-a898-48eaa223c273)

Fixes: #42