### PR TITLE
Fix bug in nudge

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -93,6 +93,7 @@ The keyboard layout resembles a typical old console game controller
   - B+LEFT/RIGHT: Next/Previous Channel in Chain/Phrase Screen. Navigation +/- 1 in Instrument/Table Screen. Switch between Song and Live Modes in Song Screen.
 - RT+ARROWS: Navigate between the Screens.
 - LT+UP/DOWN: Jump up/down to next populated row after a blank row (great for live mode entire row queuing!)
+- LT+LEFT/RIGHT: (Song view) Nudge backward/forward (great for live mode using multiple devices!)
 
 ## Selections
 
@@ -227,7 +228,7 @@ TODO: Screencap
 
 TODO: screencap
 
-- **Tempo:**: Can be set between 60bpm [0x3c] and 400bpm [0x190]. Resolution aligned to LSDJ.
+- **Tempo:**: Can be set between 60bpm [0x3c] and 400bpm [0x190]. Resolution aligned to LSDJ. Nudge back/forward by hovering over tempo, holding B+LEFT/RIGHT
 - **Master:** Main volume goes from 10% to 200%.
 - **Transpose:** Live transposition of every triggered instruments.
 - **Compact Sequencer:** Free all unused chain/phrases.

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -75,7 +75,10 @@ int Project::GetMasterVolume() {
   return v->GetInt();
 };
 
-void Project::NudgeTempo(int value) { tempoNudge_ += value; };
+void Project::NudgeTempo(int value) {
+  if((GetTempo() + tempoNudge_) > 0)
+    tempoNudge_ += value;
+};
 
 void Project::Trigger() {
   if (tempoNudge_ != 0) {

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -76,7 +76,7 @@ int Project::GetMasterVolume() {
 };
 
 void Project::NudgeTempo(int value) {
-  if((GetTempo() + tempoNudge_) > 0)
+  if ((GetTempo() + tempoNudge_) > 0)
     tempoNudge_ += value;
 };
 

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -3,6 +3,7 @@
 #include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
+#include "Application/Commands/ApplicationCommandDispatcher.h"
 #include "UIController.h"
 #include "ViewData.h"
 #include <stdlib.h>
@@ -654,6 +655,10 @@ void SongView::processNormalButtonMask(unsigned int mask) {
             jumpToNextSection(-1);
           if (mask & EPBM_START)
             startCurrentRow();
+          if (mask&EPBM_LEFT)
+            nudgeTempo(-1);
+          if (mask&EPBM_RIGHT)
+            nudgeTempo(1);
         } else {
 
           // No modifier
@@ -1034,3 +1039,15 @@ void SongView::AnimationUpdate() {
   drawBattery(batt, pos, props);
   w_.Flush();
 };
+
+void SongView::nudgeTempo(int direction) {
+  ApplicationCommandDispatcher *dispatcher=ApplicationCommandDispatcher::GetInstance();
+  switch(direction) {
+    case -1:
+      dispatcher->OnNudgeDown();
+      break;
+    case 1:
+      dispatcher->OnNudgeUp();
+      break;
+  }
+}

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -1,9 +1,9 @@
 #include "SongView.h"
+#include "Application/Commands/ApplicationCommandDispatcher.h"
 #include "Application/Player/Player.h"
 #include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
-#include "Application/Commands/ApplicationCommandDispatcher.h"
 #include "UIController.h"
 #include "ViewData.h"
 #include <stdlib.h>
@@ -655,9 +655,9 @@ void SongView::processNormalButtonMask(unsigned int mask) {
             jumpToNextSection(-1);
           if (mask & EPBM_START)
             startCurrentRow();
-          if (mask&EPBM_LEFT)
+          if (mask & EPBM_LEFT)
             nudgeTempo(-1);
-          if (mask&EPBM_RIGHT)
+          if (mask & EPBM_RIGHT)
             nudgeTempo(1);
         } else {
 
@@ -1041,13 +1041,14 @@ void SongView::AnimationUpdate() {
 };
 
 void SongView::nudgeTempo(int direction) {
-  ApplicationCommandDispatcher *dispatcher=ApplicationCommandDispatcher::GetInstance();
-  switch(direction) {
-    case -1:
-      dispatcher->OnNudgeDown();
-      break;
-    case 1:
-      dispatcher->OnNudgeUp();
-      break;
+  ApplicationCommandDispatcher *dispatcher =
+      ApplicationCommandDispatcher::GetInstance();
+  switch (direction) {
+  case -1:
+    dispatcher->OnNudgeDown();
+    break;
+  case 1:
+    dispatcher->OnNudgeUp();
+    break;
   }
 }

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -80,6 +80,7 @@ private:
   std::string songname_;
   bool invertBatt_;
   bool needClear_;
+  void nudgeTempo(int direction);
 };
 
 #endif


### PR DESCRIPTION
Introducing the already existing, awesome, hidden and completely undocumented nudge feature!
    Very useful for DJ sets when using multiple devices
    In Project view, select tempo and hold B+LEFT/RIGHT to nudge slower/faster
    In Song view, pressing LT+LEFT/RIGHT to nudge slower/faster

    Fixes:
      Crash when nudging below 0 BPM (shoutout @merumerutho) https://github.com/djdiskmachine/LittleGPTracker/issues/127