### PR TITLE
fix display of char_list variable fields

### DIFF
--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -4,6 +4,7 @@
 #include "Externals/etl/include/etl/string.h"
 #include "Externals/etl/include/etl/string_utilities.h"
 #include "Services/Midi/MidiService.h"
+#include "Variable.h"
 #include <stdlib.h>
 
 #define CONFIG_FILE_PATH "/.config.xml"
@@ -120,15 +121,7 @@ void Config::SaveContent(tinyxml2::XMLPrinter *printer) {
     printer->OpenElement(elemName.c_str());
     // these settings need to be saved as thier Int values not as String values
     // hence we *dont* use GetString() !
-    if (elemName.compare("LINEOUT") == 0) {
-      printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
-    } else if (elemName.compare("MIDIDEVICE") == 0) {
-      printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
-    } else if (elemName.compare("MIDISYNC") == 0) {
-      printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
-    } else if (elemName.compare("REMOTEUI") == 0) {
-      printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
-    } else if (elemName.compare("UIFONT") == 0) {
+    if ((*it)->GetType() == Variable::CHAR_LIST || (*it)->GetType() == Variable::INT) {
       printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
     } else {
       // all other settings need to be saved as thier String values

--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -121,7 +121,7 @@ void Config::SaveContent(tinyxml2::XMLPrinter *printer) {
     printer->OpenElement(elemName.c_str());
     // these settings need to be saved as thier Int values not as String values
     // hence we *dont* use GetString() !
-    if ((*it)->GetType() == Variable::CHAR_LIST || (*it)->GetType() == Variable::INT) {
+    if ((*it)->GetType() == Variable::CHAR_LIST) {
       printer->PushAttribute("VALUE", std::to_string((*it)->GetInt()).c_str());
     } else {
       // all other settings need to be saved as thier String values

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -226,7 +226,7 @@ etl::string<40> Variable::GetString() {
     } else {
       return list_.char_[value_.index_];
     }
-    break;  
+    break;
   };
 
   return buf;

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -173,7 +173,6 @@ void Variable::SetString(const char *string, bool notify) {
   case FLOAT:
     value_.float_ = float(atof(string));
     break;
-  case CHAR_LIST:
   case INT:
     value_.int_ = atoi(string);
     break;
@@ -182,6 +181,24 @@ void Variable::SetString(const char *string, bool notify) {
     break;
   case STRING:
     stringValue_ = std::string(string);
+    break;
+  case CHAR_LIST:
+    value_.index_ = -1;
+    for (int i = 0; i < listSize_; i++) {
+      if (list_.char_[i]) {
+        const char *d = list_.char_[i];
+        const char *s = string;
+        while (*s != 0) {
+          if (tolower(*s++) != tolower(*d++)) {
+            break;
+          }
+        }
+        if (*s == 0) {
+          value_.index_ = i;
+          break;
+        }
+      }
+    };
     break;
   };
   if (notify) {
@@ -195,7 +212,6 @@ etl::string<40> Variable::GetString() {
   case FLOAT:
     sprintf(buf, "%f", value_.float_);
     break;
-  case CHAR_LIST:
   case INT:
     sprintf(buf, "%d", value_.int_);
     break;
@@ -204,6 +220,13 @@ etl::string<40> Variable::GetString() {
     break;
   case STRING:
     return stringValue_.c_str();
+  case CHAR_LIST:
+    if ((value_.index_ < 0) || (value_.index_ >= listSize_)) {
+      return "(null)";
+    } else {
+      return list_.char_[value_.index_];
+    }
+    break;  
   };
 
   return buf;


### PR DESCRIPTION
The previous attempt to store char list variables with their integer IDs was a bit too simplistic as the GetString() method is of course also used to access the actual displayed values for the variables.
This fix the issue by instead having Config explicitly use the GetInt() method and then itself convert the int to a string for xml storage. 

Fixes: #226 