### PR TITLE
Detect missing sdcard

### DIFF
--- a/sources/Adapters/picoTracker/display/mode0.c
+++ b/sources/Adapters/picoTracker/display/mode0.c
@@ -199,7 +199,7 @@ void mode0_draw_changed() {
 }
 
 void mode0_draw_changed_simple() {
-  // This method is better (faster) for fewer characters chnaged
+  // This method is better (faster) for fewer characters changed
   for (int idx = 0; idx < TEXT_HEIGHT * TEXT_WIDTH; idx++) {
     if (TestBit(changed, idx)) {
       ClearBit(changed, idx);

--- a/sources/Adapters/picoTracker/display/mode0.h
+++ b/sources/Adapters/picoTracker/display/mode0.h
@@ -25,8 +25,8 @@ typedef enum {
   MODE0_GREEN,
   MODE0_YELLOW_GREEN,
   MODE0_BLUE,
-  MODE0_PICTON_BLUE,
-  MODE0_PALE_BLUE
+  MODE0_GURU_TXT,
+  MODE0_GURU_BG
 } mode0_color_t;
 
 void mode0_init();

--- a/sources/Adapters/picoTracker/system/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/system/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(platform_system
   picoTrackerSystem.h picoTrackerSystem.cpp
   picoTrackerEventQueue.h picoTrackerEventQueue.cpp
   input.h input.cpp
+  critical_error_message.h critical_error_message.c
 )
 
 target_link_libraries(platform_system INTERFACE system_system

--- a/sources/Adapters/picoTracker/system/critical_error_message.c
+++ b/sources/Adapters/picoTracker/system/critical_error_message.c
@@ -21,7 +21,7 @@ void critical_error_message(const char *message) {
   int center = (32 - msglen) / 2;
   if (center > 0) {
     memset(&msgbuffer[1], ' ', center - 1);
-    strncpy(&msgbuffer[center], message, msglen);
+    memcpy(&msgbuffer[center], message, msglen);
     memset(&msgbuffer[center + msglen], ' ', 32 - center - msglen - 1);
     msgbuffer[0] = '#';
     msgbuffer[31] = '#';

--- a/sources/Adapters/picoTracker/system/critical_error_message.c
+++ b/sources/Adapters/picoTracker/system/critical_error_message.c
@@ -1,10 +1,11 @@
 #include "critical_error_message.h"
 #include "Adapters/picoTracker/display/mode0.h"
+#include <System/Console/nanoprintf.h>
 #include <string.h>
 
 // show this message and basically crash, so only for critical errors where
 // we need to show user a message and cannot continue until a reboot
-void critical_error_message(const char *message) {
+void critical_error_message(const char *message, int guruId) {
   mode0_init();
 
   mode0_set_font_index(0);
@@ -17,6 +18,9 @@ void critical_error_message(const char *message) {
 
   int msglen = strlen(message) < 30 ? strlen(message) : 30;
   char msgbuffer[32];
+  char gurumsgbuffer[32];
+  npf_snprintf(gurumsgbuffer, sizeof(gurumsgbuffer),
+               "   Guru Meditation: 00000.%04d", guruId);
 
   int center = (32 - msglen) / 2;
   if (center > 0) {
@@ -25,21 +29,24 @@ void critical_error_message(const char *message) {
     memset(&msgbuffer[center + msglen], ' ', 32 - center - msglen - 1);
     msgbuffer[0] = '#';
     msgbuffer[31] = '#';
+    gurumsgbuffer[0] = '#';
+    gurumsgbuffer[31] = '#';
   }
   // halt
   for (;;) {
-    for (int y = 0; y < 3; y++) {
+    for (int y = 0; y < 4; y++) {
       for (int x = 0; x < 32; x++) {
         mode0_set_cursor(x, y + 10);
-        if (y == 0 || y == 2) {
+        if (y == 0 || y == 3) {
           mode0_putc('#', false);
+        } else if (y == 2) {
+          mode0_putc(gurumsgbuffer[x], false);
         } else {
           mode0_putc(msgbuffer[x], false);
         }
       }
     }
     mode0_draw_changed();
-
     sleep_ms(1000);
     mode0_clear(MODE0_GURU_BG);
 
@@ -47,8 +54,9 @@ void critical_error_message(const char *message) {
     for (int x = 1; x < 31; x++) {
       mode0_set_cursor(x, 11);
       mode0_putc(msgbuffer[x], false);
+      mode0_set_cursor(x, 12);
+      mode0_putc(gurumsgbuffer[x], false);
     }
-
     mode0_draw_changed();
     sleep_ms(1000);
   }

--- a/sources/Adapters/picoTracker/system/critical_error_message.c
+++ b/sources/Adapters/picoTracker/system/critical_error_message.c
@@ -1,0 +1,44 @@
+#include "critical_error_message.h"
+#include "Adapters/picoTracker/display/mode0.h"
+
+const char msg_on[4][32] = {{"################################"},
+                            {"#       SDCARD NOT FOUND       #"},
+                            {"################################"}};
+const char msg_off[4][32] = {{"                                "},
+                             {"        SDCARD NOT FOUND        "},
+                             {"                                "}};
+
+// show this message and basically crash, so only for critical errors where
+// we need to show user a message and cannot continue until a reboot
+void critical_error_message() {
+  mode0_init();
+
+  mode0_set_font_index(0);
+
+  mode0_set_palette_color(15, 0x0000); // BLACK
+  mode0_set_palette_color(14, 0xF800); // RED
+  mode0_set_background(MODE0_GURU_BG);
+  mode0_clear(MODE0_GURU_BG);
+  mode0_set_foreground(MODE0_GURU_TXT);
+
+  // halt
+  for (;;) {
+    for (int y = 0; y < 4; y++) {
+      for (int x = 0; x < 32; x++) {
+        mode0_set_cursor(x, y + 10);
+        mode0_putc(msg_on[y][x], false);
+      }
+    }
+    mode0_draw_changed();
+
+    sleep_ms(1000);
+    for (int y = 0; y < 4; y++) {
+      for (int x = 0; x < 32; x++) {
+        mode0_set_cursor(x, y + 10);
+        mode0_putc(msg_off[y][x], false);
+      }
+    }
+    mode0_draw_changed();
+    sleep_ms(1000);
+  };
+}

--- a/sources/Adapters/picoTracker/system/critical_error_message.h
+++ b/sources/Adapters/picoTracker/system/critical_error_message.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void critical_error_message();
+void critical_error_message(const char *message);
 
 #ifdef __cplusplus
 }

--- a/sources/Adapters/picoTracker/system/critical_error_message.h
+++ b/sources/Adapters/picoTracker/system/critical_error_message.h
@@ -1,0 +1,14 @@
+#ifndef _CRITICALERRORMESSAGE_H_
+#define _CRITICALERRORMESSAGE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void critical_error_message();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/sources/Adapters/picoTracker/system/critical_error_message.h
+++ b/sources/Adapters/picoTracker/system/critical_error_message.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void critical_error_message(const char *message);
+void critical_error_message(const char *message, int guruId);
 
 #ifdef __cplusplus
 }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -58,7 +58,7 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
   auto picoFS = PicoFileSystem::GetInstance();
   if (!picoFS->chdir("/")) {
     Trace::Log("PICOTRACKERSYSTEM", "SDCARD MISSING!!\n");
-    critical_error_message();
+    critical_error_message("SDCARD MISSING");
   }
 
   // Install MIDI

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include "Adapters/picoTracker/platform/platform.h"
+#include "critical_error_message.h"
 #include "hardware/adc.h"
 #include "pico/stdlib.h"
 
@@ -52,6 +53,13 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
   static char timerMemBuf[sizeof(picoTrackerTimerService)];
   TimerService::GetInstance()->Install(new (timerMemBuf)
                                            picoTrackerTimerService());
+
+  // First check for SDCard
+  auto picoFS = PicoFileSystem::GetInstance();
+  if (!picoFS->chdir("/")) {
+    Trace::Log("PICOTRACKERSYSTEM", "SDCARD MISSING!!\n");
+    critical_error_message();
+  }
 
   // Install MIDI
   // **NOTE**: MIDI install MUST happen before Audio install because it triggers

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -58,7 +58,7 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
   auto picoFS = PicoFileSystem::GetInstance();
   if (!picoFS->chdir("/")) {
     Trace::Log("PICOTRACKERSYSTEM", "SDCARD MISSING!!\n");
-    critical_error_message("SDCARD MISSING");
+    critical_error_message("SDCARD MISSING", 0x01);
   }
 
   // Install MIDI

--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -93,7 +93,7 @@ Config::Config()
 
 Config::~Config() {}
 
-void Config::Save() {
+bool Config::Save() {
   auto picoFS = PicoFileSystem::GetInstance();
   PI_File *fp = picoFS->Open(CONFIG_FILE_PATH, "w");
   if (!fp) {
@@ -105,7 +105,7 @@ void Config::Save() {
 
   SaveContent(&printer);
 
-  fp->Close();
+  return fp->Close();
 }
 
 void Config::SaveContent(tinyxml2::XMLPrinter *printer) {

--- a/sources/Application/Model/Config.h
+++ b/sources/Application/Model/Config.h
@@ -13,7 +13,7 @@ public:
   ~Config();
   int GetValue(const char *key);
   void ProcessArguments(int argc, char **argv);
-  void Save();
+  bool Save();
 
 private:
   etl::list<Variable *, 22> variables_;

--- a/sources/System/FileSystem/PicoFileSystem.cpp
+++ b/sources/System/FileSystem/PicoFileSystem.cpp
@@ -36,7 +36,9 @@ PI_File *PicoFileSystem::Open(const char *name, const char *mode) {
     return 0;
   }
   FsBaseFile cwd;
-  cwd.openCwd();
+  if (!cwd.openCwd()) {
+    return nullptr;
+  }
   PI_File *wFile = 0;
   if (cwd.open(name, rmode)) {
     wFile = new PI_File(cwd);
@@ -245,4 +247,4 @@ long PI_File::Tell() { return file_.curPosition(); }
 
 int PI_File::Error() { return file_.getError(); }
 
-void PI_File::Close() { file_.close(); }
+bool PI_File::Close() { return file_.close(); }

--- a/sources/System/FileSystem/PicoFileSystem.h
+++ b/sources/System/FileSystem/PicoFileSystem.h
@@ -21,7 +21,7 @@ public:
   int Write(const void *ptr, int size, int nmemb);
   void Seek(long offset, int whence);
   long Tell();
-  void Close();
+  bool Close();
   bool DeleteFile();
   int Error();
 


### PR DESCRIPTION
Checks for a sdcard early in boot process by changing to root directory and on error displays a error message on screen.

Also improves error handling in some file system functions to allow for adding code in the future for detecting sdcard removal after boot.

Fixes: #124