### PR TITLE
display unique device ID on device screen

### DIFF
--- a/sources/Adapters/picoTracker/system/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/system/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(platform_system INTERFACE system_system
                                       PUBLIC hardware_adc
                                       PUBLIC etl
                                       PUBLIC platform_usb
+                                      PUBLIC pico_unique_id
 )
 
 

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -28,6 +28,7 @@
 #include "critical_error_message.h"
 #include "hardware/adc.h"
 #include "pico/stdlib.h"
+#include "pico/unique_id.h"
 
 EventManager *picoTrackerSystem::eventManager_ = NULL;
 bool picoTrackerSystem::invert_ = false;
@@ -171,4 +172,24 @@ void picoTrackerSystem::PostQuitMessage() { eventManager_->PostQuitMessage(); }
 unsigned int picoTrackerSystem::GetMemoryUsage() {
   struct mallinfo m = mallinfo();
   return m.uordblks;
+}
+
+// id_out MUST be at least 16 bytes
+void picoTrackerSystem::GetDeviceId(char *id_out) {
+  // pico_unique_board_id_t board_id;
+  // pico_get_unique_board_id(&board_id);
+
+  // printf("Unique identifier:");
+  // for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; ++i) {
+  //   printf(" %02x", board_id.id[i]);
+  // }
+  // printf("\n");
+
+  // return board_id.id[0] | (board_id.id[1] << 8) | (board_id.id[2] << 16) |
+  //        (board_id.id[3] << 24) | (board_id.id[4] << 32) |
+  //        (board_id.id[5] << 40) | (board_id.id[6] << 48) |
+  //        (board_id.id[7] << 56);
+
+  pico_get_unique_board_id_string(id_out, 16);
+  printf("PICO ID: %s\n", id_out);
 }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -176,20 +176,5 @@ unsigned int picoTrackerSystem::GetMemoryUsage() {
 
 // id_out MUST be at least 16 bytes
 void picoTrackerSystem::GetDeviceId(char *id_out) {
-  // pico_unique_board_id_t board_id;
-  // pico_get_unique_board_id(&board_id);
-
-  // printf("Unique identifier:");
-  // for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; ++i) {
-  //   printf(" %02x", board_id.id[i]);
-  // }
-  // printf("\n");
-
-  // return board_id.id[0] | (board_id.id[1] << 8) | (board_id.id[2] << 16) |
-  //        (board_id.id[3] << 24) | (board_id.id[4] << 32) |
-  //        (board_id.id[5] << 40) | (board_id.id[6] << 48) |
-  //        (board_id.id[7] << 56);
-
   pico_get_unique_board_id_string(id_out, 16);
-  printf("PICO ID: %s\n", id_out);
 }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.h
@@ -25,6 +25,7 @@ public: // System implementation
   virtual void *Memcpy(void *s1, const void *s2, int n);
   virtual void PostQuitMessage();
   virtual unsigned int GetMemoryUsage();
+  virtual void GetDeviceId(char *id_out);
 
 private:
   static bool invert_;
@@ -32,5 +33,6 @@ private:
   static unsigned int lastBeatCount_;
   static EventManager *eventManager_;
   std::map<void *, unsigned> mmap_;
+  static uint64_t deviceId_;
 };
 #endif

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -189,6 +189,20 @@ void DeviceView::DrawView() {
   SetColor(CD_NORMAL);
   DrawString(pos._x, pos._y, projectString, props);
 
+  // draw Device ID on last line
+  pos._y = 23;
+  pos._x = 5; // offset to right to avoid screenmap
+
+  System *sys = System::GetInstance();
+  char id[17];
+  sys->GetDeviceId(id);
+  sprintf(projectString, "Device ID: %s", id);
+
+  SetColor(CD_INFO);
+  DrawString(pos._x, pos._y, projectString, props);
+
+  SetColor(CD_NORMAL);
+
   FieldView::Redraw();
   drawMap();
 };

--- a/sources/System/System/System.h
+++ b/sources/System/System/System.h
@@ -16,6 +16,7 @@ public:                                 // Override in implementation
   virtual void *Memcpy(void *s1, const void *s2, int n) = 0;
   virtual void PostQuitMessage() = 0;
   virtual unsigned int GetMemoryUsage() = 0;
+  virtual void GetDeviceId(char *id_out) = 0;
 };
 
 #define SYS_MEMSET(a, b, c)                                                    \


### PR DESCRIPTION
Displays unique ID (from SPI Flash as RP2040 doesnt have its own unique id) on device screen: 

![image](https://github.com/user-attachments/assets/385d488d-a4c1-4e19-ace2-f57717c35117)
