### PR TITLE
Fix SID instrument naming not displayed after the first redraw

### DIFF
--- a/sources/Application/Instruments/SIDInstrument.cpp
+++ b/sources/Application/Instruments/SIDInstrument.cpp
@@ -44,8 +44,14 @@ SIDInstrument::SIDInstrument(SIDInstrumentInstance chip)
       table_(FourCC::SIDInstrumentTable, -1),
       tableAuto_(FourCC::SIDInstrumentTableAutomation, false) {
 
-  sprintf(name_.data_end(), "SID #%.1d OSC #%.1d", (int)chip_, (int)osc_);
-  name_.trim_to_terminator();
+  name_ = "SID #";
+  etl::string<1> num;
+  etl::format_spec format;
+  etl::to_string((int)chip_, num, format);
+  name_ += num;
+  name_ += " OSC #";
+  etl::to_string(osc_, num, format);
+  name_ += num;
 
   variables_.insert(variables_.end(), &vpw_);
   variables_.insert(variables_.end(), &vwf1_);

--- a/sources/Application/Instruments/SIDInstrument.cpp
+++ b/sources/Application/Instruments/SIDInstrument.cpp
@@ -44,14 +44,8 @@ SIDInstrument::SIDInstrument(SIDInstrumentInstance chip)
       table_(FourCC::SIDInstrumentTable, -1),
       tableAuto_(FourCC::SIDInstrumentTableAutomation, false) {
 
-  name_ = "SID #";
-  etl::string<1> num;
-  etl::format_spec format;
-  etl::to_string((int)chip_, num, format);
-  name_ += num;
-  name_ += " OSC #";
-  etl::to_string(osc_, num, format);
-  name_ += num;
+  sprintf(name_.data_end(), "SID #%.1d OSC #%.1d", (int)chip_, (int)osc_);
+  name_.trim_to_terminator();
 
   variables_.insert(variables_.end(), &vpw_);
   variables_.insert(variables_.end(), &vwf1_);

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -291,12 +291,15 @@ void InstrumentView::fillSIDParameters() {
 
   int i = viewData_->currentInstrumentID_;
   InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
-  I_Instrument *instr = bank->GetInstrument(i);
-  SIDInstrument *instrument = (SIDInstrument *)instr;
+  SIDInstrument *instrument = (SIDInstrument *)bank->GetInstrument(i);
   GUIPoint position = GetAnchor();
 
   position._y += 1;
-  staticField_.emplace_back(position, instr->GetName().c_str());
+  // work around because I can't figure out why the mem returned by c_str() is
+  // being overwritten somehow after first redraw
+  const char *s = instrument->GetName().c_str();
+  strcpy(sidName_, s);
+  staticField_.emplace_back(position, sidName_);
   fieldList_.insert(fieldList_.end(), &(*staticField_.rbegin()));
 
   position._y += 2;

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -43,10 +43,12 @@ private:
   WatchedVariable instrumentType_;
   InstrumentType currentType_ = IT_NONE;
 
+  char sidName_[24];
+
   etl::vector<UIIntVarField, 1> typeIntVarField_;
   etl::vector<UIIntVarField, 40> intVarField_;
   etl::vector<UINoteVarField, 1> noteVarField_;
-  etl::vector<UIStaticField, 1> staticField_;
+  etl::vector<UIStaticField, 4> staticField_;
   etl::vector<UIBigHexVarField, 4> bigHexVarField_;
   etl::vector<UIIntVarOffField, 1> intVarOffField_;
   etl::vector<UIBitmaskVarField, 3> bitmaskVarField_;


### PR DESCRIPTION
ie. moving the cursor through instrument fields causes redraw and the name field is not redrawn because the ram where the string for is has been overwritten.