### PR TITLE
Support 2 mesg lines for MessageBox dialogs

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -768,8 +768,8 @@ void InstrumentView::Update(Observable &o, I_ObservableData *data) {
     // confirm user wants to change instrument type &lose changes
     Player *player = Player::GetInstance();
     if (!player->IsRunning()) {
-      MessageBox *mb = new MessageBox(
-          *this, "Change Instrument & lose changes?", MBBF_YES | MBBF_NO);
+      MessageBox *mb = new MessageBox(*this, "Change Instrument &",
+                                      "lose settings?", MBBF_YES | MBBF_NO);
       DoModal(mb, ChangeInstrumentTypeCallback);
     } else {
       MessageBox *mb = new MessageBox(*this, "Not while playing", MBBF_OK);

--- a/sources/Application/Views/ModalDialogs/MessageBox.cpp
+++ b/sources/Application/Views/ModalDialogs/MessageBox.cpp
@@ -4,7 +4,7 @@
 static const char *buttonText[MBL_LAST] = {"Ok", "Yes", "Cancel", "No"};
 
 MessageBox::MessageBox(View &view, const char *message, int btnFlags)
-    : ModalView(view), message_(message) {
+    : ModalView(view), line1_(message) {
 
   buttonCount_ = 0;
   for (int i = 0; i < MBL_LAST; i++) {
@@ -18,9 +18,9 @@ MessageBox::MessageBox(View &view, const char *message, int btnFlags)
 };
 
 // Constructor for 2 line message
-MessageBox::MessageBox(View &view, const char *message, const char *message2,
-                       int btnFlags)
-    : ModalView(view), message_(message), message2_(message2) {
+MessageBox::MessageBox(View &view, const char *messageLine1,
+                       const char *messageLine2, int btnFlags)
+    : ModalView(view), line1_(messageLine1), line2_(messageLine2) {
 
   buttonCount_ = 0;
   for (int i = 0; i < MBL_LAST; i++) {
@@ -37,7 +37,7 @@ MessageBox::~MessageBox(){};
 
 void MessageBox::DrawView() {
   // message size
-  int size = message_.size();
+  int size = line1_.size();
 
   // compute space needed for buttons
   // and set window size
@@ -45,17 +45,17 @@ void MessageBox::DrawView() {
   int btnSize = 5;
   int width = buttonCount_ * (btnSize + 1) + 1;
   width = (size > width) ? size : width;
-  SetWindow(width, message2_.size() > 0 ? 4 : 3);
+  SetWindow(width, line2_.size() > 0 ? 4 : 3);
 
   // draw text
   int y = 0;
   int x = (width - size) / 2;
   GUITextProperties props;
   SetColor(CD_ERROR);
-  DrawString(x, y, message_.c_str(), props);
-  if (message2_.size() > 0) {
+  DrawString(x, y, line1_.c_str(), props);
+  if (line2_.size() > 0) {
     y++;
-    DrawString(x, y, message2_.c_str(), props);
+    DrawString(x, y, line2_.c_str(), props);
   }
 
   SetColor(CD_NORMAL);

--- a/sources/Application/Views/ModalDialogs/MessageBox.cpp
+++ b/sources/Application/Views/ModalDialogs/MessageBox.cpp
@@ -1,4 +1,5 @@
 #include "MessageBox.h"
+#include <Application/AppWindow.h>
 
 static const char *buttonText[MBL_LAST] = {"Ok", "Yes", "Cancel", "No"};
 
@@ -16,6 +17,22 @@ MessageBox::MessageBox(View &view, const char *message, int btnFlags)
   NAssert(buttonCount_ != 0);
 };
 
+// Constructor for 2 line message
+MessageBox::MessageBox(View &view, const char *message, const char *message2,
+                       int btnFlags)
+    : ModalView(view), message_(message), message2_(message2) {
+
+  buttonCount_ = 0;
+  for (int i = 0; i < MBL_LAST; i++) {
+    if (btnFlags & (1 << (i))) {
+      button_[buttonCount_] = i;
+      buttonCount_++;
+    }
+  }
+  selected_ = buttonCount_ - 1;
+  NAssert(buttonCount_ != 0);
+}
+
 MessageBox::~MessageBox(){};
 
 void MessageBox::DrawView() {
@@ -28,18 +45,22 @@ void MessageBox::DrawView() {
   int btnSize = 5;
   int width = buttonCount_ * (btnSize + 1) + 1;
   width = (size > width) ? size : width;
-  SetWindow(width, 3);
+  SetWindow(width, message2_.size() > 0 ? 4 : 3);
 
   // draw text
-
   int y = 0;
   int x = (width - size) / 2;
   GUITextProperties props;
   SetColor(CD_ERROR);
   DrawString(x, y, message_.c_str(), props);
+  if (message2_.size() > 0) {
+    y++;
+    DrawString(x, y, message2_.c_str(), props);
+  }
+
   SetColor(CD_NORMAL);
 
-  y = 2;
+  y += 2;
   int offset = width / (buttonCount_ + 1);
 
   for (int i = 0; i < buttonCount_; i++) {

--- a/sources/Application/Views/ModalDialogs/MessageBox.h
+++ b/sources/Application/Views/ModalDialogs/MessageBox.h
@@ -7,6 +7,7 @@
 #ifdef MessageBox
 #undef MessageBox
 #endif
+#include <Application/AppWindow.h>
 
 enum MessageBoxList { MBL_OK = 0, MBL_YES, MBL_CANCEL, MBL_NO, MBL_LAST };
 
@@ -31,8 +32,8 @@ public:
   virtual void AnimationUpdate(){};
 
 private:
-  std::string message_ = "";
-  std::string message2_ = "";
+  etl::string<SCREEN_WIDTH - 2> line1_ = "";
+  etl::string<SCREEN_WIDTH - 2> line2_ = "";
   int button_[4];
   int buttonCount_;
   int selected_;

--- a/sources/Application/Views/ModalDialogs/MessageBox.h
+++ b/sources/Application/Views/ModalDialogs/MessageBox.h
@@ -20,6 +20,8 @@ enum MessageBoxButtonFlag {
 class MessageBox : public ModalView {
 public:
   MessageBox(View &view, const char *message, int btnFlags = MBBF_OK);
+  MessageBox(View &view, const char *message, const char *message2,
+             int btnFlags = MBBF_OK);
   virtual ~MessageBox();
 
   virtual void DrawView();
@@ -29,7 +31,8 @@ public:
   virtual void AnimationUpdate(){};
 
 private:
-  std::string message_;
+  std::string message_ = "";
+  std::string message2_ = "";
   int button_[4];
   int buttonCount_;
   int selected_;


### PR DESCRIPTION
This allows us to fix the text overflow in the instrument change confirmation dialog.

Unfort the screenshow below is missing the coloured outline of the Messagebox due to current bug in the remote UI protocol which doesn't send background coloured font char cells.

![image](https://github.com/user-attachments/assets/e5cc84da-dbaa-46de-bbb3-23c96d860305)

Fixes: #247