### PR TITLE
Fix branch name for user manual deploy action

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - master
     paths:
       - usermanual/**
 jobs:


### PR DESCRIPTION
GH deploy action was only for `main` branch whereas we still use `master`.