### PR TITLE
Only show instrument type change dialog when instrument modified

### DIFF
--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -23,6 +23,7 @@ public:
   virtual void OnFocus();
   virtual void AnimationUpdate();
   void onInstrumentTypeChange();
+  void clearInstrumentModified() { instrumentModified_ = false; }
 
 protected:
   void warpToNext(int offset);
@@ -42,6 +43,7 @@ private:
   FourCC lastFocusID_;
   WatchedVariable instrumentType_;
   InstrumentType currentType_ = IT_NONE;
+  bool instrumentModified_ = false;
 
   char sidName_[24];
 


### PR DESCRIPTION
This improves the current clunky UX by only prompting user with confirmation dialog when an instruments settings have been modified. This implementation is very basic as it doesn't take into account an instrument with settings that were modified in a previous session or where the user modified a instrument setting and set it back to the default value, but its already a big improvement over the current UX.

Fixes: #248