### PR TITLE
Enhance remote UI protocol

### DIFF
--- a/sources/Adapters/picoTracker/display/ili9341.c
+++ b/sources/Adapters/picoTracker/display/ili9341.c
@@ -77,9 +77,30 @@ void ili9341_init() {
   ili9341_set_command(ILI9341_GAMMASET);
   ili9341_command_param(0x01);
 
+#ifdef LCD_ST7789
+  // TODO: need good negative gamma correction values for ST7789, the ones below
+  // from the lvgl driver don't work well, are too "bright"
+
+  // src:
+  // https://github.com/eudoxos/pico-st7789-driver-lvgl/blob/main/st7789_lowlevel.py
+  // (ST7789_GMCTRP1,b'\x0f\x1a\x0f\x18\x2f\x28\x20\x22\x1f\x1b\x23\x37\x00\x07\x02\x10'),
+  // (ST7789_GMCTRN1,b'\x0f\x1b\x0f\x17\x33\x2c\x29\x2e\x30\x30\x39\x3f\x00\x07\x03\x10'),
+
+  ili9341_set_command(ILI9341_GMCTRP1);
+  ili9341_write_data((uint8_t[16]){0x0f, 0x1a, 0x0f, 0x18, 0x2f, 0x28, 0x20,
+                                   0x22, 0x1f, 0x1b, 0x23, 0x37, 0x00, 0x07,
+                                   0x02, 0x10},
+                     16);
+  // negative gamma correction
+  // ili9341_set_command(ILI9341_GMCTRN1);
+  // ili9341_write_data((uint8_t[16]){0x0f, 0x1b, 0x0f, 0x17, 0x33, 0x2c, 0x29,
+  //                                  0x2e, 0x30, 0x30, 0x39, 0x3f, 0x00, 0x07,
+  //                                  0x03, 0x10},
+  //                    16);
+#else
   // positive gamma correction
   ili9341_set_command(ILI9341_GMCTRP1);
-  ili9341_write_data((uint8_t[15]){0x0f, 0x31, 0x2b, 0x0c, 0x0e, 0x08, 0x4e,
+  ili9341_write_data((uint8_t[16]){0x0f, 0x31, 0x2b, 0x0c, 0x0e, 0x08, 0x4e,
                                    0xf1, 0x37, 0x07, 0x10, 0x03, 0x0e, 0x09,
                                    0x00},
                      15);
@@ -90,6 +111,7 @@ void ili9341_init() {
                                    0xc1, 0x48, 0x08, 0x0f, 0x0c, 0x31, 0x36,
                                    0x0f},
                      15);
+#endif
 
   // memory access control
   ili9341_set_command(ILI9341_MADCTL);
@@ -100,6 +122,7 @@ void ili9341_init() {
   // MY MX MV ML RGB MH -  -
   ili9341_command_param(0xC0);
   ili9341_set_command(ILI9341_INVON);
+
 #else
   ili9341_command_param(0x88);
 #endif

--- a/sources/Adapters/picoTracker/display/ili9341.c
+++ b/sources/Adapters/picoTracker/display/ili9341.c
@@ -78,25 +78,20 @@ void ili9341_init() {
   ili9341_command_param(0x01);
 
 #ifdef LCD_ST7789
-  // TODO: need good negative gamma correction values for ST7789, the ones below
-  // from the lvgl driver don't work well, are too "bright"
-
+  // gamma correction for ST7789V
   // src:
-  // https://github.com/eudoxos/pico-st7789-driver-lvgl/blob/main/st7789_lowlevel.py
-  // (ST7789_GMCTRP1,b'\x0f\x1a\x0f\x18\x2f\x28\x20\x22\x1f\x1b\x23\x37\x00\x07\x02\x10'),
-  // (ST7789_GMCTRN1,b'\x0f\x1b\x0f\x17\x33\x2c\x29\x2e\x30\x30\x39\x3f\x00\x07\x03\x10'),
-
+  // https://github.com/kiklhorn/esphome/blob/dbb824c937fda160c0f2165a29a8b1a9aee4fb43/esphome/components/st7789/st7789_init.h#L57
+  // positive gamma correction
   ili9341_set_command(ILI9341_GMCTRP1);
-  ili9341_write_data((uint8_t[16]){0x0f, 0x1a, 0x0f, 0x18, 0x2f, 0x28, 0x20,
-                                   0x22, 0x1f, 0x1b, 0x23, 0x37, 0x00, 0x07,
-                                   0x02, 0x10},
-                     16);
+  ili9341_write_data((uint8_t[14]){0xD0, 0x00, 0x02, 0x07, 0x0A, 0x28, 0x32,
+                                   0x44, 0x42, 0x06, 0x0E, 0x12, 0x14, 0x17},
+                     14);
   // negative gamma correction
-  // ili9341_set_command(ILI9341_GMCTRN1);
-  // ili9341_write_data((uint8_t[16]){0x0f, 0x1b, 0x0f, 0x17, 0x33, 0x2c, 0x29,
-  //                                  0x2e, 0x30, 0x30, 0x39, 0x3f, 0x00, 0x07,
-  //                                  0x03, 0x10},
-  //                    16);
+  ili9341_set_command(ILI9341_GMCTRN1);
+  ili9341_write_data((uint8_t[14]){0xD0, 0x00, 0x02, 0x07, 0x0A, 0x28, 0x31,
+                                   0x54, 0x47, 0x0E, 0x1C, 0x17, 0x1B, 0x1E},
+                     14);
+
 #else
   // positive gamma correction
   ili9341_set_command(ILI9341_GMCTRP1);

--- a/sources/Adapters/picoTracker/gui/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/gui/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(platform_gui
   picoTrackerGUIWindowImp.h picoTrackerGUIWindowImp.cpp
   picoTrackerEventManager.h picoTrackerEventManager.cpp
   SerialDebugUI.h SerialDebugUI.cpp
+  picoRemoteUI.h picoRemoteUI.cpp
 )
 
 target_link_libraries(platform_gui PUBLIC uiframework_simplebaseclasses

--- a/sources/Adapters/picoTracker/gui/picoRemoteUI.cpp
+++ b/sources/Adapters/picoTracker/gui/picoRemoteUI.cpp
@@ -1,0 +1,49 @@
+#include "picoRemoteUI.h"
+#include "tusb.h"
+#include <cstdint>
+
+// The Remote UI protocol consists of sending ASCII messages over the USB serial
+// connection to a client to render the UI shown by the picotracker and then
+// listening for incoming button input events sent by the remote client.
+//
+// The messages consist of the types in the RemoteUICommand enum below and
+// essentially just relay the existing draw, clear and setcolor commands that
+// already exist in picTrackerGUIWidowImp.cpp
+//
+// Note that to avoid issues with non-printing chars being mishandled by either
+// the pico SDK or client serial port drivers, most command param "values" have
+// been attempted to be offset to push them into the printable char range.
+//
+// Remote UI clients should pay careful attention to using the
+// REMOTE_UI_CMD_MARKER and also verify the expected byte count length of each
+// command received to check for any transmission errors.
+//
+
+void sendToUSBCDC(char buf[], int length) {
+  // based on PICO SDk's USB STDIO stdio_usb_out_chars function
+  // https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_stdio_usb/stdio_usb.c#L101
+  static uint64_t last_avail_time;
+  if (tud_cdc_connected()) {
+    for (int i = 0; i < length;) {
+      int n = length - i;
+      int avail = (int)tud_cdc_write_available();
+      if (n > avail)
+        n = avail;
+      if (n) {
+        int n2 = (int)tud_cdc_write(buf + i, (uint32_t)n);
+        tud_task();
+        tud_cdc_write_flush();
+        i += n2;
+        last_avail_time = time_us_64();
+      } else {
+        tud_task();
+        tud_cdc_write_flush();
+        if (!tud_cdc_connected() ||
+            (!tud_cdc_write_available() &&
+             time_us_64() > last_avail_time + USB_TIMEOUT_US)) {
+          break;
+        }
+      }
+    }
+  }
+}

--- a/sources/Adapters/picoTracker/gui/picoRemoteUI.h
+++ b/sources/Adapters/picoTracker/gui/picoRemoteUI.h
@@ -20,8 +20,8 @@
 // REMOTE_UI_CMD_MARKER and also verify the expected byte count length of each
 // command received to check for any transmission errors.
 //
-// SetPalette is currently not implemented, so remote clients just need to use
-// their own color palette for now.
+// SetPalette, SetFont are currently not implemented, so remote clients just
+// need to use their own font & color palette for now.
 
 #define ITF_NUM_CDC_0 0
 
@@ -60,7 +60,8 @@ enum RemoteUICommand {
   DRAW_CMD = 0x32,
   CLEAR_CMD = 0x33,
   SETCOLOR_CMD = 0x34,
-  SETPALETTE_CMD = 0x04
+  SETPALETTE_CMD = 0x04,
+  SETFONT_CMD = 0x05
 };
 
 #define REMOTE_UI_CMD_MARKER 0xFD

--- a/sources/Adapters/picoTracker/gui/picoRemoteUI.h
+++ b/sources/Adapters/picoTracker/gui/picoRemoteUI.h
@@ -57,14 +57,14 @@ static void sendToUSBCDC(char buf[], int length) {
 }
 
 enum RemoteUICommand {
-  DRAW_CMD = 0x32,
-  CLEAR_CMD = 0x33,
-  SETCOLOR_CMD = 0x34,
-  SETPALETTE_CMD = 0x04,
+  REMOTE_UI_CMD_MARKER = 0xFE,
+  TEXT_CMD = 0x02,
+  CLEAR_CMD = 0x03,
+  SETCOLOR_CMD = 0x04,
   SETFONT_CMD = 0x05
 };
 
-#define REMOTE_UI_CMD_MARKER 0xFD
-#define UART_ASCII_OFFSET 32
+#define ASCII_SPACE_OFFSET 0xF
+#define INVERT_ON 0x7F
 
 #endif

--- a/sources/Adapters/picoTracker/gui/picoRemoteUI.h
+++ b/sources/Adapters/picoTracker/gui/picoRemoteUI.h
@@ -2,8 +2,6 @@
 #ifndef PICO_REMOTE_UI_H_
 #define PICO_REMOTE_UI_H_
 
-#include "tusb.h"
-
 // The Remote UI protocol consists of sending ASCII messages over the USB serial
 // connection to a client to render the UI shown by the picotracker and then
 // listening for incoming button input events sent by the remote client.
@@ -14,47 +12,17 @@
 //
 // Note that to avoid issues with non-printing chars being mishandled by either
 // the pico SDK or client serial port drivers, most command param "values" have
-// been attempted to be offset by 32 to push them into the printable char range.
+// been attempted to be offset to push them into the printable char range.
 //
 // Remote UI clients should pay careful attention to using the
 // REMOTE_UI_CMD_MARKER and also verify the expected byte count length of each
 // command received to check for any transmission errors.
 //
-// SetPalette, SetFont are currently not implemented, so remote clients just
-// need to use their own font & color palette for now.
 
 #define ITF_NUM_CDC_0 0
-
 #define USB_TIMEOUT_US 500000
-
-static void sendToUSBCDC(char buf[], int length) {
-  // based on PICO SDk's USB STDIO stdio_usb_out_chars function
-  // https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_stdio_usb/stdio_usb.c#L101
-  static uint64_t last_avail_time;
-  if (tud_cdc_connected()) {
-    for (int i = 0; i < length;) {
-      int n = length - i;
-      int avail = (int)tud_cdc_write_available();
-      if (n > avail)
-        n = avail;
-      if (n) {
-        int n2 = (int)tud_cdc_write(buf + i, (uint32_t)n);
-        tud_task();
-        tud_cdc_write_flush();
-        i += n2;
-        last_avail_time = time_us_64();
-      } else {
-        tud_task();
-        tud_cdc_write_flush();
-        if (!tud_cdc_connected() ||
-            (!tud_cdc_write_available() &&
-             time_us_64() > last_avail_time + USB_TIMEOUT_US)) {
-          break;
-        }
-      }
-    }
-  }
-}
+#define ASCII_SPACE_OFFSET 0xF
+#define INVERT_ON 0x7F
 
 enum RemoteUICommand {
   REMOTE_UI_CMD_MARKER = 0xFE,
@@ -64,7 +32,11 @@ enum RemoteUICommand {
   SETFONT_CMD = 0x05
 };
 
-#define ASCII_SPACE_OFFSET 0xF
-#define INVERT_ON 0x7F
+enum RemoteInputCommand {
+  REMOTE_INPUT_CMD_MARKER = 0xFE,
+  FULL_REFRESH_CMD = 0x02,
+};
+
+void sendToUSBCDC(char buf[], int length);
 
 #endif

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -1,13 +1,12 @@
 #include "picoTrackerGUIWindowImp.h"
+#include "Adapters/picoTracker/utils/utils.h"
 #include "Application/Model/Config.h"
+#include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 #include "System/System/System.h"
+#include "UIFramework/BasicDatas/GUIEvent.h"
 #include "UIFramework/SimpleBaseClasses/GUIWindow.h"
 #include <string.h>
-// #include "Application/Utils/assert.h"
-#include "Adapters/picoTracker/utils/utils.h"
-#include "Application/Utils/char.h"
-#include "UIFramework/BasicDatas/GUIEvent.h"
 #ifdef USB_REMOTE_UI
 #include "picoRemoteUI.h"
 #endif
@@ -171,7 +170,7 @@ void picoTrackerGUIWindowImp::Unlock(){};
 void picoTrackerGUIWindowImp::Flush() { mode0_draw_changed(); };
 
 void picoTrackerGUIWindowImp::Invalidate() {
-  picoTrackerEventQueue::GetInstance()->push(picoTrackerEvent(PICO_REDRAW));
+  picoTrackerEventQueue::GetInstance()->push(picoTrackerEvent(PICO_FLUSH));
 };
 
 void picoTrackerGUIWindowImp::PushEvent(GUIEvent &event) {
@@ -187,8 +186,11 @@ void picoTrackerGUIWindowImp::ProcessEvent(picoTrackerEvent &event) {
   switch (event.type_) {
   case PICO_REDRAW:
     //        instance_->currentBuffer_^=0x01 ;
-    instance_->_window->Update();
+    instance_->_window->Update(true);
     //        gp_setFramebuffer(instance_->framebuffer_[instance_->currentBuffer_],1);
+    break;
+  case PICO_FLUSH:
+    instance_->_window->Update(false);
     break;
   case PICO_CLOCK:
     instance_->_window->ClockTick();

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -95,10 +95,14 @@ void picoTrackerGUIWindowImp::Clear(GUIColor &c, bool overlay) {
   mode0_color_t backgroundColor = GetColor(c);
   mode0_set_background(backgroundColor);
   mode0_clear(backgroundColor);
-  Trace::Debug("GUI Clear call: R:%d G:%d B:%d", c._r, c._g, c._b);
+  // split send color into r, g, b
+  auto sendColor = to_rgb565(c);
+  auto r = sendColor >> 11;
+  auto g = (sendColor >> 5) & 0b111111;
+  auto b = sendColor & 0b11111;
 #ifdef USB_REMOTE_UI
   if (remoteUIEnabled_) {
-    char remoteUIBuffer[3];
+    char remoteUIBuffer[5];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
     remoteUIBuffer[1] = CLEAR_CMD;
     remoteUIBuffer[2] = c._r;
@@ -129,11 +133,11 @@ void picoTrackerGUIWindowImp::SetColor(GUIColor &c) {
   auto r = sendColor >> 11;
   auto g = (sendColor >> 5) & 0b111111;
   auto b = sendColor & 0b11111;
-  Trace::Debug("sendColor: %d,%d,%d", r, g, b);
+  // Trace::Debug("sendColor: %d,%d,%d", r, g, b);
 
 #ifdef USB_REMOTE_UI
   if (remoteUIEnabled_) {
-    char remoteUIBuffer[3];
+    char remoteUIBuffer[5];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
     remoteUIBuffer[1] = SETCOLOR_CMD;
     remoteUIBuffer[2] = r;

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -95,13 +95,16 @@ void picoTrackerGUIWindowImp::Clear(GUIColor &c, bool overlay) {
   mode0_color_t backgroundColor = GetColor(c);
   mode0_set_background(backgroundColor);
   mode0_clear(backgroundColor);
+  Trace::Debug("GUI Clear call: R:%d G:%d B:%d", c._r, c._g, c._b);
 #ifdef USB_REMOTE_UI
   if (remoteUIEnabled_) {
     char remoteUIBuffer[3];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
     remoteUIBuffer[1] = CLEAR_CMD;
-    remoteUIBuffer[2] = backgroundColor + UART_ASCII_OFFSET;
-    sendToUSBCDC(remoteUIBuffer, 3);
+    remoteUIBuffer[2] = c._r;
+    remoteUIBuffer[3] = c._g;
+    remoteUIBuffer[4] = c._b;
+    sendToUSBCDC(remoteUIBuffer, 5);
   }
 #endif
 };
@@ -118,14 +121,25 @@ mode0_color_t picoTrackerGUIWindowImp::GetColor(GUIColor &c) {
 }
 
 void picoTrackerGUIWindowImp::SetColor(GUIColor &c) {
-  mode0_set_foreground(GetColor(c));
+  mode0_color_t color = GetColor(c);
+  mode0_set_foreground(color);
+  auto sendColor = to_rgb565(c);
+
+  // split send color into r, g, b
+  auto r = sendColor >> 11;
+  auto g = (sendColor >> 5) & 0b111111;
+  auto b = sendColor & 0b11111;
+  Trace::Debug("sendColor: %d,%d,%d", r, g, b);
+
 #ifdef USB_REMOTE_UI
   if (remoteUIEnabled_) {
     char remoteUIBuffer[3];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
     remoteUIBuffer[1] = SETCOLOR_CMD;
-    remoteUIBuffer[2] = GetColor(c) + UART_ASCII_OFFSET;
-    sendToUSBCDC(remoteUIBuffer, 3);
+    remoteUIBuffer[2] = r;
+    remoteUIBuffer[3] = g;
+    remoteUIBuffer[4] = b;
+    sendToUSBCDC(remoteUIBuffer, 5);
   }
 #endif
 };

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -105,9 +105,9 @@ void picoTrackerGUIWindowImp::Clear(GUIColor &c, bool overlay) {
     char remoteUIBuffer[5];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
     remoteUIBuffer[1] = CLEAR_CMD;
-    remoteUIBuffer[2] = c._r;
-    remoteUIBuffer[3] = c._g;
-    remoteUIBuffer[4] = c._b;
+    remoteUIBuffer[2] = r;
+    remoteUIBuffer[3] = g;
+    remoteUIBuffer[4] = b;
     sendToUSBCDC(remoteUIBuffer, 5);
   }
 #endif

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -70,11 +70,11 @@ void picoTrackerGUIWindowImp::DrawChar(const char c, GUIPoint &pos,
   if (remoteUIEnabled_) {
     char remoteUIBuffer[6];
     remoteUIBuffer[0] = REMOTE_UI_CMD_MARKER;
-    remoteUIBuffer[1] = DRAW_CMD;
+    remoteUIBuffer[1] = TEXT_CMD;
     remoteUIBuffer[2] = c;
-    remoteUIBuffer[3] = x + 32;
-    remoteUIBuffer[4] = y + 32;
-    remoteUIBuffer[5] = p.invert_ ? 127 : 32;
+    remoteUIBuffer[3] = x + ASCII_SPACE_OFFSET; // to avoid sending NUL (aka 0)
+    remoteUIBuffer[4] = y + ASCII_SPACE_OFFSET;
+    remoteUIBuffer[5] = p.invert_ ? 127 : 0;
     sendToUSBCDC(remoteUIBuffer, 6);
   }
 #endif

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -185,9 +185,16 @@ GUIRect picoTrackerGUIWindowImp::GetRect() {
 void picoTrackerGUIWindowImp::ProcessEvent(picoTrackerEvent &event) {
   switch (event.type_) {
   case PICO_REDRAW:
-    //        instance_->currentBuffer_^=0x01 ;
     instance_->_window->Update(true);
-    //        gp_setFramebuffer(instance_->framebuffer_[instance_->currentBuffer_],1);
+#ifdef USB_REMOTE_UI
+    // send font update
+    if (instance_->remoteUIEnabled_) {
+      Config *config = Config::GetInstance();
+      auto uiFontVar = config->FindVariable(FourCC::VarUIFont);
+      int uifontIndex = uiFontVar->GetInt();
+      instance_->SendFont(uifontIndex);
+    }
+#endif
     break;
   case PICO_FLUSH:
     instance_->_window->Update(false);

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.h
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.h
@@ -41,6 +41,7 @@ protected:
   virtual void Update(Observable &o, I_ObservableData *d);
 
 private:
+  void SendFont(uint8_t uifontIndex);
   bool remoteUIEnabled_ = 0;
 };
 #endif

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -4,7 +4,7 @@
 #include "Externals/etl/include/etl/deque.h"
 #include "Foundation/T_Singleton.h"
 
-enum picoTrackerEventType { PICO_REDRAW, PICO_CLOCK, LAST };
+enum picoTrackerEventType { PICO_REDRAW, PICO_FLUSH, PICO_CLOCK, LAST };
 
 class picoTrackerEvent {
 public:

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -411,9 +411,10 @@ void AppWindow::UpdateColorsFromConfig() {
   defineColor(FourCC::VarHI1Color, highlightColor_, 2);
   defineColor(FourCC::VarHI2Color, highlight2Color_, 3);
   defineColor(FourCC::VarCursorColor, cursorColor_, 4);
-  defineColor(FourCC::VarInfoColor, infoColor_, 5);
-  defineColor(FourCC::VarWarnColor, warnColor_, 6);
-  defineColor(FourCC::VarErrorColor, errorColor_, 7);
+  defineColor(FourCC::VarConsoleColor, consoleColor_, 5);
+  defineColor(FourCC::VarInfoColor, infoColor_, 6);
+  defineColor(FourCC::VarWarnColor, warnColor_, 7);
+  defineColor(FourCC::VarErrorColor, errorColor_, 8);
 };
 
 bool AppWindow::onEvent(GUIEvent &event) {

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -480,8 +480,12 @@ bool AppWindow::onEvent(GUIEvent &event) {
   return false;
 };
 
-void AppWindow::onUpdate() {
-  //	Redraw() ;
+void AppWindow::onUpdate(bool redraw) {
+  if (redraw) {
+    GUIWindow::Clear(backgroundColor_, true);
+    Clear(true);
+    Redraw();
+  }
   Flush();
 };
 

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -48,7 +48,7 @@ public:
 
 protected: // GUIWindow implementation
   virtual bool onEvent(GUIEvent &event);
-  virtual void onUpdate();
+  virtual void onUpdate(bool redraw);
   virtual void LayoutChildren();
   virtual void Flush();
   virtual void Redraw();

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -233,7 +233,7 @@ void DeviceView::Update(Observable &, I_ObservableData *data) {
     Trace::Log("DEVICE", "Color updated!");
     ((AppWindow &)w_).UpdateColorsFromConfig();
     ((AppWindow &)w_).Clear(true);
-    w_.Update();
+    w_.Update(true);
     break;
 
   case FourCC::VarLineOut: {

--- a/sources/UIFramework/SimpleBaseClasses/GUIWindow.cpp
+++ b/sources/UIFramework/SimpleBaseClasses/GUIWindow.cpp
@@ -52,7 +52,7 @@ void GUIWindow::Flush() { _imp->Flush(); }
 void GUIWindow::Lock() { _imp->Lock(); }
 void GUIWindow::Unlock() { _imp->Unlock(); }
 
-void GUIWindow::Update() { onUpdate(); }
+void GUIWindow::Update(bool redraw) { onUpdate(redraw); }
 
 void GUIWindow::ClockTick() { AnimationUpdate(); }
 

--- a/sources/UIFramework/SimpleBaseClasses/GUIWindow.h
+++ b/sources/UIFramework/SimpleBaseClasses/GUIWindow.h
@@ -37,9 +37,9 @@ public: // I_GUIGraphics implementation
   virtual void Flush();
   virtual void Lock();
   virtual void Unlock();
-  virtual void Update();
+  virtual void Update(bool redraw);
   virtual void ClockTick();
-  virtual void onUpdate() = 0;
+  virtual void onUpdate(bool redraw) = 0;
   virtual void AnimationUpdate() = 0;
   //	virtual void Save() ;
   //	virtual void Restore() ;

--- a/usermanual/content/pages/appendix-remoteui.md
+++ b/usermanual/content/pages/appendix-remoteui.md
@@ -14,36 +14,50 @@ The Remote UI protocol is a communication mechanism that allows rendering the pi
 
 ### Command Marker
 
-Every command starts with a fixed marker: 0xFD (REMOTE_UI_CMD_MARKER)
+Every command starts with a fixed marker: `0xFE` (REMOTE_UI_CMD_MARKER). This allows clients to verify the start of a valid command.
 
-This helps clients verify the start of a valid command.
+**Note:** That the use of this value as a marker to start commands means that the characters 0xFE and 0xFF from the extended ASCII range are not allowed in the protocols command parameter values.
+
 
 ### Command Types
 
-1. DRAW_CMD (0x32): Draw a character
+Note: `ASCII_SPACE_OFFSET = 0xF`
+
+
+1. TEXT_CMD (0x2): Draw a character
 
 Parameters:
 
 * Character to draw
-* X position (offset by 32)
-* Y position (offset by 32)
-* Invert flag (32 for normal, 127 for inverted)
+* X position (offset by ASCII_SPACE_OFFSET)
+* Y position (offset by ASCII_SPACE_OFFSET)
+* Invert flag (0 for normal, 0x7F for inverted)
 
-2. CLEAR_CMD (0x33): Clear screen
+2. `CLEAR_CMD (0x3)`: Clear screen
 
 Parameters:
 
 * Background color in RGB565 format
 
-3. SETCOLOR_CMD (0x34): Set foreground color
+3. SETCOLOR_CMD (0x4): Set foreground color
 
 Parameters:
 
 * Color in RGB565 format
 
-4. SETPALETTE_CMD (0x04): Not currently implemented
+4. SETFONT_CMD (0x5)
 
-Remote clients should use their own color palette
+Parameters:
+
+* Font index  (offset by ASCII_SPACE_OFFSET)
+
+Currently the only available fonts are:
+
+ | Index | Font   
+ | ----- | -----
+ | 0     | Hourglass
+ | 1     | You Squared
+
 
 ### RGB565 Format
 
@@ -62,7 +76,7 @@ To give a concrete example, below is a simple example of how a command in the pi
 ```cpp
 
 // Drawing a character 'A' at position (2,3), not inverted
-remoteUIBuffer[0] = 0xFD;        // Command marker
+remoteUIBuffer[0] = 0xFE;        // Command marker
 remoteUIBuffer[1] = DRAW_CMD;    // Draw command
 remoteUIBuffer[2] = 'A';         // Character
 remoteUIBuffer[3] = 34;          // X position (2 + 32)
@@ -73,7 +87,7 @@ sendToUSBCDC(remoteUIBuffer, 6);
 
 ### Limitations
 
-SetFont command is not implemented
+* Input events are not yet implemented
 
 ### Client Implementation Guidelines
 

--- a/usermanual/content/pages/appendix-remoteui.md
+++ b/usermanual/content/pages/appendix-remoteui.md
@@ -33,17 +33,27 @@ Parameters:
 
 Parameters:
 
-* Background color (offset by 32)
+* Background color in RGB565 format
 
 3. SETCOLOR_CMD (0x34): Set foreground color
 
 Parameters:
 
-* Color index (offset by 32)
+* Color in RGB565 format
 
 4. SETPALETTE_CMD (0x04): Not currently implemented
 
 Remote clients should use their own color palette
+
+### RGB565 Format
+
+RGB565 is a 16-bit color format used for drawing text and UI. It is composed of three 5-bit values for the red, green and blue components of the color. Example code for efficient conversion between RGB565 and RGB888 can be found from the official picoTracker client Flutter code:
+
+```dart
+r: (_byteBuffer[0] * 527 + 23) >> 5, // Red component
+g: (_byteBuffer[1] * 259 + 33) >> 6, // Green component
+b: (_byteBuffer[2] * 527 + 23) >> 5, // Blue component
+```
 
 ### Example Transmission Flow
 
@@ -63,7 +73,6 @@ sendToUSBCDC(remoteUIBuffer, 6);
 
 ### Limitations
 
-SetPalette command is not implemented
 SetFont command is not implemented
 
 ### Client Implementation Guidelines

--- a/usermanual/content/pages/appendix-remoteui.md
+++ b/usermanual/content/pages/appendix-remoteui.md
@@ -1,5 +1,75 @@
 ---
-title: Remote User Interface Protocol
+title: picoTracker Remote User Interface Protocol
 template: page
 ---
 
+## Overview
+
+The Remote UI protocol is a communication mechanism that allows rendering the picoTracker's user interface over a USB serial connection. It enables a remote client to:
+
+* Receive UI rendering commands
+* (NOT YET IMPLEMENTED) Send button input events back to the device
+
+## Command Structure
+
+### Command Marker
+
+Every command starts with a fixed marker: 0xFD (REMOTE_UI_CMD_MARKER)
+
+This helps clients verify the start of a valid command.
+
+### Command Types
+
+1. DRAW_CMD (0x32): Draw a character
+
+Parameters:
+
+* Character to draw
+* X position (offset by 32)
+* Y position (offset by 32)
+* Invert flag (32 for normal, 127 for inverted)
+
+2. CLEAR_CMD (0x33): Clear screen
+
+Parameters:
+
+* Background color (offset by 32)
+
+3. SETCOLOR_CMD (0x34): Set foreground color
+
+Parameters:
+
+* Color index (offset by 32)
+
+4. SETPALETTE_CMD (0x04): Not currently implemented
+
+Remote clients should use their own color palette
+
+### Example Transmission Flow
+
+To give a concrete example, below is a simple example of how a command in the picoTracker firmware istransmitted over USB serial:
+
+```cpp
+
+// Drawing a character 'A' at position (2,3), not inverted
+remoteUIBuffer[0] = 0xFD;        // Command marker
+remoteUIBuffer[1] = DRAW_CMD;    // Draw command
+remoteUIBuffer[2] = 'A';         // Character
+remoteUIBuffer[3] = 34;          // X position (2 + 32)
+remoteUIBuffer[4] = 35;          // Y position (3 + 32)
+remoteUIBuffer[5] = 32;          // Not inverted
+sendToUSBCDC(remoteUIBuffer, 6);
+```
+
+### Limitations
+
+SetPalette command is not implemented
+SetFont command is not implemented
+
+### Client Implementation Guidelines
+
+1. Look for REMOTE_UI_CMD_MARKER (0xFD)
+1. Verify command type
+1. Subtract 32 from positional/color values
+1. Handle potential transmission errors
+1. Implement appropriate rendering based on received commands

--- a/usermanual/content/pages/appendix-remoteui.md
+++ b/usermanual/content/pages/appendix-remoteui.md
@@ -59,6 +59,7 @@ Currently the only available fonts are:
  | 1     | You Squared
 
 
+
 ### RGB565 Format
 
 RGB565 is a 16-bit color format used for drawing text and UI. It is composed of three 5-bit values for the red, green and blue components of the color. Example code for efficient conversion between RGB565 and RGB888 can be found from the official picoTracker client Flutter code:
@@ -85,9 +86,22 @@ remoteUIBuffer[5] = 32;          // Not inverted
 sendToUSBCDC(remoteUIBuffer, 6);
 ```
 
+### Input Commands
+
+Clients are also able to send input events to the picoTracker. As for output commands, the input commands are prefixed by sending the REMOTE_UI_CMD_MARKER byte.
+
+The events currently supported are:
+
+1. FULL_REFRESH_CMD (0x2): Request sending all the current screen and current font
+
+Parameters:
+
+* None
+
+
 ### Limitations
 
-* Input events are not yet implemented
+* Input events other than FULL_REFRESH_CMD are not yet implemented.
 
 ### Client Implementation Guidelines
 


### PR DESCRIPTION
This enhances (with breaking changes) the remote UI protocol to:

* send actual colour values (instead of palette index) to allow clients to show the colour that matches on pT device
* sending current font setting
* receive input events. For now the one event implemented is request for a full screen refresh (inc sending current font)

As part of the changes, the number for the protocol commands changed to improve consistency and allow for future expansion without breaking changes.

Documentation of the remote UI protocol was also added to the user manual as an appendix.

As part of the change to allow clients to request a screen data refresh, the internal pT events for refresh vs flush were separated and related code cleaned up (commented out code removed).

In addition to the protocol changes, the gamma settings for the ST7789V improve colour accuracy on that LCD.

Fixes: #263 