### PR TITLE
Battery gauge obscures existing fields

### DIFF
--- a/sources/Application/Utils/HelpLegend.h
+++ b/sources/Application/Utils/HelpLegend.h
@@ -79,7 +79,8 @@ static char **getHelpLegend(FourCC command) {
     result[0] = (char *)("PAN:aabb, pan to value");
     break;
   case FourCC::InstrumentCommandGroove:
-    result[0] = (char *)("GRooVe:--bb, set groove bb");
+    result[0] = (char *)("GRooVe:aabb, set groove bb");
+    result[1] = (char *)("if aa > 0, set all tracks");
     break;
   case FourCC::InstrumentCommandInstrumentRetrigger:
     result[0] = (char *)("InstrumentReTrig:aabb,");
@@ -95,8 +96,7 @@ static char **getHelpLegend(FourCC command) {
     result[0] = (char *)("Stop playing song now");
     break;
   case FourCC::InstrumentCommandGateOff:
-    result[0] = (char *)("GateOff (Synth):--bb,");
-    result[1] = (char *)("close synth instrument gate");
+    result[0] = (char *)("GateOff (Synth only)");
     break;
   default:
     result[0] = result[1] = (char *)("");

--- a/sources/Application/Utils/HelpLegend.h
+++ b/sources/Application/Utils/HelpLegend.h
@@ -1,98 +1,102 @@
 #include <cstdio>
 #include <cstring>
 
+// CAUTION: all strings must fit in the line length limits!
+// First line is max 31 - MAX_BATTERY_GAUGE_WIDTH, second line is max 31
+// chars
 static char **getHelpLegend(FourCC command) {
   static char *result[2];
   result[1] = (char *)("bb at speed aa");
   switch (command) {
   case FourCC::InstrumentCommandKill:
-    result[0] = (char *)("     KILl:--bb, stop playing    ");
+    result[0] = (char *)("KILl:--bb, stop playing");
     result[1] = (char *)("after bb ticks");
     break;
   case FourCC::InstrumentCommandLoopOfset:
-    result[0] = (char *)("     Loop OFset: Shift loop     ");
+    result[0] = (char *)("Loop OFset: Shift loop");
     result[1] = (char *)("start & end values aaaa");
     break;
   case FourCC::InstrumentCommandArpeggiator:
-    result[0] = (char *)("     ARPeggio: Cycle through    ");
+    result[0] = (char *)("ARPeggio: Cycle through");
     result[1] = (char *)("relative pitches");
     break;
   case FourCC::InstrumentCommandVolume:
-    result[0] = (char *)("     VOLume:aabb, reach volume  ");
+    result[0] = (char *)("VOLume:aabb, reach volume");
     break;
   case FourCC::InstrumentCommandVelocity:
-    result[0] = (char *)("     VELocity:--bb, midi velocity ");
+    result[0] = (char *)("VELocity:--bb,");
+    result[1] = (char *)("MIDI velocity");
     break;
   case FourCC::InstrumentCommandPitchSlide:
-    result[0] = (char *)("     Pitch SLide:aabb, to pitch ");
+    result[0] = (char *)("Pitch SLide:aabb, to pitch");
     break;
   case FourCC::InstrumentCommandHop:
-    result[0] = (char *)("     HOP:aabb, hop to bb        ");
+    result[0] = (char *)("Hop:aabb, hop to bb");
     result[1] = (char *)("aa times");
     break;
   case FourCC::InstrumentCommandLegato:
-    result[0] = (char *)("     LEGato:aabb, slide         ");
+    result[0] = (char *)("Legato:aabb, slide");
     result[1] = (char *)("to pitch bb at speed aa");
     break;
   case FourCC::InstrumentCommandRetrigger:
-    result[0] = (char *)("     ReTriG:aabb retrigger loop ");
-    result[1] = (char *)("over bb ticks at speed aa");
+    result[0] = (char *)("Retrigger:aabb retrigger");
+    result[1] = (char *)("loop bb ticks at speed aa");
     break;
   case FourCC::InstrumentCommandTempo:
-    result[0] = (char *)("     TemPO:--bb, set tempo to   ");
+    result[0] = (char *)("Tempo:--bb, set tempo to");
     result[1] = (char *)("hex value bb");
     break;
   case FourCC::InstrumentCommandMidiCC:
-    result[0] = (char *)("     MidiCC:aabb, CC message aa ");
-    result[1] = (char *)("value bb");
+    result[0] = (char *)("MIDI CC:aabb, ");
+    result[1] = (char *)("CC message aa value bb");
     break;
   case FourCC::InstrumentCommandMidiPC:
-    result[0] = (char *)("     Midi Program Change:aabb,  ");
+    result[0] = (char *)("MIDI Program Change:aabb,");
     result[1] = (char *)("send program change bb");
     break;
   case FourCC::InstrumentCommandPlayOfset:
-    result[0] = (char *)("     Play OFfset:aabb, jump abs ");
+    result[0] = (char *)("Play OFfset:aabb, jump abs");
     result[1] = (char *)("to aa or move rel bb chunks");
     break;
   case FourCC::InstrumentCommandFilterResonance:
-    result[0] = (char *)("     FiLTer&Res:aabb, cutoff aa ");
+    result[0] = (char *)("FiLTer&Res:aabb, cutoff aa");
     result[1] = (char *)("resonance bb");
     break;
   case FourCC::InstrumentCommandLowPassFilter:
-    result[0] = (char *)("     FiLTeR:aabb, resonance to  ");
+    result[0] = (char *)("FiLTeR:aabb, resonance to");
     break;
   case FourCC::InstrumentCommandTable:
-    result[0] = (char *)("     TaBLe:--bb, run table bb   ");
-    result[1] = (char *)("");
+    result[0] = (char *)("TaBLe:--bb, run table bb");
     break;
   case FourCC::InstrumentCommandCrush:
-    result[0] = (char *)("     drive&CruSH:aa-b, drive aa ");
-    result[1] = (char *)("crush -b");
+    result[0] = (char *)("drive&CruSH:aa-b,");
+    result[1] = (char *)("drive aa crush -b");
     break;
   case FourCC::InstrumentCommandFilterCut:
-    result[0] = (char *)("     FilterCuToff:aabb, cutoff  ");
+    result[0] = (char *)("FilterCuToff:aabb, cutoff");
     break;
   case FourCC::InstrumentCommandPan:
-    result[0] = (char *)("     PAN:aabb, pan to value     ");
+    result[0] = (char *)("PAN:aabb, pan to value");
     break;
   case FourCC::InstrumentCommandGroove:
-    result[0] = (char *)("     GRooVe:--bb, set groove bb ");
-    result[1] = (char *)("");
+    result[0] = (char *)("GRooVe:--bb, set groove bb");
     break;
   case FourCC::InstrumentCommandInstrumentRetrigger:
-    result[0] = (char *)("     InstrumentReTrig:aabb, trig");
-    result[1] = (char *)("& transpose to aa, speed bb ");
+    result[0] = (char *)("InstrumentReTrig:aabb,");
+    result[1] = (char *)("trig&transpose aa speed bb");
     break;
   case FourCC::InstrumentCommandPitchFineTune:
-    result[0] = (char *)("     PitchFineTune:aabb, tune   ");
+    result[0] = (char *)("PitchFineTune:aabb, tune");
     break;
   case FourCC::InstrumentCommandDelay:
-    result[0] = (char *)("     DeLaY:--bb, delay bb tics  ");
-    result[1] = (char *)("");
+    result[0] = (char *)("Delay:--bb, delay bb tics");
     break;
   case FourCC::InstrumentCommandStop:
-    result[0] = (char *)("     SToP playing song now      ");
-    result[1] = (char *)("");
+    result[0] = (char *)("Stop playing song now");
+    break;
+  case FourCC::InstrumentCommandGateOff:
+    result[0] = (char *)("GateOff (Synth):--bb,");
+    result[1] = (char *)("close synth instrument gate");
     break;
   default:
     result[0] = result[1] = (char *)("");

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -1,13 +1,15 @@
 #include "ImportView.h"
 
+#include "Application/AppWindow.h"
 #include "Application/Instruments/SampleInstrument.h"
 #include "Application/Instruments/SamplePool.h"
 #include "pico/multicore.h"
 #include <memory>
 #include <nanoprintf.h>
 
-#define LIST_WIDTH 24
-#define LIST_PAGE_SIZE 18
+#define LIST_WIDTH SCREEN_WIDTH - 2
+// -4 to allow for title, filesize & spacers
+#define LIST_PAGE_SIZE SCREEN_HEIGHT - 4
 
 ImportView::ImportView(GUIWindow &w, ViewData *viewData)
     : ScreenView(w, viewData) {}
@@ -107,14 +109,16 @@ void ImportView::DrawView() {
     y += 1;
   };
 
+  // draw current selected file size
   SetColor(CD_HILITE2);
   props.invert_ = true;
   y = 0;
   auto currentFileIndex = fileIndexList_[currentIndex_];
   if (picoFS->getFileType(currentFileIndex) == PFT_FILE) {
-    auto filesize = picoFS->getFileSize(currentFileIndex);
-    npf_snprintf(buffer, sizeof(buffer), "[size: %d]", filesize);
-    x = 32 - strlen(buffer) + 1;
+    int filesize = picoFS->getFileSize(currentFileIndex);
+    npf_snprintf(buffer, sizeof(buffer), "[size: %i]", filesize);
+    x = 1;  // align with rest screen title & file list
+    y = 23; // bottom line
     DrawString(x, y, buffer, props);
   }
 

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1318,6 +1318,13 @@ void PhraseView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
 void PhraseView::printHelpLegend(FourCC command, GUITextProperties props) {
   char **helpLegend = getHelpLegend(command);
-  DrawString(0, 0, helpLegend[0], props);
-  DrawString(5, 1, helpLegend[1], props);
+  char line[32]; //-1 for 1char space start of line
+  strcpy(line, " ");
+  strcpy(line, helpLegend[0]);
+  DrawString(0, 0, line, props);
+  memset(line, ' ', 32);
+  if (helpLegend[1] != NULL) {
+    strcpy(line, helpLegend[1]);
+    DrawString(0, 1, line, props);
+  }
 }

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -887,6 +887,13 @@ void TableView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
 
 void TableView::printHelpLegend(FourCC command, GUITextProperties props) {
   char **helpLegend = getHelpLegend(command);
-  DrawString(0, 0, helpLegend[0], props);
-  DrawString(5, 1, helpLegend[1], props);
+  char line[32]; //-1 for 1char space start of line
+  strcpy(line, " ");
+  strcpy(line, helpLegend[0]);
+  DrawString(0, 0, line, props);
+  memset(line, ' ', 32);
+  if (helpLegend[1] != NULL) {
+    strcpy(line, helpLegend[1]);
+    DrawString(0, 1, line, props);
+  }
 }

--- a/usermanual/content/pages/commands.md
+++ b/usermanual/content/pages/commands.md
@@ -28,16 +28,30 @@ ARP 4050: loops between original pitch, +4 semitones, +0 semitones, + 5 semitone
 
 - FCT 0080 will instantly set the filter cutoff to 50%
 - FCT 1000 will close the filter entirely at speed 10
+
 ## FLT aabb (FLTR in lgpt)
 
 **lowpass filter, set absolute frequency value for cutoff aa & resonance bb**
 
 - FLT 00FF is un-adultered sound
+
 ## FRS aabb (FRES in lgpt)
 
 **adjust the filter resonance to bb at speed aa**
 
 - FRS 08FF will raise the resonance to screeching at speed 08
+
+## GOF
+
+**Close Gate OFF for Synth Instruments _only_**
+
+## GRV aabb
+
+**set Groove to bb**
+
+- In Phrases, if `aa > 0` then Groove will be set for _all_ tracks
+- In Tables, the Groove command has a maximum value of `1F` (15)
+
 
 ## HOP aabb
 


### PR DESCRIPTION
Fixes the Fx command help legend on Phrase and Table screen to not overlap battery gauge.
Fixes file size display in the sample import browser that broke with the move to the tiny printf lib and also moves it to the bottom line to be out of the way of the battery gauge.

Also while I was in this part of the code, added missing help legend for GOF, fixed GRV legend help and also updated the user manual entries for both.

Fixes: #284