### PR TITLE
Increase chain count

### DIFF
--- a/sources/Application/Model/Chain.h
+++ b/sources/Application/Model/Chain.h
@@ -3,8 +3,8 @@
 
 #include <bitset>
 
-#define CHAIN_COUNT 0x80
-#define NO_MORE_CHAIN 0x81
+#define CHAIN_COUNT 0xFF
+#define NO_MORE_CHAIN 0x100
 
 class Chain {
 public:

--- a/sources/Application/Model/Chain.h
+++ b/sources/Application/Model/Chain.h
@@ -1,6 +1,8 @@
 #ifndef _CHAIN_H_
 #define _CHAIN_H_
 
+#include <bitset>
+
 #define CHAIN_COUNT 0x80
 #define NO_MORE_CHAIN 0x81
 
@@ -17,7 +19,7 @@ public:
   unsigned char transpose_[CHAIN_COUNT * 16];
 
 private:
-  bool isUsed_[CHAIN_COUNT];
+  std::bitset<CHAIN_COUNT> isUsed_;
 };
 
 #endif


### PR DESCRIPTION
While this uses an extra approx 4kB of ram, it also saves ~100bytes by replacing boolean array with a bitfield.

Fixes: #288 