### PR TITLE
Try to optimise OPAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Temporary Items
 # usermanual output
 usermanual/output
 usermanual/bin
+
+optbuild/**

--- a/sources/Adapters/picoTracker/main/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/main/CMakeLists.txt
@@ -14,5 +14,6 @@ target_include_directories(picoTracker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+
 # create map/bin/hex/uf2 file etc.
 pico_add_extra_outputs(picoTracker)

--- a/sources/Application/Instruments/OpalInstrument.cpp
+++ b/sources/Application/Instruments/OpalInstrument.cpp
@@ -141,8 +141,6 @@ void OpalInstrument::Stop(int c) {
   opl_.Port(OCTAVE_BASE_REG, stop);
 };
 
-static int debugCount = 0;
-
 bool OpalInstrument::Render(int channel, fixed *buffer, int size,
                             bool updateTick) {
 
@@ -152,10 +150,7 @@ bool OpalInstrument::Render(int channel, fixed *buffer, int size,
   opl_.SampleBuffer(buffer, size);
 
   int took = micros() - start;
-  debugCount++;
-  if (debugCount % 100 == 0) {
-    Trace::Log("OPALINSTRUMENT", "Render took: %i us [%i])", took, size);
-  }
+  // Trace::Log("OPALINSTRUMENT", "Render took: %i us [%i])", took, size);
   return true;
 };
 

--- a/sources/Application/Instruments/OpalInstrument.cpp
+++ b/sources/Application/Instruments/OpalInstrument.cpp
@@ -141,22 +141,21 @@ void OpalInstrument::Stop(int c) {
   opl_.Port(OCTAVE_BASE_REG, stop);
 };
 
-bool OpalInstrument::Render(int channel, fixed *buffer, int size,
+static int debugCount = 0;
 
+bool OpalInstrument::Render(int channel, fixed *buffer, int size,
                             bool updateTick) {
 
   int start = micros();
-  int count = size;
-  while (count--) {
-    int16_t l, r;
-    opl_.Sample(&l, &r);
 
-    buffer[0] = l << 15;
-    buffer[1] = r << 15;
-    buffer += 2;
-  }
+  // optimise to remove function calls in hot loop
+  opl_.SampleBuffer(buffer, size);
+
   int took = micros() - start;
-  // printf("Render took: %i (%i ts)[%i]\n", took, took * 441 / size / 10000);
+  debugCount++;
+  if (debugCount % 100 == 0) {
+    Trace::Log("OPALINSTRUMENT", "Render took: %i us [%i])", took, size);
+  }
   return true;
 };
 

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -98,8 +98,8 @@ else ()
 endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
-pico_enable_stdio_uart(${PROJECT_NAME} 1)
+pico_enable_stdio_usb(${PROJECT_NAME} 0)
+pico_enable_stdio_uart(${PROJECT_NAME} 0)
 
 # This is the default, but better to make it explicit
 pico_set_float_implementation(${PROJECT_NAME} pico)

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -98,8 +98,8 @@ else ()
 endif()
 
 # Debug output with USB uses +6K memory
-pico_enable_stdio_usb(${PROJECT_NAME} 0)
-pico_enable_stdio_uart(${PROJECT_NAME} 0)
+pico_enable_stdio_usb(${PROJECT_NAME} 1)
+pico_enable_stdio_uart(${PROJECT_NAME} 1)
 
 # This is the default, but better to make it explicit
 pico_set_float_implementation(${PROJECT_NAME} pico)

--- a/sources/Externals/opal/CMakeLists.txt
+++ b/sources/Externals/opal/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(opal
 opal.h opal.cpp
 )
 
-#target_link_libraries(yxml PUBLIC system_filesystem
-#)
+target_link_libraries(opal PUBLIC application_utils
+)
 
 target_include_directories(opal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/sources/Externals/opal/CMakeLists.txt
+++ b/sources/Externals/opal/CMakeLists.txt
@@ -2,7 +2,9 @@ add_library(opal
 opal.h opal.cpp
 )
 
-target_link_libraries(opal PUBLIC application_utils
+target_link_libraries(opal 
+    PUBLIC application_utils
+    PUBLIC hardware_flash
 )
 
 target_include_directories(opal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sources/Externals/opal/opal.cpp
+++ b/sources/Externals/opal/opal.cpp
@@ -387,6 +387,89 @@ void Opal::Port(uint16_t reg_num, uint8_t val) {
   }
 }
 
+// Fill a fixed point buffer with size number of samples
+void Opal::SampleBuffer(fixed *buffer, int size) {
+  int count = size;
+  while (count--) {
+    int16_t l, r;
+
+    // =====
+    // for rp2040 perf optimisation inline manually: Sample(&l, &r);
+    while (SampleAccum >= SampleRate) {
+      LastOutput[0] = CurrOutput[0];
+      LastOutput[1] = CurrOutput[1];
+
+      // +++++
+      // manually inline: Output(CurrOutput[0], CurrOutput[1]);
+      int32_t leftmix = 0, rightmix = 0;
+
+      // Sum the output of each channel
+      for (int i = 0; i < NumChannels; i++) {
+
+        int16_t chanleft, chanright;
+        Chan[i].Output(chanleft, chanright);
+
+        leftmix += chanleft;
+        rightmix += chanright;
+      }
+      // Clamp
+      if (leftmix < -0x8000)
+        CurrOutput[0] = -0x8000;
+      else if (leftmix > 0x7FFF)
+        CurrOutput[0] = 0x7FFF;
+      else
+        CurrOutput[0] = static_cast<uint16_t>(leftmix);
+
+      if (rightmix < -0x8000)
+        CurrOutput[1] = -0x8000;
+      else if (rightmix > 0x7FFF)
+        CurrOutput[1] = 0x7FFF;
+      else
+        CurrOutput[1] = static_cast<uint16_t>(rightmix);
+
+      Clock++;
+
+      // Tremolo.  According to this post, the OPL3 tremolo is a 13,440 sample
+      // length triangle wave with a peak at 26 and a trough at 0 and is simply
+      // added to the logarithmic level accumulator
+      //      http://forums.submarine.org.uk/phpBB/viewtopic.php?f=9&t=1171
+      TremoloClock = (TremoloClock + 1) % 13440;
+      TremoloLevel =
+          ((TremoloClock < 13440 / 2) ? TremoloClock : 13440 - TremoloClock) /
+          256;
+      if (!TremoloDepth)
+        TremoloLevel >>= 2;
+
+      // Vibrato.  This appears to be a 8 sample long triangle wave with a
+      // magnitude of the three high bits of the channel frequency, positive and
+      // negative, divided by two if the vibrato depth is zero.  It is only
+      // cycled every 1,024 samples.
+      VibratoTick++;
+      if (VibratoTick >= 1024) {
+        VibratoTick = 0;
+        VibratoClock = (VibratoClock + 1) & 7;
+      }
+
+      // ++++++
+      SampleAccum -= SampleRate;
+    }
+
+    // Mix with the partial accumulation
+    int32_t omblend = SampleRate - SampleAccum;
+    l = static_cast<uint16_t>(
+        (LastOutput[0] * omblend + CurrOutput[0] * SampleAccum) / SampleRate);
+    r = static_cast<uint16_t>(
+        (LastOutput[1] * omblend + CurrOutput[1] * SampleAccum) / SampleRate);
+
+    SampleAccum += OPL3SampleRate;
+
+    // =====
+    buffer[0] = l << 15;
+    buffer[1] = r << 15;
+    buffer += 2;
+  }
+}
+
 //==================================================================================================
 // Generate sample.  Every time you call this you will get two signed 16-bit
 // samples (one for each stereo channel) which will sound correct when played
@@ -491,7 +574,8 @@ Opal::Channel::Channel() {
 //==================================================================================================
 // Produce output from channel.
 //==================================================================================================
-void Opal::Channel::Output(int16_t &left, int16_t &right) {
+__attribute__((always_inline)) inline void
+Opal::Channel::Output(int16_t &left, int16_t &right) {
 
   // Has the channel been disabled?  This is usually a result of the 4-op
   // enables being used to disable the secondary channel in each 4-op pair
@@ -715,8 +799,9 @@ Opal::Operator::Operator() {
 //==================================================================================================
 // Produce output from operator.
 //==================================================================================================
-int16_t Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
-                               int16_t vibrato, int16_t mod, int16_t fbshift) {
+__attribute__((always_inline)) inline int16_t
+Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
+                       int16_t vibrato, int16_t mod, int16_t fbshift) {
 
   // Advance wave phase
   if (VibratoEnable)

--- a/sources/Externals/opal/opal.cpp
+++ b/sources/Externals/opal/opal.cpp
@@ -466,8 +466,8 @@ void Opal::SampleBuffer(fixed *buffer, int size) {
     SampleAccum += OPL3SampleRate;
 
     // =====
-    buffer[0] = l << 15;
-    buffer[1] = r << 15;
+    buffer[0] = i2fp(l);
+    buffer[1] = i2fp(r);
     buffer += 2;
   }
 }

--- a/sources/Externals/opal/opal.cpp
+++ b/sources/Externals/opal/opal.cpp
@@ -7,8 +7,10 @@ const uint16_t Opal::RateTables[4][8] = {
     {1, 0, 0, 0, 1, 0, 0, 0},
     {1, 0, 0, 0, 0, 0, 0, 0},
 };
+// These look up tables are accessed in tight loops for each sample, so they
+// need to be in RAM not flash for fast access
 //--------------------------------------------------------------------------------------------------
-static const uint16_t __not_in_flash("mydata") ExpTable[0x100] = {
+static const uint16_t __not_in_flash("opalLUTdata") ExpTable[0x100] = {
     1018, 1013, 1007, 1002, 996, 991, 986, 980, 975, 969, 964, 959, 953, 948,
     942,  937,  932,  927,  921, 916, 911, 906, 900, 895, 890, 885, 880, 874,
     869,  864,  859,  854,  849, 844, 839, 834, 829, 824, 819, 814, 809, 804,
@@ -31,7 +33,7 @@ static const uint16_t __not_in_flash("mydata") ExpTable[0x100] = {
 };
 
 //--------------------------------------------------------------------------------------------------
-static const uint16_t __not_in_flash("mydata") LogSinTable[0x100] = {
+static const uint16_t __not_in_flash("opalLUTdata") LogSinTable[0x100] = {
     2137, 1731, 1543, 1419, 1326, 1252, 1190, 1137, 1091, 1050, 1013, 979, 949,
     920,  894,  869,  846,  825,  804,  785,  767,  749,  732,  717,  701, 687,
     672,  659,  646,  633,  621,  609,  598,  587,  576,  566,  556,  546, 536,

--- a/sources/Externals/opal/opal.cpp
+++ b/sources/Externals/opal/opal.cpp
@@ -1,4 +1,5 @@
 #include "opal.h"
+#include "hardware/flash.h"
 
 const uint16_t Opal::RateTables[4][8] = {
     {1, 0, 1, 0, 1, 0, 1, 0},
@@ -7,7 +8,7 @@ const uint16_t Opal::RateTables[4][8] = {
     {1, 0, 0, 0, 0, 0, 0, 0},
 };
 //--------------------------------------------------------------------------------------------------
-const uint16_t Opal::ExpTable[0x100] = {
+static const uint16_t __not_in_flash("mydata") ExpTable[0x100] = {
     1018, 1013, 1007, 1002, 996, 991, 986, 980, 975, 969, 964, 959, 953, 948,
     942,  937,  932,  927,  921, 916, 911, 906, 900, 895, 890, 885, 880, 874,
     869,  864,  859,  854,  849, 844, 839, 834, 829, 824, 819, 814, 809, 804,
@@ -28,8 +29,9 @@ const uint16_t Opal::ExpTable[0x100] = {
     48,   45,   42,   40,   37,  34,  31,  28,  25,  22,  20,  17,  14,  11,
     8,    6,    3,    0,
 };
+
 //--------------------------------------------------------------------------------------------------
-const uint16_t Opal::LogSinTable[0x100] = {
+static const uint16_t __not_in_flash("mydata") LogSinTable[0x100] = {
     2137, 1731, 1543, 1419, 1326, 1252, 1190, 1137, 1091, 1050, 1013, 979, 949,
     920,  894,  869,  846,  825,  804,  785,  767,  749,  732,  717,  701, 687,
     672,  659,  646,  633,  621,  609,  598,  587,  576,  566,  556,  546, 536,
@@ -896,7 +898,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
   case 0:
     if (phase & 0x100)
       offset ^= 0xFF;
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     negate = (phase & 0x200) != 0;
     break;
 
@@ -908,7 +910,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
       offset = 0;
     else if (phase & 0x100)
       offset ^= 0xFF;
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     break;
 
   //------------------------------------
@@ -917,7 +919,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
   case 2:
     if (phase & 0x100)
       offset ^= 0xFF;
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     break;
 
   //------------------------------------
@@ -926,7 +928,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
   case 3:
     if (phase & 0x100)
       offset = 0;
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     break;
 
   //------------------------------------
@@ -945,7 +947,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
       negate = (phase & 0x100) != 0;
     }
 
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     break;
 
   //------------------------------------
@@ -962,7 +964,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
         offset ^= 0xFF;
     }
 
-    logsin = Master->LogSinTable[offset];
+    logsin = LogSinTable[offset];
     break;
 
   //------------------------------------
@@ -996,7 +998,7 @@ Opal::Operator::Output(uint16_t /*keyscalenum*/, uint32_t phase_step,
   // (the hidden bit) is then the significand of the floating point output and
   // the yet unused MSB's of the input are the exponent of the floating point
   // output."
-  int16_t v = (Master->ExpTable[mix & 0xFF] + 1024u) >> (mix >> 8u);
+  int16_t v = (ExpTable[mix & 0xFF] + 1024u) >> (mix >> 8u);
   v += v;
   if (negate)
     v = ~v;

--- a/sources/Externals/opal/opal.h
+++ b/sources/Externals/opal/opal.h
@@ -24,6 +24,7 @@
 #ifndef _OPAL_H_
 #define _OPAL_H_
 
+#include "Application/Utils/fixed.h"
 #include <cstdint>
 
 //==================================================================================================
@@ -184,6 +185,8 @@ public:
   void SetSampleRate(int sample_rate);
   void Port(uint16_t reg_num, uint8_t val);
   void Sample(int16_t *left, int16_t *right);
+
+  void SampleBuffer(fixed *buffer, int size);
 
 protected:
   void Init(int sample_rate);

--- a/sources/Externals/opal/opal.h
+++ b/sources/Externals/opal/opal.h
@@ -197,8 +197,6 @@ protected:
   int16_t LastOutput[2], CurrOutput[2];
   Channel Chan[NumChannels];
   Operator Op[NumOperators];
-  //      uint16_t            ExpTable[256];
-  //      uint16_t            LogSinTable[256];
   uint16_t Clock;
   uint16_t TremoloClock;
   uint16_t TremoloLevel;
@@ -209,8 +207,6 @@ protected:
   bool VibratoDepth;
 
   static const uint16_t RateTables[4][8];
-  static const uint16_t ExpTable[256];
-  static const uint16_t LogSinTable[256];
 };
 
 #endif


### PR DESCRIPTION
As part of trying to improve performance for #283 this PR does some basic optimisation for the OPAL audio rendering code. The main optimisation in the OPAL code is removing function calls from the tight loop by creating a new method for generating samples together for a whole buffer and then further removing more function calls by inlining several small functions. At the cost of 200bytes of ram, the constant LUTs are also forced to be in ram all the time.

For a release builds takes rendering time for 1 `Render()` method call at default bpm and default OPAL instrument settings from:

```
Render took: 3838 (0 ts)[268860620]
Render took: 3820 (0 ts)[268860620]
Render took: 3813 (0 ts)[268860620]
Render took: 3764 (0 ts)[268860620]
Render took: 3800 (0 ts)[268860620]
Render took: 3811 (0 ts)[268860620]
Render took: 3822 (0 ts)[268860620]
Render took: 3802 (0 ts)[268860620]
Render took: 3773 (0 ts)[268860620]
Render took: 3827 (0 ts)[268860620]
```

to:
```
[OPALINSTRUMENT] Render took: 2832 us [799])
[OPALINSTRUMENT] Render took: 2812 us [799])
[OPALINSTRUMENT] Render took: 2783 us [799])
[OPALINSTRUMENT] Render took: 2829 us [799])
[OPALINSTRUMENT] Render took: 2827 us [799])
[OPALINSTRUMENT] Render took: 2805 us [798])
[OPALINSTRUMENT] Render took: 2786 us [799])
[OPALINSTRUMENT] Render took: 2792 us [799])
[OPALINSTRUMENT] Render took: 2813 us [799])
[OPALINSTRUMENT] Render took: 2840 us [799])
[OPALINSTRUMENT] Render took: 2814 us [799])
```

so from around avg of `3.8ms` to `2.8ms` which is a decent if not stellar improvement.