### PR TITLE
Fix note auditioning

### DIFF
--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -622,10 +622,11 @@ void PhraseView::pasteClipboard() {
   isDirty_ = true;
 };
 
-void PhraseView::stopAudition() {
+inline void PhraseView::stopAudition() {
   Player *player = Player::GetInstance();
-  if (viewData_->playMode_ == PM_AUDITION)
+  if (viewData_->playMode_ == PM_AUDITION) {
     player->Stop();
+  }
 }
 
 void PhraseView::unMuteAll() {
@@ -659,6 +660,12 @@ void PhraseView::OnFocus() {
 void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (!pressed) {
+    // ENTER might now no longer be pressed so first check if we were in
+    // audition mode and if its not then stop auditioning
+    if (!(mask & EPBM_A)) {
+      stopAudition();
+    }
+
     if (viewMode_ == VM_MUTEON) {
       if (mask & EPBM_R) {
         toggleMute();
@@ -807,7 +814,6 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
     if (mask & EPBM_DOWN)
       warpInChain(1);
     if (mask & EPBM_A) {
-      stopAudition();
       cutPosition();
     }
     if (mask & EPBM_L) {
@@ -815,9 +821,6 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
     };
     if (mask & EPBM_R)
       toggleMute();
-    if (mask == EPBM_B) {
-      stopAudition();
-    }
   } else {
 
     // A Modifer
@@ -853,19 +856,15 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         }
       }
     } else {
-
       // R Modifier
-
       if (mask & EPBM_R) {
         if (mask & EPBM_LEFT) {
-          stopAudition();
           ViewType vt = VT_CHAIN;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
           SetChanged();
           NotifyObservers(&ve);
         }
         if (mask & EPBM_RIGHT) {
-          stopAudition();
           unsigned char *c =
               phrase_->instr_ + (16 * viewData_->currentPhrase_ + row_);
           if (*c != 0xFF) {
@@ -882,7 +881,6 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         }
         if (mask & EPBM_DOWN) {
           // Go to table view
-          stopAudition();
 
           ViewType vt = VT_TABLE;
 

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -213,9 +213,20 @@ void PhraseView::updateCursorValue(ViewUpdateDirection direction, int xOffset,
 
     updateData(c, offset, limit, wrap);
     switch (col_ + xOffset) {
-    case 0:
+    case 0: {
       lastNote_ = *c;
+
+      Player *player = Player::GetInstance();
+      if (player->IsRunning()) {
+        // now also update if in auditioning mode
+        if (viewData_->playMode_ == PM_AUDITION) {
+          player->Stop();
+          player->OnStartButton(PM_AUDITION, viewData_->songX_, false,
+                                viewData_->chainRow_);
+        }
+      }
       break;
+    }
     case 1:
       lastInstr_ = *c;
       break;
@@ -661,7 +672,8 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (!pressed) {
     // ENTER might now no longer be pressed so first check if we were in
-    // audition mode and if its not then stop auditioning
+    // audition mode and if its not then stop auditioning, stopAudition does
+    // both those things
     if (!(mask & EPBM_A)) {
       stopAudition();
     }

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -860,6 +860,9 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         if ((col_ == 1) || (col_ == 3) || (col_ == 5))
           viewMode_ = VM_NEW;
         if (col_ == 0 || col_ == 1) {
+          // Start auditionq, note stopping audition happens in
+          // processButtonMask on key up
+          stopAudition();
           startAudition(true);
         }
       }

--- a/sources/Application/Views/PhraseView.h
+++ b/sources/Application/Views/PhraseView.h
@@ -34,6 +34,7 @@ protected:
   void cutSelection();
   void pasteClipboard();
 
+  void startAudition(bool startIfNotRunning);
   void stopAudition();
   void unMuteAll();
   void toggleMute();


### PR DESCRIPTION
Note will now only audition while the Enter key is held down.
Also fixes updating the note being auditioned while playing continues if the note is edited in the Phrase UI.

Fixes: #295