### PR TITLE
Update const names to match picoTracker key names

### DIFF
--- a/sources/Application/Views/BaseClasses/UIField.h
+++ b/sources/Application/Views/BaseClasses/UIField.h
@@ -13,8 +13,8 @@ public:
   virtual void Draw(GUIWindow &w, int offset = 0) = 0;
   virtual void OnClick() = 0; // A depressed
   virtual void ProcessArrow(unsigned short mask) = 0;
-  virtual void OnBClick(){}; // B depressed
-  virtual void ProcessBArrow(unsigned short mask){};
+  virtual void OnEditClick(){}; // B depressed
+  virtual void ProcessEditArrow(unsigned short mask){};
   void SetFocus();
   void ClearFocus();
   bool HasFocus();

--- a/sources/Application/Views/BaseClasses/UITempoField.cpp
+++ b/sources/Application/Views/BaseClasses/UITempoField.cpp
@@ -21,7 +21,7 @@ UITempoField::UITempoField(FourCC action, GUIPoint &position, Variable &v,
 } ;
 */
 
-void UITempoField::OnBClick() {
+void UITempoField::OnEditClick() {
   ApplicationCommandDispatcher::GetInstance()->OnTempoTap();
 };
 
@@ -57,7 +57,7 @@ void UITempoField::ProcessArrow(unsigned short mask) {
   src_.SetInt(value);
 };
 
-void UITempoField::ProcessBArrow(unsigned short mask) {
+void UITempoField::ProcessEditArrow(unsigned short mask) {
 
   ApplicationCommandDispatcher *dispatcher =
       ApplicationCommandDispatcher::GetInstance();

--- a/sources/Application/Views/BaseClasses/UITempoField.h
+++ b/sources/Application/Views/BaseClasses/UITempoField.h
@@ -8,10 +8,10 @@ class UITempoField : public UIIntVarField, public I_Observer {
 public:
   UITempoField(FourCC action, GUIPoint &position, Variable &variable,
                const char *format, int min, int max, int xOffset, int yOffset);
-  virtual void OnBClick();
+  virtual void OnEditClick();
   void Update(Observable &, I_ObservableData *);
   void ProcessArrow(unsigned short mask);
-  void ProcessBArrow(unsigned short mask);
+  void ProcessEditArrow(unsigned short mask);
 
 private:
   FourCC action_;

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -16,14 +16,12 @@ enum GUIEventPadButtonMasks {
   EPBM_DOWN = 2,
   EPBM_RIGHT = 4,
   EPBM_UP = 8,
-  EPBM_L = 16,
-  EPBM_B = 32,
-  EPBM_A = 64,
-  EPBM_R = 128,
-  EPBM_START = 256,
+  EPBM_ALT = 16,
+  EPBM_EDIT = 32,
+  EPBM_ENTER = 64,
+  EPBM_NAV = 128,
+  EPBM_PLAY = 256,
   EPBM_SELECT = 512,
-  EPBM_DOUBLE_A = 1024,
-  EPBM_DOUBLE_B = 2048
 };
 
 enum ViewType {

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -375,12 +375,12 @@ void ChainView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (!pressed) {
     if (viewMode_ == VM_MUTEON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         toggleMute();
       }
     };
     if (viewMode_ == VM_SOLOON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         switchSoloMode();
       }
     };
@@ -388,20 +388,20 @@ void ChainView::ProcessButtonMask(unsigned short mask, bool pressed) {
   };
 
   if (viewMode_ == VM_NEW) {
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
       unsigned short next = viewData_->song_->phrase_.GetNext();
       if (next != NO_MORE_PHRASE) {
         setPhrase((unsigned char)next);
         isDirty_ = true;
       }
-      mask &= (0xFFFF - EPBM_A);
+      mask &= (0xFFFF - EPBM_ENTER);
     }
   }
 
   if (viewMode_ == VM_CLONE) {
-    if ((mask & EPBM_A) && (mask & EPBM_L)) {
+    if ((mask & EPBM_ENTER) && (mask & EPBM_ALT)) {
       clonePosition();
-      mask &= (0xFFFF - (EPBM_A | EPBM_L));
+      mask &= (0xFFFF - (EPBM_ENTER | EPBM_ALT));
     } else {
       viewMode_ = VM_SELECTION;
     }
@@ -434,7 +434,7 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
 
   // B Modifier
 
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_LEFT)
       warpToNeighbour(-1);
     if (mask & EPBM_RIGHT)
@@ -443,18 +443,18 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
       warpInColumn(-1);
     if (mask & EPBM_DOWN)
       warpInColumn(+1);
-    if (mask & EPBM_A)
+    if (mask & EPBM_ENTER)
       cutPosition();
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       viewMode_ = VM_CLONE;
     };
-    if (mask & EPBM_R)
+    if (mask & EPBM_NAV)
       toggleMute();
   } else {
 
     // A Modifier
 
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       if (mask & EPBM_DOWN)
         updateCursorValue(viewData_->chainCol_ == 0 ? -0x10 : -0x0C);
       if (mask & EPBM_UP)
@@ -463,20 +463,20 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
         updateCursorValue(-0x01);
       if (mask & EPBM_RIGHT)
         updateCursorValue(0x01);
-      if (mask & EPBM_L)
+      if (mask & EPBM_ALT)
         pasteClipboard();
-      if (mask == EPBM_A) {
+      if (mask == EPBM_ENTER) {
         pasteLastPhrase();
         if (viewData_->chainCol_ == 0)
           viewMode_ = VM_NEW;
       }
-      if (mask & EPBM_R)
+      if (mask & EPBM_NAV)
         switchSoloMode();
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
 
         if (mask & EPBM_LEFT) {
           ViewType vt = VT_SONG;
@@ -499,15 +499,15 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
         // We toggle full chain start only if we"re not in live mode
         // or if the player ain't playing yet
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_CHAIN, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
-        if (mask & EPBM_L)
+        if (mask & EPBM_ALT)
           unMuteAll();
       } else {
         // L Modifier
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
 
         } else {
           // NO modifier
@@ -519,7 +519,7 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
             updateCursor(-1, 0);
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             player->OnStartButton(PM_CHAIN, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }
@@ -527,7 +527,7 @@ void ChainView::processNormalButtonMask(unsigned short mask) {
       }
     }
   }
-  if ((!(mask & EPBM_A)) && updatingPhrase_) {
+  if ((!(mask & EPBM_ENTER)) && updatingPhrase_) {
     unsigned char *c = viewData_->song_->chain_.data_ +
                        (16 * viewData_->currentChain_ + updateRow_);
     viewData_->song_->phrase_.SetUsed(*c);
@@ -541,18 +541,18 @@ void ChainView::processSelectionButtonMask(unsigned short mask) {
 
   // B Modifier
 
-  if (mask & EPBM_B) {
-    if (mask == EPBM_B)
+  if (mask & EPBM_EDIT) {
+    if (mask == EPBM_EDIT)
       copySelection();
-    if (mask & EPBM_R)
+    if (mask & EPBM_NAV)
       toggleMute();
-    if (mask & EPBM_L)
+    if (mask & EPBM_ALT)
       extendSelection();
   } else {
 
     // A modifier
 
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
 
       if (mask & EPBM_DOWN)
         updateSelectionValue(viewData_->chainCol_ == 0 ? -0x10 : -0x0C);
@@ -563,16 +563,16 @@ void ChainView::processSelectionButtonMask(unsigned short mask) {
       if (mask & EPBM_RIGHT)
         updateSelectionValue(0x01);
 
-      if (mask & EPBM_L) {
+      if (mask & EPBM_ALT) {
         cutSelection();
       }
-      if (mask & EPBM_R)
+      if (mask & EPBM_NAV)
         switchSoloMode();
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
 
         if (mask & EPBM_LEFT) {
           ViewType vt = VT_SONG;
@@ -592,12 +592,12 @@ void ChainView::processSelectionButtonMask(unsigned short mask) {
           }
         }
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_CHAIN, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
 
-        if (mask & EPBM_L)
+        if (mask & EPBM_ALT)
           unMuteAll();
 
       } else {
@@ -613,7 +613,7 @@ void ChainView::processSelectionButtonMask(unsigned short mask) {
         if (mask & EPBM_RIGHT)
           updateCursor(1, 0);
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_CHAIN, viewData_->songX_, false,
                                 viewData_->chainRow_);
         }

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -159,7 +159,7 @@ void DeviceView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   FieldView::ProcessButtonMask(mask);
 
-  if (mask & EPBM_R) {
+  if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {
       ViewType vt = VT_PROJECT;
       ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -167,7 +167,7 @@ void DeviceView::ProcessButtonMask(unsigned short mask, bool pressed) {
       NotifyObservers(&ve);
     }
   } else {
-    if (mask & EPBM_START) {
+    if (mask & EPBM_PLAY) {
       Player *player = Player::GetInstance();
       player->OnStartButton(PM_SONG, viewData_->songX_, false,
                             viewData_->songX_);

--- a/sources/Application/Views/FieldView.cpp
+++ b/sources/Application/Views/FieldView.cpp
@@ -53,7 +53,7 @@ void FieldView::ProcessButtonMask(unsigned short mask) {
     focus_->SetFocus();
   }
 
-  if (mask & EPBM_A) { // A or A+ARROW is sent to the field
+  if (mask & EPBM_ENTER) { // A or A+ARROW is sent to the field
     if (mask & EPBM_DOWN) {
       focus_->ProcessArrow(EPBM_DOWN);
       isDirty_ = true;
@@ -73,14 +73,14 @@ void FieldView::ProcessButtonMask(unsigned short mask) {
       isDirty_ = true;
     }
 
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
       focus_->OnClick();
     };
 
   } else {
-    if (mask & EPBM_B) { // B or B+ARROW is sent to the field
+    if (mask & EPBM_EDIT) { // B or B+ARROW is sent to the field
 
-      if (mask == EPBM_B) {
+      if (mask == EPBM_EDIT) {
         focus_->OnBClick();
         isDirty_ = true;
       };
@@ -106,8 +106,8 @@ void FieldView::ProcessButtonMask(unsigned short mask) {
 
     } else { // Nor B or A is pressed
 
-      if (!(mask &
-            (EPBM_A | EPBM_B | EPBM_L | EPBM_R | EPBM_SELECT | EPBM_START))) {
+      if (!(mask & (EPBM_ENTER | EPBM_EDIT | EPBM_ALT | EPBM_NAV | EPBM_SELECT |
+                    EPBM_PLAY))) {
 
         if (mask & EPBM_DOWN) {
           UIField *next = 0;

--- a/sources/Application/Views/FieldView.cpp
+++ b/sources/Application/Views/FieldView.cpp
@@ -81,26 +81,26 @@ void FieldView::ProcessButtonMask(unsigned short mask) {
     if (mask & EPBM_EDIT) { // B or B+ARROW is sent to the field
 
       if (mask == EPBM_EDIT) {
-        focus_->OnBClick();
+        focus_->OnEditClick();
         isDirty_ = true;
       };
 
       if (mask & EPBM_DOWN) {
-        focus_->ProcessBArrow(EPBM_DOWN);
+        focus_->ProcessEditArrow(EPBM_DOWN);
         isDirty_ = true;
       }
       if (mask & EPBM_UP) {
-        focus_->ProcessBArrow(EPBM_UP);
+        focus_->ProcessEditArrow(EPBM_UP);
         isDirty_ = true;
       }
 
       if (mask & EPBM_LEFT) {
-        focus_->ProcessBArrow(EPBM_LEFT);
+        focus_->ProcessEditArrow(EPBM_LEFT);
         isDirty_ = true;
       }
 
       if (mask & EPBM_RIGHT) {
-        focus_->ProcessBArrow(EPBM_RIGHT);
+        focus_->ProcessEditArrow(EPBM_RIGHT);
         isDirty_ = true;
       }
 

--- a/sources/Application/Views/GrooveView.cpp
+++ b/sources/Application/Views/GrooveView.cpp
@@ -72,7 +72,7 @@ void GrooveView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   Player *player = Player::GetInstance();
 
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_LEFT) {
       warpGroove(-1);
     }
@@ -85,13 +85,13 @@ void GrooveView::ProcessButtonMask(unsigned short mask, bool pressed) {
     if (mask & EPBM_UP) {
       warpGroove(0x10);
     }
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       clearCursorValue();
     };
   } else {
 
     // A modifier
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       if (mask & EPBM_LEFT) {
         updateCursorValue(-1);
       }
@@ -104,20 +104,20 @@ void GrooveView::ProcessButtonMask(unsigned short mask, bool pressed) {
       if (mask & EPBM_UP) {
         updateCursorValue(1, true);
       }
-      if (mask == EPBM_A) {
+      if (mask == EPBM_ENTER) {
         initCursorValue();
       };
     } else {
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_DOWN) {
           ViewType vt = VT_PHRASE;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
           SetChanged();
           NotifyObservers(&ve);
         }
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
@@ -128,7 +128,7 @@ void GrooveView::ProcessButtonMask(unsigned short mask, bool pressed) {
           updateCursor(1);
         if (mask & EPBM_UP)
           updateCursor(-1);
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                 viewData_->chainRow_);
         }

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -20,13 +20,13 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  if (mask & EPBM_START) {
+  if (mask & EPBM_PLAY) {
     auto picoFS = PicoFileSystem::GetInstance();
     char name[PFILENAME_SIZE];
     unsigned fileIndex = fileIndexList_[currentIndex_];
     picoFS->getFileName(fileIndex, name, PFILENAME_SIZE);
 
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       Trace::Log("PICOIMPORT", "SHIFT play - import");
       import(name);
     } else {
@@ -38,7 +38,7 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
     warpToNextSample(true);
   } else if (mask & EPBM_DOWN) {
     warpToNextSample(false);
-  } else if ((mask & EPBM_LEFT) && (mask & EPBM_R)) {
+  } else if ((mask & EPBM_LEFT) && (mask & EPBM_NAV)) {
     // Go to back "left" to instrument screen
     ViewType vt = VT_INSTRUMENT;
     ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -47,7 +47,7 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
     return;
   } else {
     // A modifier
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       auto picoFS = PicoFileSystem::GetInstance();
       unsigned fileIndex = fileIndexList_[currentIndex_];
       char name[PFILENAME_SIZE];

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -592,7 +592,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
   Player *player = Player::GetInstance();
 
   if (viewMode_ == VM_NEW) {
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
       UIIntVarField *field = (UIIntVarField *)GetFocus();
       Variable &v = field->GetVariable();
       switch (v.GetID()) {
@@ -630,14 +630,14 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
       default:
         break;
       }
-      mask &= (0xFFFF - EPBM_A);
+      mask &= (0xFFFF - EPBM_ENTER);
     }
   }
 
   if (viewMode_ == VM_CLONE) {
-    if ((mask & EPBM_A) && (mask & EPBM_L)) {
+    if ((mask & EPBM_ENTER) && (mask & EPBM_ALT)) {
       UIIntVarField *field = (UIIntVarField *)GetFocus();
-      mask &= (0xFFFF - EPBM_A);
+      mask &= (0xFFFF - EPBM_ENTER);
       Variable &v = field->GetVariable();
       int current = v.GetInt();
       if (current == -1)
@@ -649,7 +649,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
         isDirty_ = true;
       }
     }
-    mask &= (0xFFFF - (EPBM_A | EPBM_L));
+    mask &= (0xFFFF - (EPBM_ENTER | EPBM_ALT));
   };
 
   if (viewMode_ == VM_SELECTION) {
@@ -660,7 +660,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
   FieldView::ProcessButtonMask(mask);
 
   // B Modifier
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_LEFT)
       warpToNext(-1);
     if (mask & EPBM_RIGHT)
@@ -669,7 +669,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
       warpToNext(-16);
     if (mask & EPBM_UP)
       warpToNext(+16);
-    if (mask & EPBM_A) { // Allow cut instrument
+    if (mask & EPBM_ENTER) { // Allow cut instrument
       if (getInstrument()->GetType() == IT_SAMPLE) {
         if (GetFocus() == *fieldList_.begin()) {
           int i = viewData_->currentInstrumentID_;
@@ -692,14 +692,14 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
         isDirty_ = true;
       };
     }
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       viewMode_ = VM_CLONE;
     };
   } else {
 
     // A modifier
 
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
       FourCC varID = ((UIIntVarField *)GetFocus())->GetVariableID();
       if ((varID == FourCC::SampleInstrumentTable) ||
           (varID == FourCC::MidiInstrumentTable) ||
@@ -710,7 +710,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_LEFT) {
           ViewType vt = VT_PHRASE;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -741,13 +741,13 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
           NotifyObservers(&ve);
         }
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
       } else {
         // No modifier
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                 viewData_->chainRow_);
         }

--- a/sources/Application/Views/ModalDialogs/MessageBox.cpp
+++ b/sources/Application/Views/ModalDialogs/MessageBox.cpp
@@ -84,7 +84,7 @@ void MessageBox::ProcessButtonMask(unsigned short mask, bool pressed) {
     if (selected_ < 0) {
       selected_ = buttonCount_ - 1;
     }
-  } else if (mask & EPBM_A && pressed) {
+  } else if (mask & EPBM_ENTER && pressed) {
     EndModal(button_[selected_]);
   }
   isDirty_ = true;

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -682,17 +682,17 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
     // ENTER might now no longer be pressed so first check if we were in
     // audition mode and if its not then stop auditioning, stopAudition does
     // both those things
-    if (!(mask & EPBM_A)) {
+    if (!(mask & EPBM_ENTER)) {
       stopAudition();
     }
 
     if (viewMode_ == VM_MUTEON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         toggleMute();
       }
     };
     if (viewMode_ == VM_SOLOON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         switchSoloMode();
       }
     };
@@ -700,7 +700,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
   };
 
   if (viewMode_ == VM_NEW) {
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
 
       // If note or I, we request a new instr
       if (col_ < 2) {
@@ -716,7 +716,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
           lastInstr_ = next;
           isDirty_ = true;
         }
-        mask &= (0xFFFF - EPBM_A);
+        mask &= (0xFFFF - EPBM_ENTER);
       } else {
         if ((col_ == 3) &&
             (*(phrase_->cmd1_ + (16 * viewData_->currentPhrase_ + row_))) ==
@@ -728,7 +728,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
                 phrase_->param1_ + (16 * viewData_->currentPhrase_ + row_);
             *c = next;
             isDirty_ = true;
-            mask &= (0xFFFF - EPBM_A);
+            mask &= (0xFFFF - EPBM_ENTER);
             cmdEdit_.SetInt(next);
           }
         }
@@ -742,7 +742,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
                 phrase_->param2_ + (16 * viewData_->currentPhrase_ + row_);
             *c = next;
             isDirty_ = true;
-            mask &= (0xFFFF - EPBM_A);
+            mask &= (0xFFFF - EPBM_ENTER);
             cmdEdit_.SetInt(next);
           }
         }
@@ -751,7 +751,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
   }
 
   if (viewMode_ == VM_CLONE) {
-    if ((mask & EPBM_A) && (mask & EPBM_L)) {
+    if ((mask & EPBM_ENTER) && (mask & EPBM_ALT)) {
       if (col_ < 2) {
         InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
         unsigned char *c =
@@ -797,7 +797,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
           }
         }
       };
-      mask &= (0xFFFF - (EPBM_A | EPBM_L));
+      mask &= (0xFFFF - (EPBM_ENTER | EPBM_ALT));
     } else {
       viewMode_ = VM_SELECTION;
     }
@@ -821,7 +821,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
 void PhraseView::processNormalButtonMask(unsigned short mask) {
 
   // B Modifier
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_LEFT)
       warpToNeighbour(-1);
     if (mask & EPBM_RIGHT)
@@ -830,19 +830,19 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
       warpInChain(-1);
     if (mask & EPBM_DOWN)
       warpInChain(1);
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       cutPosition();
     }
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       viewMode_ = VM_CLONE;
     };
-    if (mask & EPBM_R)
+    if (mask & EPBM_NAV)
       toggleMute();
   } else {
     Player *player = Player::GetInstance();
 
     // A Modifer
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       if (mask & EPBM_DOWN)
         updateCursorValue(VUD_DOWN);
       if (mask & EPBM_UP)
@@ -851,11 +851,11 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
         updateCursorValue(VUD_LEFT);
       if (mask & EPBM_RIGHT)
         updateCursorValue(VUD_RIGHT);
-      if (mask & EPBM_L)
+      if (mask & EPBM_ALT)
         pasteClipboard();
-      if (mask & EPBM_R)
+      if (mask & EPBM_NAV)
         switchSoloMode();
-      if (mask == EPBM_A) {
+      if (mask == EPBM_ENTER) {
         pasteLast();
         if ((col_ == 1) || (col_ == 3) || (col_ == 5))
           viewMode_ = VM_NEW;
@@ -868,7 +868,7 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
       }
     } else {
       // R Modifier
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_LEFT) {
           ViewType vt = VT_CHAIN;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -922,16 +922,16 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
           NotifyObservers(&ve);
         }
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
-        if (mask & EPBM_L)
+        if (mask & EPBM_ALT)
           unMuteAll();
 
       } else {
         // L Modifier
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
 
         } else {
           // No modifier
@@ -944,7 +944,7 @@ void PhraseView::processNormalButtonMask(unsigned short mask) {
             updateCursor(-1, 0);
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }
@@ -960,8 +960,8 @@ void PhraseView::processSelectionButtonMask(unsigned short mask) {
 
   // B modifier
 
-  if (mask & EPBM_B) {
-    if (mask & EPBM_L) {
+  if (mask & EPBM_EDIT) {
+    if (mask & EPBM_ALT) {
       extendSelection();
     } else {
       copySelection();
@@ -970,7 +970,7 @@ void PhraseView::processSelectionButtonMask(unsigned short mask) {
 
     // A Modifer
 
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
 
       if (mask & EPBM_DOWN)
         updateSelectionValue(VUD_DOWN);
@@ -981,15 +981,15 @@ void PhraseView::processSelectionButtonMask(unsigned short mask) {
       if (mask & EPBM_RIGHT)
         updateSelectionValue(VUD_RIGHT);
 
-      if (mask & EPBM_L)
+      if (mask & EPBM_ALT)
         cutSelection();
-      if (mask & EPBM_R)
+      if (mask & EPBM_NAV)
         switchSoloMode();
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_LEFT) {
           ViewType vt = VT_CHAIN;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -1009,16 +1009,16 @@ void PhraseView::processSelectionButtonMask(unsigned short mask) {
           SetChanged();
           NotifyObservers(&ve);
         }
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
-        if (mask & EPBM_L)
+        if (mask & EPBM_ALT)
           unMuteAll();
 
       } else {
         // L Modifier
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
 
         } else {
           // No modifier
@@ -1031,7 +1031,7 @@ void PhraseView::processSelectionButtonMask(unsigned short mask) {
             updateCursor(-1, 0);
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -162,7 +162,7 @@ void ProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   FieldView::ProcessButtonMask(mask);
 
-  if (mask & EPBM_R) {
+  if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {
       ViewType vt = VT_SONG;
       ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -176,7 +176,7 @@ void ProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
       NotifyObservers(&ve);
     }
   } else {
-    if (mask & EPBM_START) {
+    if (mask & EPBM_PLAY) {
       Player *player = Player::GetInstance();
       player->OnStartButton(PM_SONG, viewData_->songX_, false,
                             viewData_->songX_);

--- a/sources/Application/Views/SelectProjectView.cpp
+++ b/sources/Application/Views/SelectProjectView.cpp
@@ -73,14 +73,14 @@ void SelectProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_UP)
       warpToNextProject(true);
     if (mask & EPBM_DOWN)
       warpToNextProject(false);
   } else {
     // A modifier
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       // all subdirs directly inside /project are expected to be projects
       unsigned fileIndex = fileIndexList_[currentIndex_];
       auto picoFS = PicoFileSystem::GetInstance();
@@ -101,7 +101,7 @@ void SelectProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
       return;
     } else {
       // R Modifier
-      if ((mask & EPBM_R) && (mask & EPBM_LEFT)) {
+      if ((mask & EPBM_NAV) && (mask & EPBM_LEFT)) {
         // Go to back "left" to Project Screen
         ViewType vt = VT_PROJECT;
         ViewEvent ve(VET_SWITCH_VIEW, &vt);

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -485,12 +485,12 @@ void SongView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (!pressed) {
     if (viewMode_ == VM_MUTEON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         toggleMute();
       }
     };
     if (viewMode_ == VM_SOLOON) {
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         switchSoloMode();
       }
     };
@@ -498,20 +498,20 @@ void SongView::ProcessButtonMask(unsigned short mask, bool pressed) {
   };
 
   if (viewMode_ == VM_NEW) {
-    if (mask == EPBM_A) {
+    if (mask == EPBM_ENTER) {
       unsigned short next = viewData_->song_->chain_.GetNext();
       if (next != NO_MORE_CHAIN) {
         setChain((unsigned char)next);
         isDirty_ = true;
       }
-      mask &= (0xFFFF - EPBM_A);
+      mask &= (0xFFFF - EPBM_ENTER);
     }
   }
 
   if (viewMode_ == VM_CLONE) {
-    if ((mask & EPBM_A) && (mask & EPBM_L)) {
+    if ((mask & EPBM_ENTER) && (mask & EPBM_ALT)) {
       clonePosition();
-      mask &= (0xFFFF - (EPBM_A | EPBM_L));
+      mask &= (0xFFFF - (EPBM_ENTER | EPBM_ALT));
     } else {
       viewMode_ = VM_SELECTION;
     }
@@ -552,7 +552,7 @@ void SongView::processNormalButtonMask(unsigned int mask) {
 
   // B Modifier
 
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_DOWN)
       updateSongOffset(View::songRowCount_);
     if (mask & EPBM_UP)
@@ -569,22 +569,22 @@ void SongView::processNormalButtonMask(unsigned int mask) {
       }
       isDirty_ = true;
     }
-    if ((mask & EPBM_A) && (!(mask & EPBM_R)))
+    if ((mask & EPBM_ENTER) && (!(mask & EPBM_NAV)))
       cutPosition();
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       viewMode_ = VM_CLONE;
     };
-    if (mask & EPBM_R) {
+    if (mask & EPBM_NAV) {
       toggleMute();
     };
-    if (mask & EPBM_START) {
+    if (mask & EPBM_PLAY) {
       startImmediate();
     }
   } else {
 
     // A modifier
 
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
 
       if (mask & EPBM_DOWN)
         updateChain(-0x10);
@@ -594,22 +594,22 @@ void SongView::processNormalButtonMask(unsigned int mask) {
         updateChain(-0x01);
       if (mask & EPBM_RIGHT)
         updateChain(0x01);
-      if (mask & EPBM_L)
+      if (mask & EPBM_ALT)
         pasteClipboard();
-      if (mask == EPBM_A) {
+      if (mask == EPBM_ENTER) {
         pasteLast();
         viewMode_ = VM_NEW;
       }
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         switchSoloMode();
       };
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
 
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
           unMuteAll();
         }
 
@@ -638,7 +638,7 @@ void SongView::processNormalButtonMask(unsigned int mask) {
           NotifyObservers(&ve);
         }
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           onStop();
         }
 
@@ -646,12 +646,12 @@ void SongView::processNormalButtonMask(unsigned int mask) {
 
         // L Modifier
 
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
           if (mask & EPBM_DOWN)
             jumpToNextSection(1);
           if (mask & EPBM_UP)
             jumpToNextSection(-1);
-          if (mask & EPBM_START)
+          if (mask & EPBM_PLAY)
             startCurrentRow();
         } else {
 
@@ -666,7 +666,7 @@ void SongView::processNormalButtonMask(unsigned int mask) {
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
 
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             onStart();
           }
         }
@@ -674,7 +674,7 @@ void SongView::processNormalButtonMask(unsigned int mask) {
     }
   }
 
-  if ((!(mask & EPBM_A)) && updatingChain_) {
+  if ((!(mask & EPBM_ENTER)) && updatingChain_) {
     unsigned char *c = viewData_->song_->data_ + updateX_ +
                        SONG_CHANNEL_COUNT * (viewData_->songOffset_ + updateY_);
     viewData_->song_->chain_.SetUsed(*c);
@@ -692,14 +692,14 @@ void SongView::processSelectionButtonMask(unsigned int mask) {
 
   // B Modifier
 
-  if (mask & EPBM_B) {
-    if (mask & EPBM_R) {
+  if (mask & EPBM_EDIT) {
+    if (mask & EPBM_NAV) {
       toggleMute();
     };
-    if (mask & EPBM_L) {
+    if (mask & EPBM_ALT) {
       extendSelection();
     };
-    if (mask == EPBM_B) {
+    if (mask == EPBM_EDIT) {
       copySelection();
     }
 
@@ -707,20 +707,20 @@ void SongView::processSelectionButtonMask(unsigned int mask) {
 
     // A modifier
 
-    if (mask & EPBM_A) {
-      if (mask & EPBM_L) {
+    if (mask & EPBM_ENTER) {
+      if (mask & EPBM_ALT) {
         cutSelection();
       }
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         switchSoloMode();
       };
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
 
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
           unMuteAll();
         }
 
@@ -749,7 +749,7 @@ void SongView::processSelectionButtonMask(unsigned int mask) {
           NotifyObservers(&ve);
         }
 
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           onStop();
         }
 
@@ -765,7 +765,7 @@ void SongView::processSelectionButtonMask(unsigned int mask) {
           updateCursor(-1, 0);
         if (mask & EPBM_RIGHT)
           updateCursor(1, 0);
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           onStart();
         }
       }

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -506,7 +506,7 @@ void TableView::processNormalButtonMask(unsigned short mask) {
 
   Player *player = Player::GetInstance();
 
-  if (mask & EPBM_B) {
+  if (mask & EPBM_EDIT) {
     if (mask & EPBM_LEFT)
       warpToNeighbour(-1);
     if (mask & EPBM_RIGHT)
@@ -515,16 +515,16 @@ void TableView::processNormalButtonMask(unsigned short mask) {
       warpToNeighbour(-16);
     if (mask & EPBM_UP)
       warpToNeighbour(16);
-    if (mask & EPBM_A)
+    if (mask & EPBM_ENTER)
       cutPosition();
-    if (mask & EPBM_L)
+    if (mask & EPBM_ALT)
       viewMode_ = VM_SELECTION;
 
   } else {
 
     // A modifier
 
-    if (mask & EPBM_A) {
+    if (mask & EPBM_ENTER) {
       if (mask & EPBM_DOWN)
         updateCursorValue(-0x10);
       if (mask & EPBM_UP)
@@ -533,15 +533,15 @@ void TableView::processNormalButtonMask(unsigned short mask) {
         updateCursorValue(-0x01);
       if (mask & EPBM_RIGHT)
         updateCursorValue(0x01);
-      if (mask == EPBM_A)
+      if (mask == EPBM_ENTER)
         pasteLast();
-      if (mask & EPBM_L)
+      if (mask & EPBM_ALT)
         pasteClipboard();
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_UP) {
           ViewType vt = (viewType_ == VT_TABLE ? VT_PHRASE : VT_INSTRUMENT);
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
@@ -564,14 +564,14 @@ void TableView::processNormalButtonMask(unsigned short mask) {
             NotifyObservers(&ve);
           }
         }
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
 
       } else {
         // L MOdifier
-        if (mask & EPBM_R) {
+        if (mask & EPBM_NAV) {
         } else {
 
           // No modifier
@@ -584,7 +584,7 @@ void TableView::processNormalButtonMask(unsigned short mask) {
             updateCursor(-1, 0);
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }
@@ -598,8 +598,8 @@ void TableView::processSelectionButtonMask(unsigned short mask) {
 
   Player *player = Player::GetInstance();
 
-  if (mask & EPBM_B) {
-    if (mask & EPBM_L) {
+  if (mask & EPBM_EDIT) {
+    if (mask & EPBM_ALT) {
       extendSelection();
     } else {
       copySelection();
@@ -608,22 +608,22 @@ void TableView::processSelectionButtonMask(unsigned short mask) {
 
     // A Modifer
 
-    if (mask & EPBM_A) {
-      if (mask & EPBM_L)
+    if (mask & EPBM_ENTER) {
+      if (mask & EPBM_ALT)
         cutSelection();
       //		if (mask&EPBM_R) switchSoloMode() ;
     } else {
 
       // R Modifier
 
-      if (mask & EPBM_R) {
+      if (mask & EPBM_NAV) {
         if (mask & EPBM_UP) {
           ViewType vt = VT_PHRASE;
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
           SetChanged();
           NotifyObservers(&ve);
         }
-        if (mask & EPBM_START) {
+        if (mask & EPBM_PLAY) {
           player->OnStartButton(PM_PHRASE, viewData_->songX_, true,
                                 viewData_->chainRow_);
         }
@@ -631,7 +631,7 @@ void TableView::processSelectionButtonMask(unsigned short mask) {
          */
       } else {
         // L Modifier
-        if (mask & EPBM_L) {
+        if (mask & EPBM_ALT) {
 
         } else {
           // No modifier
@@ -644,7 +644,7 @@ void TableView::processSelectionButtonMask(unsigned short mask) {
             updateCursor(-1, 0);
           if (mask & EPBM_RIGHT)
             updateCursor(1, 0);
-          if (mask & EPBM_START) {
+          if (mask & EPBM_PLAY) {
             player->OnStartButton(PM_PHRASE, viewData_->songX_, false,
                                   viewData_->chainRow_);
           }


### PR DESCRIPTION
Just an automated renaming of the consts to match user facing names of each key in the picoTracker user manual.

Fixes: #298 