### PR TITLE
Fixes multiple issues with project naming

### DIFF
--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -13,14 +13,17 @@ public:
   void Draw(GUIWindow &w, int offset = 0);
   void ProcessArrow(unsigned short mask);
   void OnClick();
+  void OnBClick();
   etl::string<40> GetString();
 
 private:
   int selected_;
-  int lastChar_;
   int currentChar_ = 0;
   Variable *src_;
   const char *name_;
   unsigned int fourcc_;
 };
+
+char getNext(char c, bool reverse);
+void deleteChar(char *name, uint8_t pos);
 #endif


### PR DESCRIPTION
1. Iterate over a list of valid characters (should we add/delete some? maybe lower case doesn't make sense to have)
2. Cursor goes to first char on focus/click
3. Use "edit" to delete a char, if cursor is at the end, move it left so we can quickly delete the whole name
4. when editing .Untitled project name immediately delete the string to start a new name
5. when moving right from last char, create a new char (easily deletable pressing "edit" if done by mistake)

