### PR TITLE
Clear previous unnamed project when user does "New"

### DIFF
--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -8,8 +8,6 @@
 #include <string.h>
 #include <string>
 
-#define MAX_PROJECT_SAMPLE_PATH_LENGTH 146 // 17 + 128 + 1
-
 #ifdef LOAD_IN_FLASH
 #include "hardware/flash.h"
 // #define FLASH_TARGET_OFFSET (1024 * 1024)

--- a/sources/Application/Persistency/PersistencyService.cpp
+++ b/sources/Application/Persistency/PersistencyService.cpp
@@ -25,7 +25,7 @@ void PersistencyService::PurgeUnnamedProject() {
   picoFS->DeleteFile(PROJECT_DATA_FILE);
 
   picoFS->chdir("samples");
-  etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexes;
+  etl::vector<int, MAX_PIG_SAMPLES> fileIndexes;
   picoFS->list(&fileIndexes, ".wav", false);
 
   // delete all samples

--- a/sources/Application/Persistency/PersistencyService.cpp
+++ b/sources/Application/Persistency/PersistencyService.cpp
@@ -16,6 +16,27 @@ PersistencyResult PersistencyService::CreateProject() {
   return PersistencyService::GetInstance()->Save(UNNAMED_PROJECT_NAME, true);
 };
 
+void PersistencyService::PurgeUnnamedProject() {
+  auto picoFS = PicoFileSystem::GetInstance();
+
+  picoFS->chdir(PROJECTS_DIR);
+  Trace::Debug("PERSISTENCYSERVICE", "purging unnamed project dir\n");
+  picoFS->chdir(UNNAMED_PROJECT_NAME);
+  picoFS->DeleteFile(PROJECT_DATA_FILE);
+
+  picoFS->chdir("samples");
+  etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexes;
+  picoFS->list(&fileIndexes, ".wav", false);
+
+  // delete all samples
+  char filename[128];
+  for (size_t i = 0; i < fileIndexes.size(); i++) {
+    picoFS->getFileName(fileIndexes[i], filename,
+                        MAX_PROJECT_SAMPLE_PATH_LENGTH);
+    picoFS->DeleteFile(filename);
+  };
+};
+
 PersistencyResult PersistencyService::Save(const char *projectName,
                                            bool saveAs) {
   etl::string<128> projectFilePath(PROJECTS_DIR);
@@ -36,7 +57,8 @@ PersistencyResult PersistencyService::Save(const char *projectName,
                samplesPath.c_str());
   }
 
-  projectFilePath.append("/lgptsav.dat");
+  projectFilePath.append("/");
+  projectFilePath.append(PROJECT_DATA_FILE);
 
   PI_File *fp = picoFS->Open(projectFilePath.c_str(), "w");
   if (!fp) {
@@ -79,7 +101,8 @@ PersistencyResult PersistencyService::Load(const char *projectName) {
   etl::string<128> projectFilePath(PROJECTS_DIR);
   projectFilePath.append("/");
   projectFilePath.append(projectName);
-  projectFilePath.append("/lgptsav.dat");
+  projectFilePath.append("/");
+  projectFilePath.append(PROJECT_DATA_FILE);
 
   PersistencyDocument doc;
   if (!doc.Load(projectFilePath.c_str()))

--- a/sources/Application/Persistency/PersistencyService.h
+++ b/sources/Application/Persistency/PersistencyService.h
@@ -21,6 +21,7 @@ enum PersistencyResult {
 };
 
 #define UNNAMED_PROJECT_NAME ".untitled"
+#define PROJECT_DATA_FILE "lgptsav.dat"
 
 class PersistencyService : public Service,
                            public T_Singleton<PersistencyService> {
@@ -32,6 +33,7 @@ public:
   PersistencyResult SaveProjectState(const char *projectName);
   PersistencyResult CreateProject();
   bool Exists(const char *projectName);
+  void PurgeUnnamedProject();
 };
 
 #endif

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -30,6 +30,9 @@ static void CreateNewProjectCallback(View &v, ModalView &dialog) {
   if (dialog.GetReturnCode() == MBL_YES) {
     PersistencyService::GetInstance()->SaveProjectState(UNNAMED_PROJECT_NAME);
 
+    // first clear out any existing "unnamed" project
+    PersistencyService::GetInstance()->PurgeUnnamedProject();
+
     // now reboot!
     watchdog_reboot(0, 0, 0);
   }
@@ -249,12 +252,6 @@ void ProjectView::Update(Observable &, I_ObservableData *data) {
       char projName[MAX_PROJECT_NAME_LENGTH];
       project_->GetProjectName(projName);
 
-      if (strcmp(projName, UNNAMED_PROJECT_NAME) == 0) {
-        MessageBox *mb =
-            new MessageBox(*this, "Please name the project first", MBBF_OK);
-        DoModal(mb);
-        return;
-      }
       if (saveAsFlag_) {
         // first need to check if project with this name already exists
         if (persist->Exists(projName)) {

--- a/sources/System/FileSystem/PicoFileSystem.cpp
+++ b/sources/System/FileSystem/PicoFileSystem.cpp
@@ -89,8 +89,8 @@ PicoFileType PicoFileSystem::getFileType(int index) {
   return isDir ? PFT_DIR : PFT_FILE;
 }
 
-void PicoFileSystem::list(etl::vector<int, MAX_FILE_INDEX_SIZE> *fileIndexes,
-                          const char *filter, bool subDirOnly) {
+void PicoFileSystem::list(etl::ivector<int> *fileIndexes, const char *filter,
+                          bool subDirOnly) {
   std::lock_guard<Mutex> lock(mutex);
 
   fileIndexes->clear();
@@ -112,10 +112,10 @@ void PicoFileSystem::list(etl::vector<int, MAX_FILE_INDEX_SIZE> *fileIndexes,
   }
 
   File entry;
-  int count = 0;
+  uint16_t count = 0;
 
   // ref: https://github.com/greiman/SdFat/issues/353#issuecomment-1003422848
-  while (entry.openNext(&cwd, O_READ) && (count < PFILENAME_SIZE)) {
+  while (entry.openNext(&cwd, O_READ) && (count < fileIndexes->capacity())) {
     uint32_t index = entry.dirIndex();
     entry.getName(buffer, PFILENAME_SIZE);
 

--- a/sources/System/FileSystem/PicoFileSystem.cpp
+++ b/sources/System/FileSystem/PicoFileSystem.cpp
@@ -194,6 +194,11 @@ bool PicoFileSystem::DeleteFile(const char *path) {
   return sd.remove(path);
 }
 
+bool PicoFileSystem::DeleteDir(const char *path) {
+  std::lock_guard<Mutex> lock(mutex);
+  return sd.rmdir(path);
+}
+
 bool PicoFileSystem::exists(const char *path) {
   std::lock_guard<Mutex> lock(mutex);
   return sd.exists(path);

--- a/sources/System/FileSystem/PicoFileSystem.h
+++ b/sources/System/FileSystem/PicoFileSystem.h
@@ -38,8 +38,8 @@ public:
   PI_File *Open(const char *name, const char *mode);
   bool chdir(const char *path);
   bool read(int index, void *data);
-  void list(etl::vector<int, MAX_FILE_INDEX_SIZE> *fileIndexes,
-            const char *filter, bool subDirOnly);
+  void list(etl::ivector<int> *fileIndexes, const char *filter,
+            bool subDirOnly);
   void getFileName(int index, char *name, int length);
   PicoFileType getFileType(int index);
   bool isParentRoot();

--- a/sources/System/FileSystem/PicoFileSystem.h
+++ b/sources/System/FileSystem/PicoFileSystem.h
@@ -11,6 +11,7 @@
 
 #define MAX_FILE_INDEX_SIZE 256
 #define PFILENAME_SIZE 128
+#define MAX_PROJECT_SAMPLE_PATH_LENGTH 146 // 17 + 128 + 1
 
 enum PicoFileType { PFT_UNKNOWN, PFT_FILE, PFT_DIR };
 
@@ -43,6 +44,7 @@ public:
   PicoFileType getFileType(int index);
   bool isParentRoot();
   bool DeleteFile(const char *name);
+  bool DeleteDir(const char *name);
   bool exists(const char *path);
   bool makeDir(const char *path);
   uint64_t getFileSize(int index);


### PR DESCRIPTION
When the user chooses "New" on the project screen, this will clear the project data and samples if a previous "unnamed" project had been saved with any data or samples.

This also means that the previous restriction on not allowing saving a unnamed project has been removed. 

Fixes: #308