### PR TITLE
Hacky workaround for timing issue with interrupts

### DIFF
--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -128,6 +128,7 @@ char **SamplePool::GetNameList() { return names_; };
 int SamplePool::GetNameListSize() { return count_; };
 
 bool SamplePool::loadSample(const char *name) {
+  Trace::Log("SAMPLEPOOL", "Loading sample into flash: %s", name);
 
   if (count_ == MAX_PIG_SAMPLES)
     return false;

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -317,12 +317,12 @@ bool __not_in_flash_func(WavFile::LoadInFlash)(int &flashEraseOffset,
   // this time
   int irqs = save_and_disable_interrupts();
 
-// TODO: Need to remove this hacky delay workaround and properly fix underlying
-// issue with disabling interrupts needed to import samples into Flash !!
+  // TODO: Need to remove this hacky delay workaround and properly fix
+  // underlying issue with disabling interrupts needed to import samples into
+  // Flash !!
 
-// This is required due to strange issue with above interrupts disable causing a
-// crash without this delay but only in deoptimised debug builds
-#ifdef PICO_DEOPTIMIZED_DEBUG
+  // This is required due to strange issue with above interrupts disable causing
+  // a crash without this delay but only in deoptimised debug builds
   for (int i = 0; i < 100000; i++) {
     if (i % 10000 == 0) {
       Trace::Log("WAVFILE", ".");

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -317,12 +317,15 @@ bool __not_in_flash_func(WavFile::LoadInFlash)(int &flashEraseOffset,
   // this time
   int irqs = save_and_disable_interrupts();
 
-// this is required due to strange issue with above interrupts disable causing a
-// crash without this delay but only in deoptimised debug builds
-#ifdef PICO_DEOPTIMIZED_DEBUG
+  // this is required due to strange issue with above interrupts disable causing
+  // a crash without this delay
+  // Don't be tempted to replace this with a sleep because it doesn't work with
+  // no interrupts enabled!!
   for (int i = 0; i < 100000; i++) {
+    if (i % 10000 == 0) {
+      Trace::Log("WAVFILE", ".");
+    }
   }
-#endif
 
   // If data doesn't fit in previously erased page, we'll have to erase
   // additional ones


### PR DESCRIPTION
*sigh* need this to work around issue after disabling interrupts when importing samples into flash.

Fixes: #325