### PR TITLE
Check for instrument type change before releasing current instrument

### DIFF
--- a/sources/Application/Instruments/I_Instrument.h
+++ b/sources/Application/Instruments/I_Instrument.h
@@ -9,10 +9,11 @@
 
 #include "Application/Player/TablePlayback.h"
 
+const u_char INSTRUMENT_TYPES_COUNT = 5;
+
 enum InstrumentType { IT_NONE, IT_SAMPLE, IT_MIDI, IT_SID, IT_OPAL, IT_MACRO };
-static const char *InstrumentTypeNames[] = {
-    "NONE", "SAMPLE", "MIDI", "SID", "OPAL", "MACRO",
-};
+static const char *InstrumentTypeNames[INSTRUMENT_TYPES_COUNT] = {
+    "NONE", "SAMPLE", "MIDI", "SID", "OPAL"};
 
 class I_Instrument : public VariableContainer, public Observable {
 public:


### PR DESCRIPTION
Need to check if the instrument type actually changed due to UI event (key combo) trying to trigger an instrument type change before we actually try to release the current instrument object.

Also quick clean up to remove macro instrument type from enum list to prevent future confusion on it not yet being shipped.

Fixes: #328