### PR TITLE
memory corruption due to vector not being cleared before use fixes #354

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -113,6 +113,7 @@ void InstrumentView::refreshInstrumentFields(const I_Instrument *old) {
   staticField_.clear();
   bigHexVarField_.clear();
   intVarOffField_.clear();
+  bitmaskVarField_.clear();
 
   // first put back the type field as its shown on *all* instrument types
   fieldList_.insert(fieldList_.end(), &(*typeIntVarField_.rbegin()));


### PR DESCRIPTION
This is a problem, we need to check the ETL library for strict bounds, which I thought we had