### PR TITLE
enable ETL debug asserts for debug builds

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -43,6 +43,11 @@ message(USE_LCD="${USE_LCD}")
 add_compile_definitions(${USE_LCD})
 # add_compile_definitions(LCD_ST7789)
 
+# Enable ETL debug mode only for Debug builds
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(ETL_DEBUG)
+endif()
+
 # Initialize the SDK
 pico_sdk_init()
 


### PR DESCRIPTION
This is a follow up to #369 to enable ETL asserts on debug firmware builds.