### PR TITLE
use consistent values for min. max, default tempo

### DIFF
--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -16,7 +16,7 @@
 
 Project::Project(const char *name)
     : Persistent("PROJECT"), VariableContainer(&variables_), song_(),
-      tempoNudge_(0), tempo_(FourCC::VarTempo, 138),
+      tempoNudge_(0), tempo_(FourCC::VarTempo, DEFAULT_TEMPO),
       masterVolume_(FourCC::VarMasterVolume, 100),
       wrap_(FourCC::VarWrap, false), transpose_(FourCC::VarTranspose, 0),
       scale_(FourCC::VarScale, scaleNames, numScales, 0),
@@ -318,6 +318,8 @@ void Project::OnTempoTap() {
       int tempo =
           int(60000 * (tempoTapCount_ - 1) / (float)(now - lastTap_[0]));
       Variable *v = FindVariable(FourCC::VarTempo);
+      // ensure tempo is within range
+      tempo = std::clamp((unsigned short)tempo, MIN_TEMPO, MAX_TEMPO);
       v->SetInt(tempo);
     } else {
       tempoTapCount_ = 1;

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -16,6 +16,10 @@
 
 #define MAX_TAP 3
 
+const unsigned short MAX_TEMPO = 400;
+const unsigned short MIN_TEMPO = 60;
+const unsigned short DEFAULT_TEMPO = 138;
+
 class Project : public Persistent, public VariableContainer, I_Observer {
 public:
   Project(const char *name);

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -651,15 +651,15 @@ bool Player::ProcessChannelCommand(int channel, FourCC cmd, ushort param) {
       timeToLive_[channel] = timeToLive + 1;
     }
     return true;
-  case FourCC::InstrumentCommandTempo:
-    if ((param < 400) && (param > 40)) {
-      Variable *v = project_->FindVariable(FourCC::VarTempo);
-      v->SetInt(param);
-      SyncMaster *sync = SyncMaster::GetInstance();
-      sync->SetTempo(project_->GetTempo());
-    }
+  case FourCC::InstrumentCommandTempo: {
+    param = std::clamp(param, MIN_TEMPO, MAX_TEMPO);
+    Variable *v = project_->FindVariable(FourCC::VarTempo);
+    v->SetInt(param);
+    SyncMaster *sync = SyncMaster::GetInstance();
+    sync->SetTempo(project_->GetTempo());
     return true;
     break;
+  }
   case FourCC::InstrumentCommandTable: {
     TableHolder *th = TableHolder::GetInstance();
     TablePlayback &tpb = TablePlayback::GetTablePlayback(channel);

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -86,8 +86,9 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   GUIPoint position = GetAnchor();
 
   Variable *v = project_->FindVariable(FourCC::VarTempo);
-  UITempoField *f = new UITempoField(FourCC::ActionTempoChanged, position, *v,
-                                     "tempo: %d [%2.2x]  ", 60, 400, 1, 10);
+  UITempoField *f =
+      new UITempoField(FourCC::ActionTempoChanged, position, *v,
+                       "tempo: %d [%2.2x]  ", MIN_TEMPO, MAX_TEMPO, 1, 10);
   fieldList_.insert(fieldList_.end(), f);
   f->AddObserver(*this);
   tempoField_ = f;

--- a/usermanual/content/pages/commands.md
+++ b/usermanual/content/pages/commands.md
@@ -162,7 +162,8 @@ RTG 0101: does not do anything because after looping one tick, you move forward 
 **sets the tempo to hex value –bb.**
 
 - TPO 0000 is safe and doesn't effect the tempo at all.
-- TPO 003C (60bpm) is the lowest acceptable value and TPO 0190 (400bpm) is the highest acceptable value
+- TPO 003C (60bpm) is the lowest acceptable value and TPO 0190 (400bpm) is the highest acceptable value.
+  Values outside the allowable range will be clamped to the nearest value within the range.
 
 ## VEL --bb
 


### PR DESCRIPTION
Also constrain out of range values to be within max-min tempo range.

Fixes: #391