### PR TITLE
Preserve ID when non-consecutive instrument slots

### DIFF
--- a/sources/Application/Instruments/InstrumentBank.cpp
+++ b/sources/Application/Instruments/InstrumentBank.cpp
@@ -41,8 +41,9 @@ void InstrumentBank::SaveContent(tinyxml2::XMLPrinter *printer) {
   char hex[3];
   int i = 0;
   for (auto &instr : instruments_) {
-    hex2char(i++, hex);
+    i++;
     if (!instr->IsEmpty()) {
+      hex2char(i, hex);
       printer->OpenElement("INSTRUMENT");
       printer->PushAttribute("ID", hex);
       printer->PushAttribute("TYPE", InstrumentTypeNames[instr->GetType()]);

--- a/sources/Application/Instruments/InstrumentBank.cpp
+++ b/sources/Application/Instruments/InstrumentBank.cpp
@@ -41,9 +41,9 @@ void InstrumentBank::SaveContent(tinyxml2::XMLPrinter *printer) {
   char hex[3];
   int i = 0;
   for (auto &instr : instruments_) {
+    hex2char(i++, hex);
     if (!instr->IsEmpty()) {
       printer->OpenElement("INSTRUMENT");
-      hex2char(i++, hex);
       printer->PushAttribute("ID", hex);
       printer->PushAttribute("TYPE", InstrumentTypeNames[instr->GetType()]);
 


### PR DESCRIPTION
The problem here was that the loop counter was only being incremented for "non empty" instrument slots so if you had non consecutive  non-empty instruments, their correct index into the instruments array (aka their "ID") would be incorrectly saved into the project data file.

Fixes: #368