### PR TITLE
Fix phrase out of range

### DIFF
--- a/sources/Application/Views/ViewData.cpp
+++ b/sources/Application/Views/ViewData.cpp
@@ -79,7 +79,7 @@ unsigned char ViewData::UpdateChainCursorValue(int offset, int dx, int dy) {
   switch (chainCol_ + dx) {
   case 0:
     c = song_->chain_.data_ + (16 * currentChain_ + chainRow_ + dy);
-    limit = CHAIN_COUNT - 1;
+    limit = PHRASE_COUNT - 1;
     wrap = false;
     break;
   case 1:

--- a/usermanual/content/pages/introduction.md
+++ b/usermanual/content/pages/introduction.md
@@ -15,7 +15,7 @@ Trackers later evolved to also run on devices such as the Gameboy as popularised
 The picoTracker features include:
 
 * 8 song channels
-* 128 chains
+* 256 chains
 * 128 phrases
 * 32 tables
 * 16 Sample instruments


### PR DESCRIPTION
Fixes to use the correct constant for limiting the phrase count when incrementing on the chain screen.

Also sneaks in update to user manual to reflect the new limit on number of chains supported in v2.

Fixes: #329