### PR TITLE
Crash when project name too long

### DIFF
--- a/sources/Application/Views/BaseClasses/UITextField.cpp
+++ b/sources/Application/Views/BaseClasses/UITextField.cpp
@@ -45,7 +45,7 @@ void UITextField::OnClick() {
 };
 
 void UITextField::OnEditClick() {
-  char name[40];
+  char name[MAX_PROJECT_NAME_LENGTH + 1];
   strcpy(name, src_->GetString().c_str());
   uint8_t len = std::strlen(name);
   deleteChar(name, currentChar_);
@@ -57,7 +57,7 @@ void UITextField::OnEditClick() {
 };
 
 void UITextField::ProcessArrow(unsigned short mask) {
-  char name[40];
+  char name[MAX_PROJECT_NAME_LENGTH + 1];
   strcpy(name, src_->GetString().c_str());
   int len = std::strlen(name);
 
@@ -92,7 +92,7 @@ void UITextField::ProcessArrow(unsigned short mask) {
   case EPBM_RIGHT:
     if (currentChar_ < len - 1) {
       currentChar_++;
-    } else if (currentChar_ < 39) {
+    } else if (currentChar_ < MAX_PROJECT_NAME_LENGTH - 1) {
       currentChar_++;
       name[currentChar_] = 'A';
       name[currentChar_ + 1] = '\0';
@@ -105,7 +105,9 @@ void UITextField::ProcessArrow(unsigned short mask) {
   };
 };
 
-etl::string<40> UITextField::GetString() { return src_->GetString(); };
+etl::string<MAX_PROJECT_NAME_LENGTH> UITextField::GetString() {
+  return src_->GetString();
+};
 
 char getNext(char c, bool reverse) {
   // Valid characters in order

--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -14,7 +14,7 @@ public:
   void ProcessArrow(unsigned short mask);
   void OnClick();
   void OnEditClick();
-  etl::string<40> GetString();
+  etl::string<MAX_PROJECT_NAME_LENGTH> GetString();
 
 private:
   int selected_;

--- a/usermanual/content/pages/projects.md
+++ b/usermanual/content/pages/projects.md
@@ -30,7 +30,7 @@ You can ***explicitly*** save the current project by pressing [SAVE] on the proj
 - **New** *REPLACE* the current project with a new, *Blank* project.  
 - **Random** *RENAME* the current project with a new, *Randomly generated* name.  
 
-The project name is **limited to 12 characters**. 
+The project name is **limited to 16 characters**. 
 
 You edit to project name by moving onto the name field and then holding the `ENTER` key while using the `UP` and `DOWN` keys to change the selected character and `LEFT` and `RIGHT` keys to move the cursor to the left or right of the current character. When on the last character, you can add chararacter to the end of the project name by using the `RIGHT` key.
 To delete a character, select the character and press `EDIT`. 

--- a/usermanual/content/pages/projects.md
+++ b/usermanual/content/pages/projects.md
@@ -33,3 +33,4 @@ You can ***explicitly*** save the current project by pressing [SAVE] on the proj
 The project name is **limited to 12 characters**. 
 
 You edit to project name by moving onto the name field and then holding the `ENTER` key while using the `UP` and `DOWN` keys to change the selected character and `LEFT` and `RIGHT` keys to move the cursor to the left or right of the current character. When on the last character, you can add chararacter to the end of the project name by using the `RIGHT` key.
+To delete a character, select the character and press `EDIT`. 


### PR DESCRIPTION
The UITextField was not using the correct max length constant value for project names, allowing users to enter far too long names and crash.

Also updated the user manual to reflect that the project max length actually used in the code (16) and added documentation on the key for deleting chars in project name.

Fixes: #400