### PR TITLE
Generic UITextfield

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -7,6 +7,7 @@
 #include "Application/Player/TablePlayback.h"
 #include "Application/Utils/char.h"
 #include "Application/Views/ModalDialogs/MessageBox.h"
+#include "Application/Views/ProjectView.h"
 #include "Foundation/Variables/WatchedVariable.h"
 #include "Player/Player.h"
 #include "Services/Midi/MidiService.h"

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -10,7 +10,6 @@
 #include "Application/Views/InstrumentView.h"
 #include "Application/Views/NullView.h"
 #include "Application/Views/PhraseView.h"
-#include "Application/Views/ProjectView.h"
 #include "Application/Views/SelectProjectView.h"
 #include "Application/Views/SongView.h"
 #include "Application/Views/TableView.h"
@@ -30,6 +29,12 @@
 #define BATTERY_GAUGE_WIDTH 5
 #define SCREEN_CHARS SCREEN_WIDTH *SCREEN_HEIGHT
 #define MAX_FIELD_WIDTH 26
+
+// need this forward declaration to break out of circular dependency as
+// ProjectView uses a UITextfield which in turn had dependency on AppWindow
+// and UITextField is templated which means its class/method definitions need to
+// be in its header file  :-(
+class ProjectView;
 
 class AppWindow : public GUIWindow, I_Observer, Status {
 protected:

--- a/sources/Application/Views/BaseClasses/CMakeLists.txt
+++ b/sources/Application/Views/BaseClasses/CMakeLists.txt
@@ -11,11 +11,12 @@ add_library(application_views_baseclasses
   UISortedVarList.h UISortedVarList.cpp
   UIStaticField.h UIStaticField.cpp
   UITempoField.h UITempoField.cpp
-  UITextField.h UITextField.cpp
+  UITextField.h
   UISwatchField.h UISwatchField.cpp
   UIBitmaskVarField.h UIBitmaskVarField.cpp
   View.h View.cpp
   ViewEvent.h ViewEvent.cpp
+  stringutils.h stringutils.cpp 
 )
 
 target_link_libraries(application_views_baseclasses PUBLIC pico_stdlib

--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -3,27 +3,30 @@
 
 #include "Foundation/Observable.h"
 #include "UIField.h"
+#include "stdint.h"
 
+template <uint8_t MaxLength>
 class UITextField : public UIField, public Observable {
 public:
-  UITextField(Variable *v, GUIPoint &position, const char *name,
-              unsigned int fourcc);
+  UITextField(Variable *v, GUIPoint &position, const char *name, uint8_t fourcc,
+              const char *defaultValue_);
 
   virtual ~UITextField();
   void Draw(GUIWindow &w, int offset = 0);
   void ProcessArrow(unsigned short mask);
   void OnClick();
   void OnEditClick();
-  etl::string<MAX_PROJECT_NAME_LENGTH> GetString();
+  etl::string<MaxLength> GetString();
 
 private:
   int selected_;
   int currentChar_ = 0;
   Variable *src_;
   const char *name_;
-  unsigned int fourcc_;
+  uint8_t fourcc_;
+  const char *defaultValue_;
 };
 
-char getNext(char c, bool reverse);
-void deleteChar(char *name, uint8_t pos);
+#include "UITextField.ipp"
+
 #endif

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -1,17 +1,18 @@
-#include "UITextField.h"
 #include "Application/AppWindow.h"
 #include "View.h"
+#include "stringutils.h"
 
-UITextField::UITextField(Variable *v, GUIPoint &position, const char *name,
-                         unsigned int fourcc)
-    : UIField(position), src_(v) {
-  name_ = name;
-  fourcc_ = fourcc;
-};
+template <uint8_t MaxLength>
+UITextField<MaxLength>::UITextField(Variable *v, GUIPoint &position,
+                                    const char *name, uint8_t fourcc,
+                                    const char *defaultValue_)
+    : UIField(position), src_(v), name_(name), fourcc_(fourcc),
+      defaultValue_(defaultValue_) {}
 
-UITextField::~UITextField(){};
+template <uint8_t MaxLength> UITextField<MaxLength>::~UITextField(){};
 
-void UITextField::Draw(GUIWindow &w, int offset) {
+template <uint8_t MaxLength>
+void UITextField<MaxLength>::Draw(GUIWindow &w, int offset) {
 
   GUITextProperties props;
   GUIPoint position = GetPosition();
@@ -38,13 +39,13 @@ void UITextField::Draw(GUIWindow &w, int offset) {
   }
 };
 
-void UITextField::OnClick() {
+template <uint8_t MaxLength> void UITextField<MaxLength>::OnClick() {
   currentChar_ = 0;
   SetChanged();
   NotifyObservers((I_ObservableData *)fourcc_);
 };
 
-void UITextField::OnEditClick() {
+template <uint8_t MaxLength> void UITextField<MaxLength>::OnEditClick() {
   char name[MAX_PROJECT_NAME_LENGTH + 1];
   strcpy(name, src_->GetString().c_str());
   uint8_t len = std::strlen(name);
@@ -56,14 +57,15 @@ void UITextField::OnEditClick() {
   NotifyObservers((I_ObservableData *)fourcc_);
 };
 
-void UITextField::ProcessArrow(unsigned short mask) {
-  char name[MAX_PROJECT_NAME_LENGTH + 1];
+template <uint8_t MaxLength>
+void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
+  char name[MaxLength + 1];
   strcpy(name, src_->GetString().c_str());
   int len = std::strlen(name);
 
   switch (mask) {
   case EPBM_UP:
-    if (!strcmp(name, UNNAMED_PROJECT_NAME)) {
+    if (!strcmp(name, defaultValue_)) {
       currentChar_ = 0;
       name[0] = 'A' - 1; // to land in A
       name[1] = '\0';
@@ -74,7 +76,7 @@ void UITextField::ProcessArrow(unsigned short mask) {
     NotifyObservers((I_ObservableData *)fourcc_);
     break;
   case EPBM_DOWN:
-    if (!strcmp(name, UNNAMED_PROJECT_NAME)) {
+    if (!strcmp(name, defaultValue_)) {
       currentChar_ = 0;
       name[0] = 'A' + 1; // to land in A
       name[1] = '\0';
@@ -105,43 +107,7 @@ void UITextField::ProcessArrow(unsigned short mask) {
   };
 };
 
-etl::string<MAX_PROJECT_NAME_LENGTH> UITextField::GetString() {
+template <uint8_t MaxLength>
+etl::string<MaxLength> UITextField<MaxLength>::GetString() {
   return src_->GetString();
 };
-
-char getNext(char c, bool reverse) {
-  // Valid characters in order
-  const char validChars[] =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._";
-  const int numChars = sizeof(validChars) - 1; // Exclude null terminator
-
-  // Find the index of the current character
-  for (int i = 0; i < numChars; ++i) {
-    if (validChars[i] == c) {
-      // Calculate next index based on direction (forward or reverse)
-      int nextIndex =
-          reverse ? (i - 1 + numChars) % numChars : (i + 1) % numChars;
-      return validChars[nextIndex];
-    }
-  }
-
-  // If character is not valid, return the first valid character in the list
-  return reverse ? validChars[numChars - 1] : validChars[0];
-};
-
-void deleteChar(char *name, uint8_t pos) {
-  int len = std::strlen(name);
-
-  // If length is 1 or position is invalid, do nothing
-  if (len <= 1 || pos < 0 || pos >= len) {
-    return;
-  }
-
-  // Shift characters left starting from the position
-  for (int i = pos; i < len - 1; ++i) {
-    name[i] = name[i + 1];
-  }
-
-  // Null-terminate the string at the new end
-  name[len - 1] = '\0';
-}

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -46,7 +46,7 @@ template <uint8_t MaxLength> void UITextField<MaxLength>::OnClick() {
 };
 
 template <uint8_t MaxLength> void UITextField<MaxLength>::OnEditClick() {
-  char name[MAX_PROJECT_NAME_LENGTH + 1];
+  char name[MaxLength + 1];
   strcpy(name, src_->GetString().c_str());
   uint8_t len = std::strlen(name);
   deleteChar(name, currentChar_);
@@ -94,7 +94,7 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
   case EPBM_RIGHT:
     if (currentChar_ < len - 1) {
       currentChar_++;
-    } else if (currentChar_ < MAX_PROJECT_NAME_LENGTH - 1) {
+    } else if (currentChar_ < MaxLength - 1) {
       currentChar_++;
       name[currentChar_] = 'A';
       name[currentChar_ + 1] = '\0';

--- a/sources/Application/Views/BaseClasses/stringutils.cpp
+++ b/sources/Application/Views/BaseClasses/stringutils.cpp
@@ -1,0 +1,39 @@
+#include <cstring>
+#include <stdint.h>
+
+char getNext(char c, bool reverse) {
+  // Valid characters in order
+  const char validChars[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._";
+  const int numChars = sizeof(validChars) - 1; // Exclude null terminator
+
+  // Find the index of the current character
+  for (int i = 0; i < numChars; ++i) {
+    if (validChars[i] == c) {
+      // Calculate next index based on direction (forward or reverse)
+      int nextIndex =
+          reverse ? (i - 1 + numChars) % numChars : (i + 1) % numChars;
+      return validChars[nextIndex];
+    }
+  }
+
+  // If character is not valid, return the first valid character in the list
+  return reverse ? validChars[numChars - 1] : validChars[0];
+};
+
+void deleteChar(char *name, uint8_t pos) {
+  int len = std::strlen(name);
+
+  // If length is 1 or position is invalid, do nothing
+  if (len <= 1 || pos < 0 || pos >= len) {
+    return;
+  }
+
+  // Shift characters left starting from the position
+  for (int i = pos; i < len - 1; ++i) {
+    name[i] = name[i + 1];
+  }
+
+  // Null-terminate the string at the new end
+  name[len - 1] = '\0';
+}

--- a/sources/Application/Views/BaseClasses/stringutils.h
+++ b/sources/Application/Views/BaseClasses/stringutils.h
@@ -1,0 +1,2 @@
+char getNext(char c, bool reverse);
+void deleteChar(char *name, uint8_t pos);

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -14,7 +14,6 @@
 #include "hardware/watchdog.h"
 #include "pico/bootrom.h"
 #endif
-#include <Application/AppWindow.h>
 #include <nanoprintf.h>
 
 static void LoadCallback(View &v, ModalView &dialog) {
@@ -127,8 +126,9 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   int xalign = position._x;
 
   v = project_->FindVariable(FourCC::VarProjectName);
-  nameField_ =
-      new UITextField(v, position, "project: ", FourCC::ActionProjectRename);
+  nameField_ = new UITextField<MAX_PROJECT_NAME_LENGTH>(
+      v, position, "project: ", FourCC::ActionProjectRename,
+      UNNAMED_PROJECT_NAME);
   nameField_->AddObserver(*this);
   fieldList_.insert(fieldList_.end(), nameField_);
 

--- a/sources/Application/Views/ProjectView.h
+++ b/sources/Application/Views/ProjectView.h
@@ -5,6 +5,9 @@
 #include "FieldView.h"
 #include "Foundation/Observable.h"
 #include "ViewData.h"
+#include <stdint.h>
+
+template <uint8_t MaxLength> class UITextField;
 
 class ProjectView : public FieldView, public I_Observer {
 public:
@@ -19,6 +22,7 @@ public:
   etl::string<MAX_PROJECT_NAME_LENGTH> getProjectName() {
     return nameField_->GetString();
   };
+
   etl::string<MAX_PROJECT_NAME_LENGTH> getOldProjectName() {
     return oldProjName_;
   };
@@ -40,7 +44,7 @@ private:
   unsigned long lastTick_;
   unsigned long lastClock_;
   UIField *tempoField_;
-  UITextField *nameField_;
+  UITextField<MAX_PROJECT_NAME_LENGTH> *nameField_;
   bool saveAsFlag_ = false;
   etl::string<MAX_PROJECT_NAME_LENGTH> oldProjName_;
 };

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -207,8 +207,8 @@ void Variable::SetString(const char *string, bool notify) {
   }
 };
 
-etl::string<40> Variable::GetString() {
-  char buf[40];
+etl::string<MAX_VARIABLE_STRING_LENGTH> Variable::GetString() {
+  char buf[MAX_VARIABLE_STRING_LENGTH];
   switch (type_) {
   // !!! NOTE !!! we don't want to enable nanoprintf's float support so we just
   // cast to int here because we don't really display floats anyway

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -7,6 +7,8 @@
 #define VAR_OFF -1
 #include <string>
 
+static const int MAX_VARIABLE_STRING_LENGTH = 40;
+
 class Variable {
 
 public:


### PR DESCRIPTION
This removes the implicit hardcoded use of UITextField for only project name, allowing it to be used in the future anywhere a textfield widget is required.

The wrinkle here why this ended up being such a big change is that this required making UITextfield a templated class by templated value (`MaxLength`) based on the max field size to match with how the ETL string class that this used by this class works.

Fixes: #403