### PR TITLE
Named midi instruments

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -17,6 +17,19 @@
 #include <nanoprintf.h>
 #include <string.h>
 
+#include "Application/Views/ChainView.h"
+#include "Application/Views/ConsoleView.h"
+#include "Application/Views/DeviceView.h"
+#include "Application/Views/GrooveView.h"
+#include "Application/Views/ImportView.h"
+#include "Application/Views/InstrumentView.h"
+#include "Application/Views/NullView.h"
+#include "Application/Views/PhraseView.h"
+#include "Application/Views/SelectProjectView.h"
+#include "Application/Views/SongView.h"
+#include "Application/Views/TableView.h"
+#include "BaseClasses/View.h"
+
 const uint16_t AUTOSAVE_INTERVAL_IN_SECONDS = 1 * 60;
 
 AppWindow *instance = 0;

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -2,17 +2,7 @@
 #ifndef _APP_WINDOW_H_
 #define _APP_WINDOW_H_
 
-#include "Application/Views/ChainView.h"
-#include "Application/Views/ConsoleView.h"
-#include "Application/Views/DeviceView.h"
-#include "Application/Views/GrooveView.h"
-#include "Application/Views/ImportView.h"
-#include "Application/Views/InstrumentView.h"
-#include "Application/Views/NullView.h"
-#include "Application/Views/PhraseView.h"
-#include "Application/Views/SelectProjectView.h"
-#include "Application/Views/SongView.h"
-#include "Application/Views/TableView.h"
+#include "Application/Views/BaseClasses/View.h"
 #include "Application/Views/ViewData.h"
 #include "Foundation/Observable.h"
 #include "System/Process/SysMutex.h"
@@ -35,6 +25,19 @@
 // and UITextField is templated which means its class/method definitions need to
 // be in its header file  :-(
 class ProjectView;
+class ChainView;
+class ConsoleView;
+class DeviceView;
+class GrooveView;
+class ImportView;
+class InstrumentView;
+class NullView;
+class PhraseView;
+class SelectProjectView;
+class SongView;
+class TableView;
+class ScreenView;
+class View;
 
 class AppWindow : public GUIWindow, I_Observer, Status {
 protected:

--- a/sources/Application/Instruments/CMakeLists.txt
+++ b/sources/Application/Instruments/CMakeLists.txt
@@ -33,6 +33,8 @@ target_link_libraries(application_instruments PUBLIC foundation_services
                                               PUBLIC sdfat
                                               PUBLIC platform_sdcard
                                               PUBLIC services_time
+                                              PUBLIC etl
+                                              PUBLIC application_utils
 )
 
 target_include_directories(application_instruments PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sources/Application/Instruments/InstrumentBank.cpp
+++ b/sources/Application/Instruments/InstrumentBank.cpp
@@ -128,6 +128,7 @@ void InstrumentBank::RestoreContent(PersistencyDocument *doc) {
           auto vars = instr->Variables();
           for (auto elem : *vars) {
             if (!strcasecmp((elem)->GetName(), name)) {
+              Trace::Debug("Restore SetString %s->%s", name, value);
               (elem)->SetString(value);
             };
           }

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -4,6 +4,7 @@
 #include "CommandList.h"
 #include "Externals/etl/include/etl/to_string.h"
 #include "System/Console/Trace.h"
+#include "stringutils.h"
 #include <string.h>
 
 MidiService *MidiInstrument::svc_ = 0;
@@ -14,7 +15,7 @@ MidiInstrument::MidiInstrument()
       volume_(FourCC::MidiInstrumentVolume, 255),
       table_(FourCC::MidiInstrumentTable, -1),
       tableAuto_(FourCC::MidiInstrumentTableAutomation, false),
-      name_(FourCC::MidiInstrumentName, "") {
+      name_(FourCC::MidiInstrumentName, DEFAULT_EMPTY_VALUE) {
 
   if (svc_ == 0) {
     svc_ = MidiService::GetInstance();
@@ -225,7 +226,7 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
 etl::string<24> MidiInstrument::GetName() {
   Variable *v = FindVariable(FourCC::MidiInstrumentName);
   if (v->GetString().length() > 0) {
-    return v->GetString();
+    return v->GetString().substr(0, 24);
   }
   v = FindVariable(FourCC::MidiInstrumentChannel);
   etl::string<24> name = "MIDI CH ";

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -13,7 +13,8 @@ MidiInstrument::MidiInstrument()
       noteLen_(FourCC::MidiInstrumentNoteLength, 0),
       volume_(FourCC::MidiInstrumentVolume, 255),
       table_(FourCC::MidiInstrumentTable, -1),
-      tableAuto_(FourCC::MidiInstrumentTableAutomation, false) {
+      tableAuto_(FourCC::MidiInstrumentTableAutomation, false),
+      name_(FourCC::MidiInstrumentName, "") {
 
   if (svc_ == 0) {
     svc_ = MidiService::GetInstance();
@@ -24,6 +25,7 @@ MidiInstrument::MidiInstrument()
   variables_.insert(variables_.end(), &volume_);
   variables_.insert(variables_.end(), &table_);
   variables_.insert(variables_.end(), &tableAuto_);
+  variables_.insert(variables_.end(), &name_);
 }
 
 MidiInstrument::~MidiInstrument(){};
@@ -221,7 +223,11 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
 }
 
 etl::string<24> MidiInstrument::GetName() {
-  Variable *v = FindVariable(FourCC::MidiInstrumentChannel);
+  Variable *v = FindVariable(FourCC::MidiInstrumentName);
+  if (v->GetString().length() > 0) {
+    return v->GetString();
+  }
+  v = FindVariable(FourCC::MidiInstrumentChannel);
   etl::string<24> name = "MIDI CH ";
   etl::to_string(v->GetInt() + 1, name, etl::format_spec().precision(0), true);
   return name;

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -2,6 +2,7 @@
 #define _MIDI_INSTRUMENT_H_
 
 #include "Application/Model/Song.h"
+#include "Externals/etl/include/etl/string.h"
 #include "I_Instrument.h"
 #include "Services/Midi/MidiService.h"
 
@@ -11,6 +12,8 @@
 #define MIDI_PRG 0xC0
 
 #define MAX_MIDI_CHORD_NOTES 4
+
+const int MAX_MIDI_INSTRUMENT_NAME_LENGTH = 12;
 
 class MidiInstrument : public I_Instrument {
 
@@ -51,7 +54,7 @@ public:
   void SetChannel(int i);
 
 private:
-  etl::list<Variable *, 5> variables_;
+  etl::list<Variable *, 6> variables_;
 
   etl::array<uint8_t, MAX_MIDI_CHORD_NOTES + 1> lastNotes_[SONG_CHANNEL_COUNT];
   int remainingTicks_;
@@ -67,6 +70,7 @@ private:
   Variable volume_;
   Variable table_;
   Variable tableAuto_;
+  Variable name_;
 
   static MidiService *svc_;
 };

--- a/sources/Application/Utils/CMakeLists.txt
+++ b/sources/Application/Utils/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(application_utils
   char.h char.cpp
   fixed.h fixed.cpp
   randomnames.h
+  stringutils.h stringutils.cpp 
 )
 
 target_link_libraries(application_utils

--- a/sources/Application/Utils/stringutils.cpp
+++ b/sources/Application/Utils/stringutils.cpp
@@ -20,20 +20,3 @@ char getNext(char c, bool reverse) {
   // If character is not valid, return the first valid character in the list
   return reverse ? validChars[numChars - 1] : validChars[0];
 };
-
-void deleteChar(char *name, uint8_t pos) {
-  int len = std::strlen(name);
-
-  // If length is 1 or position is invalid, do nothing
-  if (len <= 1 || pos < 0 || pos >= len) {
-    return;
-  }
-
-  // Shift characters left starting from the position
-  for (int i = pos; i < len - 1; ++i) {
-    name[i] = name[i + 1];
-  }
-
-  // Null-terminate the string at the new end
-  name[len - 1] = '\0';
-}

--- a/sources/Application/Utils/stringutils.h
+++ b/sources/Application/Utils/stringutils.h
@@ -1,0 +1,3 @@
+#define DEFAULT_EMPTY_VALUE " "
+
+char getNext(char c, bool reverse);

--- a/sources/Application/Views/BaseClasses/CMakeLists.txt
+++ b/sources/Application/Views/BaseClasses/CMakeLists.txt
@@ -16,12 +16,12 @@ add_library(application_views_baseclasses
   UIBitmaskVarField.h UIBitmaskVarField.cpp
   View.h View.cpp
   ViewEvent.h ViewEvent.cpp
-  stringutils.h stringutils.cpp 
 )
 
 target_link_libraries(application_views_baseclasses PUBLIC pico_stdlib
                                           PUBLIC sdfat
                                           PUBLIC platform_sdcard
+                                          PUBLIC application_utils
 )
 
 target_include_directories(application_views_baseclasses PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -23,7 +23,7 @@ public:
 
 private:
   int selected_;
-  int currentChar_ = 0;
+  uint8_t currentChar_ = 0;
   Variable &src_;
   const etl::string<8> label_;
   uint8_t fourcc_;

--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -5,11 +5,14 @@
 #include "UIField.h"
 #include "stdint.h"
 
+#define MAX_LABEL_LENGTH 8
+
 template <uint8_t MaxLength>
 class UITextField : public UIField, public Observable {
 public:
-  UITextField(Variable *v, GUIPoint &position, const char *name, uint8_t fourcc,
-              const char *defaultValue_);
+  UITextField(Variable &v, GUIPoint &position,
+              const etl::string<MAX_LABEL_LENGTH> &label, uint8_t fourcc,
+              etl::string<MaxLength> &defaultValue_);
 
   virtual ~UITextField();
   void Draw(GUIWindow &w, int offset = 0);
@@ -21,10 +24,10 @@ public:
 private:
   int selected_;
   int currentChar_ = 0;
-  Variable *src_;
-  const char *name_;
+  Variable &src_;
+  const etl::string<8> label_;
   uint8_t fourcc_;
-  const char *defaultValue_;
+  etl::string<MaxLength> defaultValue_;
 };
 
 #include "UITextField.ipp"

--- a/sources/Application/Views/BaseClasses/UITextField.h
+++ b/sources/Application/Views/BaseClasses/UITextField.h
@@ -5,14 +5,14 @@
 #include "UIField.h"
 #include "stdint.h"
 
-#define MAX_LABEL_LENGTH 8
+#define MAX_UITEXTFIELD_LABEL_LENGTH 8
 
 template <uint8_t MaxLength>
 class UITextField : public UIField, public Observable {
 public:
   UITextField(Variable &v, GUIPoint &position,
-              const etl::string<MAX_LABEL_LENGTH> &label, uint8_t fourcc,
-              etl::string<MaxLength> &defaultValue_);
+              const etl::string<MAX_UITEXTFIELD_LABEL_LENGTH> &label,
+              uint8_t fourcc, etl::string<MaxLength> &defaultValue_);
 
   virtual ~UITextField();
   void Draw(GUIWindow &w, int offset = 0);

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -26,10 +26,7 @@ void UITextField<MaxLength>::Draw(GUIWindow &w, int offset) {
 
   auto value = src_.GetString().c_str();
   int len = src_.GetString().length();
-  if (len == 0) {
-    value = defaultValue_.c_str();
-    len = defaultValue_.length();
-  }
+
   if (focus_) {
     char buffer[2];
     buffer[1] = 0;
@@ -40,54 +37,57 @@ void UITextField<MaxLength>::Draw(GUIWindow &w, int offset) {
       position._x += 1;
     }
   } else {
-    w.DrawString(value, position, props);
+    if (len != 0) {
+      w.DrawString(value, position, props);
+    }
   }
 };
 
 template <uint8_t MaxLength> void UITextField<MaxLength>::OnClick() {
-  currentChar_ = 0;
   SetChanged();
   NotifyObservers((I_ObservableData *)fourcc_);
 };
 
 template <uint8_t MaxLength> void UITextField<MaxLength>::OnEditClick() {
-  char name[MaxLength + 1];
-  strcpy(name, src_.GetString().c_str());
-  uint8_t len = std::strlen(name);
-  deleteChar(name, currentChar_);
-  if (currentChar_ && (currentChar_ == len - 1))
+  etl::string<MAX_VARIABLE_STRING_LENGTH> buffer(src_.GetString());
+  if (currentChar_ > 0 && currentChar_ < buffer.length()) {
+    buffer.erase(currentChar_, 1);
     currentChar_--;
-  src_.SetString(name, true);
+  }
+  src_.SetString(buffer.c_str(), true);
   SetChanged();
   NotifyObservers((I_ObservableData *)fourcc_);
 };
 
 template <uint8_t MaxLength>
 void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
-  char name[MaxLength + 1];
-  strcpy(name, src_.GetString().c_str());
-  int len = std::strlen(name);
+  auto buffer(src_.GetString());
 
   switch (mask) {
   case EPBM_UP:
-    if (!strcmp(name, defaultValue_.c_str())) {
+    // on a char edit key (up or down), if we are on the default string value,
+    // we want to clear default value and start user off with just first char
+    if (buffer.compare(defaultValue_) == 0) {
       currentChar_ = 0;
-      name[0] = 'A' - 1; // to land in A
-      name[1] = '\0';
+      buffer.clear();
+      buffer.append("A");
+      src_.SetString(buffer.c_str(), true);
+    } else {
+      buffer[currentChar_] = getNext(buffer.c_str()[currentChar_], false);
+      src_.SetString(buffer.c_str(), true);
     }
-    name[currentChar_] = getNext(name[currentChar_], false);
-    src_.SetString(name, true);
     SetChanged();
     NotifyObservers((I_ObservableData *)fourcc_);
     break;
   case EPBM_DOWN:
-    if (!strcmp(name, defaultValue_.c_str())) {
+    if (buffer.compare(defaultValue_) == 0) {
       currentChar_ = 0;
-      name[0] = 'A' + 1; // to land in A
-      name[1] = '\0';
+      buffer.clear();
+      buffer.append("A");
+      src_.SetString(buffer.c_str(), true);
     }
-    name[currentChar_] = getNext(name[currentChar_], true);
-    src_.SetString(name, true);
+    buffer[currentChar_] = getNext((char)buffer.c_str()[currentChar_], true);
+    src_.SetString(buffer.c_str(), true);
     SetChanged();
     NotifyObservers((I_ObservableData *)fourcc_);
     break;
@@ -97,14 +97,13 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
     }
     break;
   case EPBM_RIGHT:
-    if (currentChar_ < len - 1) {
+    if (currentChar_ < (buffer.length() - 1)) {
       currentChar_++;
-    } else if (currentChar_ < MaxLength - 1) {
+      // -1 to allow for adding 1 more char
+    } else if (currentChar_ < (MaxLength - 1)) {
       currentChar_++;
-      name[currentChar_] = 'A';
-      name[currentChar_ + 1] = '\0';
-      len++;
-      src_.SetString(name, true);
+      buffer.append("A");
+      src_.SetString(buffer.c_str(), true);
       SetChanged();
       NotifyObservers((I_ObservableData *)fourcc_);
     }
@@ -114,5 +113,5 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
 
 template <uint8_t MaxLength>
 etl::string<MaxLength> UITextField<MaxLength>::GetString() {
-  return src_.GetString();
+  return src_.GetString().substr(0, MaxLength);
 };

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -3,10 +3,10 @@
 #include "stringutils.h"
 
 template <uint8_t MaxLength>
-UITextField<MaxLength>::UITextField(Variable &v, GUIPoint &position,
-                                    const etl::string<MAX_LABEL_LENGTH> &label,
-                                    uint8_t fourcc,
-                                    etl::string<MaxLength> &defaultValue_)
+UITextField<MaxLength>::UITextField(
+    Variable &v, GUIPoint &position,
+    const etl::string<MAX_UITEXTFIELD_LABEL_LENGTH> &label, uint8_t fourcc,
+    etl::string<MaxLength> &defaultValue_)
     : UIField(position), src_(v), label_(label), fourcc_(fourcc),
       defaultValue_(defaultValue_) {}
 

--- a/sources/Application/Views/BaseClasses/stringutils.h
+++ b/sources/Application/Views/BaseClasses/stringutils.h
@@ -1,2 +1,0 @@
-char getNext(char c, bool reverse);
-void deleteChar(char *name, uint8_t pos);

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -446,7 +446,8 @@ void InstrumentView::fillMidiParameters() {
   GUIPoint position = GetAnchor();
 
   Variable *v = instrument->FindVariable(FourCC::MidiInstrumentName);
-  auto label = etl::make_string_with_capacity<MAX_LABEL_LENGTH>("name: ");
+  auto label =
+      etl::make_string_with_capacity<MAX_UITEXTFIELD_LABEL_LENGTH>("name: ");
   auto defaultName =
       etl::make_string_with_capacity<MAX_MIDI_INSTRUMENT_NAME_LENGTH>(
           DEFAULT_EMPTY_VALUE);

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -449,7 +449,7 @@ void InstrumentView::fillMidiParameters() {
   auto label = etl::make_string_with_capacity<MAX_LABEL_LENGTH>("name: ");
   auto defaultName =
       etl::make_string_with_capacity<MAX_MIDI_INSTRUMENT_NAME_LENGTH>(
-          UNNAMED_PROJECT_NAME);
+          DEFAULT_EMPTY_VALUE);
   uiTextfield_.emplace_back(UITextField<MAX_MIDI_INSTRUMENT_NAME_LENGTH>(
       *v, position, label, FourCC::MidiInstrumentName, defaultName));
   fieldList_.insert(fieldList_.end(), &(*uiTextfield_.rbegin()));

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -114,6 +114,7 @@ void InstrumentView::refreshInstrumentFields(const I_Instrument *old) {
   bigHexVarField_.clear();
   intVarOffField_.clear();
   bitmaskVarField_.clear();
+  uiTextfield_.clear();
 
   // first put back the type field as its shown on *all* instrument types
   fieldList_.insert(fieldList_.end(), &(*typeIntVarField_.rbegin()));
@@ -444,7 +445,17 @@ void InstrumentView::fillMidiParameters() {
   MidiInstrument *instrument = (MidiInstrument *)instr;
   GUIPoint position = GetAnchor();
 
-  Variable *v = instrument->FindVariable(FourCC::MidiInstrumentChannel);
+  Variable *v = instrument->FindVariable(FourCC::MidiInstrumentName);
+  auto label = etl::make_string_with_capacity<MAX_LABEL_LENGTH>("name: ");
+  auto defaultName =
+      etl::make_string_with_capacity<MAX_MIDI_INSTRUMENT_NAME_LENGTH>(
+          UNNAMED_PROJECT_NAME);
+  uiTextfield_.emplace_back(UITextField<MAX_MIDI_INSTRUMENT_NAME_LENGTH>(
+      *v, position, label, FourCC::MidiInstrumentName, defaultName));
+  fieldList_.insert(fieldList_.end(), &(*uiTextfield_.rbegin()));
+  position._y += 1;
+
+  v = instrument->FindVariable(FourCC::MidiInstrumentChannel);
   intVarField_.emplace_back(
       UIIntVarField(position, *v, "channel: %2.2d", 0, 0x0F, 1, 0x04, 1));
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -7,6 +7,7 @@
 #include "BaseClasses/UIIntVarOffField.h"
 #include "BaseClasses/UINoteVarField.h"
 #include "BaseClasses/UIStaticField.h"
+#include "BaseClasses/UITextField.h"
 #include "Externals/etl/include/etl/vector.h"
 #include "FieldView.h"
 #include "Foundation/Observable.h"
@@ -52,5 +53,6 @@ private:
   etl::vector<UIBigHexVarField, 4> bigHexVarField_;
   etl::vector<UIIntVarOffField, 1> intVarOffField_;
   etl::vector<UIBitmaskVarField, 3> bitmaskVarField_;
+  etl::vector<UITextField<MAX_MIDI_INSTRUMENT_NAME_LENGTH>, 1> uiTextfield_;
 };
 #endif

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -126,9 +126,12 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   int xalign = position._x;
 
   v = project_->FindVariable(FourCC::VarProjectName);
-  nameField_ = new UITextField<MAX_PROJECT_NAME_LENGTH>(
-      v, position, "project: ", FourCC::ActionProjectRename,
+  auto label = etl::make_string_with_capacity<MAX_LABEL_LENGTH>("project: ");
+  auto defaultName = etl::make_string_with_capacity<MAX_PROJECT_NAME_LENGTH>(
       UNNAMED_PROJECT_NAME);
+  nameField_ = new UITextField<MAX_PROJECT_NAME_LENGTH>(
+      *v, position, label, FourCC::ActionProjectRename, defaultName);
+
   nameField_->AddObserver(*this);
   fieldList_.insert(fieldList_.end(), nameField_);
 

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -126,7 +126,8 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   int xalign = position._x;
 
   v = project_->FindVariable(FourCC::VarProjectName);
-  auto label = etl::make_string_with_capacity<MAX_LABEL_LENGTH>("project: ");
+  auto label =
+      etl::make_string_with_capacity<MAX_UITEXTFIELD_LABEL_LENGTH>("project: ");
   auto defaultName = etl::make_string_with_capacity<MAX_PROJECT_NAME_LENGTH>(
       UNNAMED_PROJECT_NAME);
   nameField_ = new UITextField<MAX_PROJECT_NAME_LENGTH>(

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -69,6 +69,7 @@ struct FourCC {
     MidiInstrumentVolume = 118,
     MidiInstrumentTable = 119,
     MidiInstrumentTableAutomation = 120,
+    MidiInstrumentName = 144,
 
     SIDInstrument1Waveform = 72,
     SIDInstrument2Waveform = 73,
@@ -152,6 +153,7 @@ struct FourCC {
     VarUIFont = 141,
     // 142 is taken for SIDInstrumentOSCNumber
     // 143 is taken for InstrumentCommandMidiChord
+    // 144 is taken for InstrumentMidiName
 
     VarInstrumentType = 113,
 
@@ -231,6 +233,7 @@ struct FourCC {
   ETL_ENUM_TYPE(SampleInstrumentTable, "table")
   ETL_ENUM_TYPE(SampleInstrumentTableAutomation, "table automation")
   ETL_ENUM_TYPE(MidiInstrumentChannel, "channel")
+  ETL_ENUM_TYPE(MidiInstrumentName, "midi name")
   ETL_ENUM_TYPE(MidiInstrumentNoteLength, "note length")
   ETL_ENUM_TYPE(MidiInstrumentVolume, "volume")
   ETL_ENUM_TYPE(MidiInstrumentTable, "table")

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -181,7 +181,8 @@ void Variable::SetString(const char *string, bool notify) {
     value_.bool_ = (!strcmp("false", string) ? false : true);
     break;
   case STRING:
-    stringValue_ = std::string(string);
+    stringValue_.clear();
+    stringValue_.append(string);
     break;
   case CHAR_LIST:
     value_.index_ = -1;
@@ -222,7 +223,7 @@ etl::string<MAX_VARIABLE_STRING_LENGTH> Variable::GetString() {
     npf_snprintf(buf, sizeof(buf), "%s", value_.bool_ ? "true" : "false");
     break;
   case STRING:
-    return stringValue_.c_str();
+    return stringValue_;
   case CHAR_LIST:
     if ((value_.index_ < 0) || (value_.index_ >= listSize_)) {
       return "(null)";

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -32,7 +32,7 @@ public:
   void SetFloat(float value, bool notify = true);
   float GetFloat();
   void SetString(const char *string, bool notify = true);
-  etl::string<40> GetString();
+  etl::string<MAX_VARIABLE_STRING_LENGTH> GetString();
   void SetBool(bool value, bool notify = true);
   bool GetBool();
   void CopyFrom(Variable &other);
@@ -65,8 +65,10 @@ protected:
     const char *const *char_;
   } list_;
 
-  etl::string<MAX_VARIABLE_STRING_LENGTH> stringValue_;
+  etl::string<MAX_VARIABLE_STRING_LENGTH> *stringValue_ = nullptr;
 
   uint8_t listSize_;
+
+  void setStringValue(const char *value);
 };
 #endif

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -65,7 +65,7 @@ protected:
     const char *const *char_;
   } list_;
 
-  std::string stringValue_;
+  etl::string<MAX_VARIABLE_STRING_LENGTH> stringValue_;
 
   uint8_t listSize_;
 };


### PR DESCRIPTION
This adds a `name` field to MIDI instruments to help distinguishing between MIDI instruments once multiple MIDI instruments are created and especially when multiple instruments are created for the same  MIDI channel.

This is a much bigger PR because apart from the above, this also needed to fix ram usage of Variables after previous PR caused ram usage to grow dramatically because it replaced use of `std:string` dynamic mem alloc with static allow of etl:string **but** this meant that all `Variable` objects now had a 40 byte etl:string field while only a tiny minority objects that actually were of "type" `STRING` needed them. The correct solution to this is to actually subtype or template `Variable` class but that can be done in future PR.

Finally `UITextField` was improved to only use etl:string and related methods instead of C-style string manipulation and related util code was also cleaned up and functionality of `UITextField` for the MIDI name where the default value can essentially be ab "empty string" was added.

Note: there doesnt seem to be a firm std for naming template implementation header files so I went with `ipp` which is mentioned here: https://stackoverflow.com/questions/19147208/difference-between-using-ipp-extension-and-cpp-extension-files

Fixes: #406