### PR TITLE
ETL Logging

### DIFF
--- a/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
+++ b/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
@@ -6,6 +6,7 @@
 #include "hardware/pll.h"
 #include "pico/stdlib.h"
 #include "tusb.h"
+#include <System/Console/Trace.h>
 
 int main(int argc, char *argv[]) {
 
@@ -18,6 +19,9 @@ int main(int argc, char *argv[]) {
   // Do remaining pT init, this needs to be done *after* above hardware and
   // tinyusb subsystem init
   platform_init();
+
+  // Make sure we get ETL logs
+  Trace::RegisterEtlErrorHandler();
 
   picoTrackerSystem::Boot(argc, argv);
 

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -43,6 +43,10 @@ message(USE_LCD="${USE_LCD}")
 add_compile_definitions(${USE_LCD})
 # add_compile_definitions(LCD_ST7789)
 
+
+# Needed for ETL to pick up our etl_profile.h
+include_directories("config/")
+
 # Enable ETL debug mode only for Debug builds
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(ETL_DEBUG)

--- a/sources/System/Console/Trace.cpp
+++ b/sources/System/Console/Trace.cpp
@@ -1,5 +1,6 @@
 #include "Trace.h"
 #include "Adapters/picoTracker/platform/platform.h"
+#include "Externals/etl/include/etl/error_handler.h"
 #include "hardware/uart.h"
 #include <string.h>
 
@@ -55,6 +56,19 @@ void Trace::Error(const char *fmt, ...) {
   va_start(args, fmt);
   VLog("*ERROR*", fmt, args);
   va_end(args);
+}
+
+//------------------------------------------------------------------------------
+
+// Never inline, so you can breakpoint on this function to get backtraces
+__attribute__((noinline)) void EtlError(const etl::exception &e) {
+  Trace::Error("ETL: %s:%d: %s", e.file_name(), e.line_number(), e.what());
+}
+
+void Trace::RegisterEtlErrorHandler() {
+#ifdef ETL_LOG_ERRORS
+  etl::error_handler::set_callback<EtlError>();
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/sources/System/Console/Trace.h
+++ b/sources/System/Console/Trace.h
@@ -19,6 +19,7 @@ public:
   static void Debug(const char *fmt, ...);
   static void Log(const char *category, const char *fmt, ...);
   static void Error(const char *fmt, ...);
+  static void RegisterEtlErrorHandler();
 
   //--------------------------------------
 

--- a/sources/config/etl_profile.h
+++ b/sources/config/etl_profile.h
@@ -8,4 +8,9 @@
 #define ETL_CPP17_SUPPORTED 1
 #define ETL_CHECK_PUSH_POP
 
+#ifdef ETL_DEBUG
+#define ETL_LOG_ERRORS
+#define ETL_VERBOSE_ERRORS
+#endif
+
 #endif


### PR DESCRIPTION
This enables ETL logging to Trace for debug builds. Also, fixes a bug where etl_profile.h wasn't actually getting included by ETL (and thus, was having no actual effect on ETL's behavior).

Basically, ETL does

	#include "etl_profile.h"

So the `config` path needs to be on the list of top level include directories.

I'm not great at CMake so I'm not sure if this is the right way to do that.

Closes #443