### PR TITLE
fixes to build using GCC13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       id: arm-none-eabi-gcc-action
       with:
-        release: 12.3.Rel1
+        release: 13.2.Rel1
     - run: arm-none-eabi-gcc --version
 
     - name: Create Build Environment for ILI9341

--- a/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
+++ b/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
@@ -7,6 +7,16 @@
 #include "pico/stdlib.h"
 #include "tusb.h"
 
+// this prevents a really annoying linker warning due to newlib and >gcc13
+// ref:
+// https://github.com/raspberrypi/pico-sdk/issues/1768#issuecomment-2649260970
+#ifdef __cplusplus
+extern "C" {
+int _getentropy(void *buffer, size_t length) { return -1; }
+}
+#endif
+// ================
+
 int main(int argc, char *argv[]) {
 
   // Initialise microcontroller specific hardware

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -157,7 +157,7 @@ void DeviceView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {

--- a/sources/Application/Views/FieldView.cpp
+++ b/sources/Application/Views/FieldView.cpp
@@ -43,7 +43,7 @@ void FieldView::Redraw() {
   };
 };
 
-void FieldView::ProcessButtonMask(unsigned short mask) {
+void FieldView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (focus_ == 0) {
     focus_ = *fieldList_.begin();

--- a/sources/Application/Views/FieldView.h
+++ b/sources/Application/Views/FieldView.h
@@ -10,7 +10,7 @@ public:
   FieldView(GUIWindow &w, ViewData *viewData);
 
   virtual void Redraw();
-  virtual void ProcessButtonMask(unsigned short mask);
+  virtual void ProcessButtonMask(unsigned short mask, bool pressed) override;
 
   void SetFocus(UIField *);
   UIField *GetFocus();

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -682,7 +682,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
     viewMode_ = VM_NORMAL;
   }
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   // EDIT Modifier
   if (mask & EPBM_EDIT) {

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -201,7 +201,7 @@ void ProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {

--- a/sources/Externals/SdFat/src/common/ArduinoFiles.h
+++ b/sources/Externals/SdFat/src/common/ArduinoFiles.h
@@ -53,6 +53,15 @@ class PrintFile : public print_t, public BaseFile {
   size_t write(uint8_t b) {
     return BaseFile::write(&b, 1);
   }
+  
+  /** Write multiple bytes.
+   * \param[in] buffer pointer to data to be written.
+   * \param[in] size number of bytes to write.
+   * \return number of bytes written.
+   */
+  virtual size_t write(const uint8_t* buffer, size_t size) override {
+    return BaseFile::write(buffer, size);
+  }
 };
 //------------------------------------------------------------------------------
 /**

--- a/sources/Externals/opal/CMakeLists.txt
+++ b/sources/Externals/opal/CMakeLists.txt
@@ -3,6 +3,8 @@ opal.h opal.cpp
 )
 
 # Disable the aggressive-loop-optimizations warning that can cause build errors with GCC14
+# this is causeed only by the code changes in opal.cpp lines 241-247 due to code for 4-Op
+# which would cause out of bounds access but doesnt because 4-Op are currently disabled
 target_compile_options(opal PRIVATE -Wno-aggressive-loop-optimizations)
 
 target_link_libraries(opal 

--- a/sources/Externals/opal/CMakeLists.txt
+++ b/sources/Externals/opal/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(opal
 opal.h opal.cpp
 )
 
+# Disable the aggressive-loop-optimizations warning that can cause build errors with GCC14
+target_compile_options(opal PRIVATE -Wno-aggressive-loop-optimizations)
+
 target_link_libraries(opal 
     PUBLIC application_utils
     PUBLIC hardware_flash

--- a/sources/Foundation/T_Factory.h
+++ b/sources/Foundation/T_Factory.h
@@ -9,7 +9,7 @@
 
 template <class Item> class T_Factory {
 protected:
-  virtual ~T_Factory<Item>(){};
+  virtual ~T_Factory(){};
 
 public:
   // Install the factory to use


### PR DESCRIPTION
This fixes the build for GCC13 and GCC14.

It also updates CI GH Action to use GCC13.2 and potentially could be updated to GCC14.1 as well.

Fixes: #293, #179