### PR TITLE
i2s: sign extend correctly; insert 1-bit padding to prevent DAC automute

### DIFF
--- a/sources/Adapters/picoTracker/audio/audio_i2s.pio
+++ b/sources/Adapters/picoTracker/audio/audio_i2s.pio
@@ -33,12 +33,12 @@
 ;
 ; The modifications bare a little bit of explanation:
 ; The I2S output bitstream word length has been changed to 32bit BUT the input data has been
-; untouched, so what the modified PIO code below does is insert a fixed amount of 0 bits at the
+; untouched, so what the modified PIO code below does is insert a fixed amount of bits at the
 ; front of the real 16bit sample data and then fills in after the real data the remaining required
 ; number of bits to get to 32 in total. We can't *just* blindly preface 0 bits at the start of the 
 ; real data on the i2s output because the data in i2s is twos-complement so we need to preserve the
 ; real data's MSB on the i2s output bitstream so the i2s bitstream becomes:
-; MSB+0-bits-padding+RealData+0-bits-Backfill
+; MSB+Copies of MSB+RestOfData+0-bits-Backfill
 
 
 .program audio_i2s
@@ -65,10 +65,10 @@ bitloop1:                   ;      ||
     set x, DATA_LOOP_COUNT  side 0b01
 
     out pins, 1             side 0b00 ; twos complement so need to keep most significant Bit of real sample data
-    set y, OFFSET_COUNT     side 0b01 ; now how many bits+1 of zeros we will pad from MSB
+    set y, OFFSET_COUNT     side 0b01 ; now how many bits+1 of MSB we will pad from MSB
 
 padloop1:
-    set pins, 0             side 0b00
+    nop                     side 0b00 ; Clocking out MSB for sign extension
     jmp y-- padloop1        side 0b01
 
 bitloop0:
@@ -89,10 +89,10 @@ public entry_point:
     set x, DATA_LOOP_COUNT  side 0b11
 
     out pins, 1             side 0b10 ; twos complement so need to keep most significant Bit of real sample data
-    set y, OFFSET_COUNT     side 0b11 ; now how many bits+1 of zeros we will pad from MSB
+    set y, OFFSET_COUNT     side 0b11 ; now how many bits+1 of MSB we will pad from MSB
 
 padloop0:
-    set pins, 0             side 0b10
+    nop                     side 0b10 ; Clocking out MSB for sign extension
     jmp y-- padloop0        side 0b11
      
 
@@ -102,6 +102,7 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
     pio_sm_config sm_config = audio_i2s_program_get_default_config(offset);
     
     sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_set_pins(&sm_config, data_pin, 1);
     sm_config_set_sideset_pins(&sm_config, clock_pin_base);
     sm_config_set_out_shift(&sm_config, false, true, 32);
 

--- a/sources/Adapters/picoTracker/audio/audio_i2s.pio
+++ b/sources/Adapters/picoTracker/audio/audio_i2s.pio
@@ -61,7 +61,7 @@ bitloop1:                   ;      ||
     set pins, 0             side 0b10
     jmp y-- backfill1       side 0b11
 
-    set pins, 0             side 0b00
+    set pins, 1             side 0b00 ; Final LSB is a 1, to prevent DAC hardware mute
     set x, DATA_LOOP_COUNT  side 0b01
 
     out pins, 1             side 0b00 ; twos complement so need to keep most significant Bit of real sample data
@@ -82,7 +82,7 @@ bitloop0:
     set pins, 0             side 0b00
     jmp y-- backfill0       side 0b01
 
-    set pins, 0             side 0b10
+    set pins, 1             side 0b10 ; Final LSB is a 1, to prevent DAC hardware mute
 
 ;----
 public entry_point:


### PR DESCRIPTION
I believe this PR takes care of https://github.com/xiphonics/picoTracker/issues/435 as it gets rid of the clicking sounds I hear on my machine.

I've tested it with HP Low, HP High, and Line Level output levels, and the volume adjustment code appears to still work. This is what I'd expect because I did not move any PIO instructions around or change the loop counter sets

## Fix i2s_audio to sign extend correctly

The i2s audio code as written was not correctly sign-extending twos-complement values, because it was padding with zeroes between the MSB and the rest of the value regardless of the MSB value. The correct way to sign extend is to pad with 1s for a negative number and 0s for a positive (i.e. replicate the sign bit)

However, thankfully, the code was inadvertently sign-extending anyway because the data pins for `set` were not configured at all, so the set command was essentially acting as a NOP, preserving the MSB during the padding.

This PR fixes the code to explicitly sign-extend correctly.


## Work around DAC chip auto-mute

The DAC chip used in the picotracker, pcm5102a, has an auto-mute behavior when it detects a continuous string of zeroes. It is described in section 9.3.2.3 of the datasheet.

For whatever reason, when this kicks in, it causes an audible click sound, which is particularly apparent when auditioning notes while sequencing, or during quiet sections of a song that may go to silence for a row or two.

It's possible to prevent this by inserting a 1 in the LSB of the 32-bit value we send in the i2s datastream. This should be well below the noise floor, so it should not cause any harm to the actual audio signal.