### PR TITLE
Slices rebased again

### DIFF
--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -234,14 +234,15 @@ bool SampleInstrument::Start(int channel, unsigned char midinote,
   }
   case SILM_SLICE: {
     int note = rp->midiNote_;
-    if (note > slices_->GetInt() - 1) break; // No sound outside of slice range
+    if (note > slices_->GetInt() - 1)
+      break; // No sound outside of slice range
     int slice = rp->rendLoopEnd_ / slices_->GetInt();
 
-    rp->position_ = float(note*slice);
-    rp->baseSpeed_ = fl2fp(source_->GetSampleRate(note)/driverRate) ;
+    rp->position_ = float(note * slice);
+    rp->baseSpeed_ = fl2fp(source_->GetSampleRate(note) / driverRate);
     rp->speed_ = rp->baseSpeed_;
-    rp->rendLoopEnd_ = (note+1)*slice;
-    break ;
+    rp->rendLoopEnd_ = (note + 1) * slice;
+    break;
   }
   case SILM_LAST:
     NAssert(0);

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -234,9 +234,9 @@ bool SampleInstrument::Start(int channel, unsigned char midinote,
   }
   case SILM_SLICE: {
     int note = rp->midiNote_;
-    if (note > slices_->GetInt() - 1)
+    if (note > slices_.GetInt() - 1)
       break; // No sound outside of slice range
-    int slice = rp->rendLoopEnd_ / slices_->GetInt();
+    int slice = rp->rendLoopEnd_ / slices_.GetInt();
 
     rp->position_ = float(note * slice);
     rp->baseSpeed_ = fl2fp(source_->GetSampleRate(note) / driverRate);

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -234,8 +234,9 @@ bool SampleInstrument::Start(int channel, unsigned char midinote,
   }
   case SILM_SLICE: {
     int note = rp->midiNote_;
-    if (note > slices_.GetInt() - 1)
+    if (note > slices_.GetInt() - 1) {
       break; // No sound outside of slice range
+    }
     int slice = rp->rendLoopEnd_ / slices_.GetInt();
 
     rp->position_ = float(note * slice);

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -19,6 +19,7 @@ enum SampleInstrumentLoopMode {
   SILM_OSC,
   //	SILM_OSCFINE,
   SILM_LOOPSYNC,
+  SILM_SLICE,
   SILM_LAST
 };
 
@@ -101,6 +102,7 @@ private:
   WatchedVariable loopEnd_;
   Variable table_;
   Variable tableAuto_;
+  Variable slices_;
 
   static bool useDirtyDownsampling_;
 };

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -73,7 +73,7 @@ protected:
   void doKRateUpdate(int channel);
 
 private:
-  etl::list<Variable *, 20> variables_;
+  etl::list<Variable *, 21> variables_;
 
   SoundSource *source_;
   static struct renderParams renderParams_[SONG_CHANNEL_COUNT];

--- a/sources/Application/Instruments/SampleInstrumentDatas.h
+++ b/sources/Application/Instruments/SampleInstrumentDatas.h
@@ -2,7 +2,7 @@
 
 const char *loopTypes[SILM_LAST] = {"none", "loop", "pingpong", "oscillator",
                                     //	"oscillator fine",
-                                    "looper sync"};
+                                    "looper sync", "slicer"};
 
 const char *interpolationTypes[] = {"linear", "none"};
 

--- a/sources/Application/Instruments/SampleInstrumentDatas.h
+++ b/sources/Application/Instruments/SampleInstrumentDatas.h
@@ -2,7 +2,7 @@
 
 const char *loopTypes[SILM_LAST] = {"none", "loop", "pingpong", "oscillator",
                                     //	"oscillator fine",
-                                    "looper sync", "slicer"};
+                                    "looper sync", "slices"};
 
 const char *interpolationTypes[] = {"linear", "none"};
 

--- a/sources/Application/Views/FieldView.h
+++ b/sources/Application/Views/FieldView.h
@@ -18,7 +18,7 @@ public:
   int GetFocusIndex();
   void SetSize(int size);
 
-  etl::list<UIField *, 34> fieldList_; // adjust to maximum fields on one screen
+  etl::list<UIField *, 35> fieldList_; // adjust to maximum fields on one screen
 
 private:
   UIField *focus_;

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -763,6 +763,14 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   // EDIT Modifier
   if (mask & EPBM_EDIT) {
+    FourCC varID = ((UIIntVarField *)GetFocus())->GetVariableID();
+    if (varID == SIP_LOOPMODE) { // Show or hide slices
+      onInstrumentChange();
+    }
+  }
+  // B Modifier
+
+  if (mask & EPBM_B) {
     if (mask & EPBM_LEFT)
       warpToNext(-1);
     if (mask & EPBM_RIGHT)

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -369,6 +369,14 @@ void InstrumentView::fillSampleParameters() {
                             1);
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
 
+  if (v->GetString() == "slicer") {
+    position._x += 18;
+    v = instrument->FindVariable(SIP_SLICES);
+    intVarField_.emplace_back(position, *v, "slcs: %d", 1, 128, 1, 16);
+    fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
+    position._x -= 18;
+  }
+
   position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentStart);
   bigHexVarField_.emplace_back(position, *v, 7, "start: %7.7X", 0,

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -208,12 +208,7 @@ void InstrumentView::refreshInstrumentFields(const I_Instrument *old) {
     break;
   };
 
-  for (auto field : fieldList_) {
-    if (((UIIntVarField *)field)->GetVariableID() == lastFocusID_) {
-      SetFocus(field);
-      break;
-    }
-  }
+  setFocus(lastFocusID_);
 
   // observer all var fields so we can mark the instrument as modified
   // to be able to show confirmation dialog when switching instrument type
@@ -763,10 +758,6 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   // EDIT Modifier
   if (mask & EPBM_EDIT) {
-    FourCC varID = ((UIIntVarField *)GetFocus())->GetVariableID();
-    if (varID == FourCC::SampleInstrumentLoopMode) { // Show or hide slices
-      onInstrumentChange();
-    }
     if (mask & EPBM_LEFT)
       warpToNext(-1);
     if (mask & EPBM_RIGHT)
@@ -951,6 +942,12 @@ void InstrumentView::Update(Observable &o, I_ObservableData *data) {
     SetChanged();
     NotifyObservers(&ve);
   } break;
+  case FourCC::SampleInstrumentLoopMode: {
+    // Show or hide slices
+    onInstrumentChange();
+    lastFocusID_ = FourCC::SampleInstrumentLoopMode;
+    setFocus(lastFocusID_);
+  }
   default:
     if (fourcc != 0) {
       instrumentModified_ = true;

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -371,7 +371,7 @@ void InstrumentView::fillSampleParameters() {
 
   if (v->GetString() == "slicer") {
     position._x += 18;
-    v = instrument->FindVariable(SIP_SLICES);
+    v = instrument->FindVariable(FourCC::SampleInstrumentSlices);
     intVarField_.emplace_back(position, *v, "slcs: %d", 1, 128, 1, 16);
     fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
     position._x -= 18;
@@ -764,13 +764,9 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
   // EDIT Modifier
   if (mask & EPBM_EDIT) {
     FourCC varID = ((UIIntVarField *)GetFocus())->GetVariableID();
-    if (varID == SIP_LOOPMODE) { // Show or hide slices
+    if (varID == FourCC::SampleInstrumentLoopMode) { // Show or hide slices
       onInstrumentChange();
     }
-  }
-  // B Modifier
-
-  if (mask & EPBM_B) {
     if (mask & EPBM_LEFT)
       warpToNext(-1);
     if (mask & EPBM_RIGHT)

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -364,10 +364,10 @@ void InstrumentView::fillSampleParameters() {
                             1);
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
 
-  if (v->GetString() == "slicer") {
+  if (v->GetString() == "slices") {
     position._x += 18;
     v = instrument->FindVariable(FourCC::SampleInstrumentSlices);
-    intVarField_.emplace_back(position, *v, "slcs: %d", 1, 128, 1, 16);
+    intVarField_.emplace_back(position, *v, "#%d", 1, 128, 1, 16);
     fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
     position._x -= 18;
   }

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -42,6 +42,7 @@ protected:
   void refreshInstrumentFields(const I_Instrument *old);
   void addNameTextField(I_Instrument *instr, GUIPoint &position);
   void handleInstrumentExport();
+  void setFocus(FourCC id);
 
 private:
   Project *project_;

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -56,7 +56,7 @@ struct FourCC {
     SampleInstrumentEnd = 6,
     SampleInstrumentTable = 117,
     SampleInstrumentTableAutomation = 60,
-    SampleInstrumentSlices = 202,
+    SampleInstrumentSlices = 151,
 
     MacroInstrumentShape = 93,
     MacroInstrmentTimbre = 94,

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -56,6 +56,7 @@ struct FourCC {
     SampleInstrumentEnd = 6,
     SampleInstrumentTable = 117,
     SampleInstrumentTableAutomation = 60,
+    SampleInstrumentSlices = 202,
 
     MacroInstrumentShape = 93,
     MacroInstrmentTimbre = 94,


### PR DESCRIPTION
Not quite sure what to do with this section that went in MANUAL.md?

  - slicer will cut the sample into "slices" (displayed only in slice mode) amount of samples. Slices are mapped from C-2 (the lowest note) up to amount of slices. Example: slices == 4 will give you four slices mapped to C-2, C#-2, D-2, D#-2