### PR TITLE
use ETL atomic queue to prevent race with ISR

### DIFF
--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
@@ -1,15 +1,18 @@
 #include "picoTrackerEventQueue.h"
 
 picoTrackerEventQueue::picoTrackerEventQueue(){};
+
 void picoTrackerEventQueue::push(picoTrackerEvent event) {
-  if (std::find(queue_.begin(), queue_.end(), event) == queue_.end()) {
-    queue_.push_back(event);
+  if (!queue_.full()) {
+    queue_.push(event);
   }
 };
 
 void picoTrackerEventQueue::pop_into(picoTrackerEvent &event) {
-  event.type_ = queue_.front().type_;
-  queue_.pop_front();
+  if (!queue_.empty()) {
+    event.type_ = queue_.front().type_;
+    queue_.pop();
+  }
 };
 
 bool picoTrackerEventQueue::empty() { return queue_.empty(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -1,7 +1,7 @@
 #ifndef _PICOTRACKEREVENTQUEUE_H_
 #define _PICOTRACKEREVENTQUEUE_H_
 
-#include "Externals/etl/include/etl/deque.h"
+#include "Externals/etl/include/etl/queue_spsc_atomic.h"
 #include "Foundation/T_Singleton.h"
 
 enum picoTrackerEventType { PICO_REDRAW, PICO_FLUSH, PICO_CLOCK, LAST };
@@ -25,7 +25,8 @@ public:
   bool empty();
 
 private:
-  etl::deque<picoTrackerEvent, picoTrackerEventType::LAST> queue_;
+  static const size_t EVENT_QUEUE_SIZE = 256;
+  etl::queue_spsc_atomic<picoTrackerEvent, EVENT_QUEUE_SIZE> queue_;
 };
 
 #endif


### PR DESCRIPTION
Because both the 1khz timer ISR & the mainloop modify the event queue.

One thing to note is that as a part of this change I removed the deduplication of events being added to the queue for which I don't think there is any reason as far as I know.

All credit for finding and correctly debugging this issue goes to @faithanalog who provided a excellent detailed analysis in #450 🙏🏻 

Fixes: #332, #450