### PR TITLE
Remove unused midi-in handling code to save ram

### DIFF
--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -63,13 +63,9 @@ protected:
 
 private:
   static bool dumpEvents_;
-  // MIDI Channel dependant channels
-  MidiChannel *ccChannel_[16][128];   // Control Change
-  MidiChannel *noteChannel_[16][128]; // Note on / note off
-  MidiChannel *atChannel_[16][128];   // After touch
-  MidiChannel *pbChannel_[16];        // Pitch bend
-  MidiChannel *catChannel_[16];       // Channel after touch
-  MidiChannel *pcChannel_[16];        // Program change
+  // MidiChannel *pbChannel_[16];  // Pitch bend
+  // MidiChannel *catChannel_[16]; // Channel after touch
+  // MidiChannel *pcChannel_[16];  // Program change
 
   // New direct mapping from MIDI channels to instrument indices
   static int8_t channelToInstrument_[16];


### PR DESCRIPTION
Removing unused per channel midi message handling code saves ~45kB of static ram allocation that was previously introduced when MIDI input handling was recently added.

Fixes: #467