### PR TITLE
Add key input debouncing

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -12,6 +12,8 @@
 #include "picoRemoteUI.h"
 #endif
 
+#define KEY_DEBOUNCE_TIME 40
+
 bool picoTrackerEventManager::finished_ = false;
 bool picoTrackerEventManager::redrawing_ = false;
 uint16_t picoTrackerEventManager::buttonMask_ = 0;
@@ -22,7 +24,6 @@ unsigned int picoTrackerEventManager::keyRepeat_ = 25;
 unsigned int picoTrackerEventManager::keyDelay_ = 500;
 unsigned int picoTrackerEventManager::keyKill_ = 5;
 
-unsigned int picoTrackerEventManager::debounceTime_ = 40;
 unsigned int picoTrackerEventManager::lastDebounceTime_ = 0;
 uint16_t picoTrackerEventManager::debounceMask_ = 0;
 
@@ -140,7 +141,7 @@ void picoTrackerEventManager::ProcessInputEvent() {
   unsigned long now = gTime_;
 
   if (newMask != debounceMask_) {
-    if ((now - lastDebounceTime_) < debounceTime_) {
+    if ((now - lastDebounceTime_) < KEY_DEBOUNCE_TIME) {
       return;
     }
     debounceMask_ = newMask;

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
@@ -29,7 +29,6 @@ private:
   static bool redrawing_;
   static uint16_t buttonMask_;
   static uint16_t debounceMask_;
-  static unsigned int debounceTime_;
   static unsigned int lastDebounceTime_;
   static unsigned int keyRepeat_;
   static unsigned int keyDelay_;

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.h
@@ -28,6 +28,9 @@ private:
   static bool finished_;
   static bool redrawing_;
   static uint16_t buttonMask_;
+  static uint16_t debounceMask_;
+  static unsigned int debounceTime_;
+  static unsigned int lastDebounceTime_;
   static unsigned int keyRepeat_;
   static unsigned int keyDelay_;
   static unsigned int keyKill_;


### PR DESCRIPTION
Addresses issue [#337](https://github.com/xiphonics/picoTracker/issues/337)

40ms seemed like a safe number when testing!

Also, I couldn't get clang to check for linting/standard, so apologies if the workflow fails...