### PR TITLE
Cherrypick-for-2.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       id: arm-none-eabi-gcc-action
       with:
-        release: 12.3.Rel1
+        release: 13.2.Rel1
     - run: arm-none-eabi-gcc --version
 
     - name: Create Build Environment for ILI9341

--- a/sources/Adapters/picoTracker/audio/audio_i2s.pio
+++ b/sources/Adapters/picoTracker/audio/audio_i2s.pio
@@ -33,12 +33,12 @@
 ;
 ; The modifications bare a little bit of explanation:
 ; The I2S output bitstream word length has been changed to 32bit BUT the input data has been
-; untouched, so what the modified PIO code below does is insert a fixed amount of 0 bits at the
+; untouched, so what the modified PIO code below does is insert a fixed amount of bits at the
 ; front of the real 16bit sample data and then fills in after the real data the remaining required
 ; number of bits to get to 32 in total. We can't *just* blindly preface 0 bits at the start of the 
 ; real data on the i2s output because the data in i2s is twos-complement so we need to preserve the
 ; real data's MSB on the i2s output bitstream so the i2s bitstream becomes:
-; MSB+0-bits-padding+RealData+0-bits-Backfill
+; MSB+Copies of MSB+RestOfData+0-bits-Backfill
 
 
 .program audio_i2s
@@ -61,14 +61,14 @@ bitloop1:                   ;      ||
     set pins, 0             side 0b10
     jmp y-- backfill1       side 0b11
 
-    set pins, 0             side 0b00
+    set pins, 1             side 0b00 ; Final LSB is a 1, to prevent DAC hardware mute
     set x, DATA_LOOP_COUNT  side 0b01
 
     out pins, 1             side 0b00 ; twos complement so need to keep most significant Bit of real sample data
-    set y, OFFSET_COUNT     side 0b01 ; now how many bits+1 of zeros we will pad from MSB
+    set y, OFFSET_COUNT     side 0b01 ; now how many bits+1 of MSB we will pad from MSB
 
 padloop1:
-    set pins, 0             side 0b00
+    nop                     side 0b00 ; Clocking out MSB for sign extension
     jmp y-- padloop1        side 0b01
 
 bitloop0:
@@ -82,17 +82,17 @@ bitloop0:
     set pins, 0             side 0b00
     jmp y-- backfill0       side 0b01
 
-    set pins, 0             side 0b10
+    set pins, 1             side 0b10 ; Final LSB is a 1, to prevent DAC hardware mute
 
 ;----
 public entry_point:
     set x, DATA_LOOP_COUNT  side 0b11
 
     out pins, 1             side 0b10 ; twos complement so need to keep most significant Bit of real sample data
-    set y, OFFSET_COUNT     side 0b11 ; now how many bits+1 of zeros we will pad from MSB
+    set y, OFFSET_COUNT     side 0b11 ; now how many bits+1 of MSB we will pad from MSB
 
 padloop0:
-    set pins, 0             side 0b10
+    nop                     side 0b10 ; Clocking out MSB for sign extension
     jmp y-- padloop0        side 0b11
      
 
@@ -102,6 +102,7 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
     pio_sm_config sm_config = audio_i2s_program_get_default_config(offset);
     
     sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_set_pins(&sm_config, data_pin, 1);
     sm_config_set_sideset_pins(&sm_config, clock_pin_base);
     sm_config_set_out_shift(&sm_config, false, true, 32);
 

--- a/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
+++ b/sources/Adapters/picoTracker/main/picoTrackerMain.cpp
@@ -7,6 +7,16 @@
 #include "pico/stdlib.h"
 #include "tusb.h"
 
+// this prevents a really annoying linker warning due to newlib and >gcc13
+// ref:
+// https://github.com/raspberrypi/pico-sdk/issues/1768#issuecomment-2649260970
+#ifdef __cplusplus
+extern "C" {
+int _getentropy(void *buffer, size_t length) { return -1; }
+}
+#endif
+// ================
+
 int main(int argc, char *argv[]) {
 
   // Initialise microcontroller specific hardware

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.cpp
@@ -1,15 +1,18 @@
 #include "picoTrackerEventQueue.h"
 
 picoTrackerEventQueue::picoTrackerEventQueue(){};
+
 void picoTrackerEventQueue::push(picoTrackerEvent event) {
-  if (std::find(queue_.begin(), queue_.end(), event) == queue_.end()) {
-    queue_.push_back(event);
+  if (!queue_.full()) {
+    queue_.push(event);
   }
 };
 
 void picoTrackerEventQueue::pop_into(picoTrackerEvent &event) {
-  event.type_ = queue_.front().type_;
-  queue_.pop_front();
+  if (!queue_.empty()) {
+    event.type_ = queue_.front().type_;
+    queue_.pop();
+  }
 };
 
 bool picoTrackerEventQueue::empty() { return queue_.empty(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -1,7 +1,7 @@
 #ifndef _PICOTRACKEREVENTQUEUE_H_
 #define _PICOTRACKEREVENTQUEUE_H_
 
-#include "Externals/etl/include/etl/deque.h"
+#include "Externals/etl/include/etl/queue_spsc_atomic.h"
 #include "Foundation/T_Singleton.h"
 
 enum picoTrackerEventType { PICO_REDRAW, PICO_FLUSH, PICO_CLOCK, LAST };
@@ -25,7 +25,8 @@ public:
   bool empty();
 
 private:
-  etl::deque<picoTrackerEvent, picoTrackerEventType::LAST> queue_;
+  static const size_t EVENT_QUEUE_SIZE = 256;
+  etl::queue_spsc_atomic<picoTrackerEvent, EVENT_QUEUE_SIZE> queue_;
 };
 
 #endif

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -157,7 +157,7 @@ void DeviceView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {

--- a/sources/Application/Views/FieldView.cpp
+++ b/sources/Application/Views/FieldView.cpp
@@ -43,7 +43,7 @@ void FieldView::Redraw() {
   };
 };
 
-void FieldView::ProcessButtonMask(unsigned short mask) {
+void FieldView::ProcessButtonMask(unsigned short mask, bool pressed) {
 
   if (focus_ == 0) {
     focus_ = *fieldList_.begin();

--- a/sources/Application/Views/FieldView.h
+++ b/sources/Application/Views/FieldView.h
@@ -10,7 +10,7 @@ public:
   FieldView(GUIWindow &w, ViewData *viewData);
 
   virtual void Redraw();
-  virtual void ProcessButtonMask(unsigned short mask);
+  virtual void ProcessButtonMask(unsigned short mask, bool pressed) override;
 
   void SetFocus(UIField *);
   UIField *GetFocus();

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -670,7 +670,7 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
     viewMode_ = VM_NORMAL;
   }
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   // EDIT Modifier
   if (mask & EPBM_EDIT) {

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -161,7 +161,7 @@ void ProjectView::ProcessButtonMask(unsigned short mask, bool pressed) {
   if (!pressed)
     return;
 
-  FieldView::ProcessButtonMask(mask);
+  FieldView::ProcessButtonMask(mask, pressed);
 
   if (mask & EPBM_NAV) {
     if (mask & EPBM_DOWN) {

--- a/sources/Externals/SdFat/src/common/ArduinoFiles.h
+++ b/sources/Externals/SdFat/src/common/ArduinoFiles.h
@@ -53,6 +53,15 @@ class PrintFile : public print_t, public BaseFile {
   size_t write(uint8_t b) {
     return BaseFile::write(&b, 1);
   }
+  
+  /** Write multiple bytes.
+   * \param[in] buffer pointer to data to be written.
+   * \param[in] size number of bytes to write.
+   * \return number of bytes written.
+   */
+  virtual size_t write(const uint8_t* buffer, size_t size) override {
+    return BaseFile::write(buffer, size);
+  }
 };
 //------------------------------------------------------------------------------
 /**

--- a/sources/Externals/opal/CMakeLists.txt
+++ b/sources/Externals/opal/CMakeLists.txt
@@ -2,6 +2,11 @@ add_library(opal
 opal.h opal.cpp
 )
 
+# Disable the aggressive-loop-optimizations warning that can cause build errors with GCC14
+# this is causeed only by the code changes in opal.cpp lines 241-247 due to code for 4-Op
+# which would cause out of bounds access but doesnt because 4-Op are currently disabled
+target_compile_options(opal PRIVATE -Wno-aggressive-loop-optimizations)
+
 target_link_libraries(opal 
     PUBLIC application_utils
     PUBLIC hardware_flash

--- a/sources/Foundation/T_Factory.h
+++ b/sources/Foundation/T_Factory.h
@@ -9,7 +9,7 @@
 
 template <class Item> class T_Factory {
 protected:
-  virtual ~T_Factory<Item>(){};
+  virtual ~T_Factory(){};
 
 public:
   // Install the factory to use

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -194,7 +194,7 @@ void Variable::SetString(const char *string, bool notify) {
             break;
           }
         }
-        if (*s == 0) {
+        if (*s == 0 && *d == 0) { // Ensure both strings end at the same point
           value_.index_ = i;
           break;
         }


### PR DESCRIPTION
This cherry-picks the following fixes for the 2.0.1 stable fix release:

* fixes to build using GCC13 (#446)
* use etl atomic queue to prevent race with ISR (#465)
* Fix bug in Variable::SetString (#46o)
* i2s: sign extend correctly; insert 1-bit padding to prevent DAC automute (#449)