### PR TITLE
fix SID Waveform not persisting if noise waveform selected

### DIFF
--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -187,16 +187,7 @@ void Variable::SetString(const char *string, bool notify) {
     value_.index_ = -1;
     for (int i = 0; i < listSize_; i++) {
       if (list_.char_[i]) {
-        const char *d = list_.char_[i];
-        const char *s = string;
-        while (*s != 0) {
-          if (tolower(*s) != tolower(*d)) {
-            break;
-          }
-          s++;
-          d++;
-        }
-        if (*s == 0 && *d == 0) { // Ensure both strings end at the same point
+        if (strcasecmp(string, list_.char_[i]) == 0) {
           value_.index_ = i;
           break;
         }

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -190,9 +190,11 @@ void Variable::SetString(const char *string, bool notify) {
         const char *d = list_.char_[i];
         const char *s = string;
         while (*s != 0) {
-          if (tolower(*s++) != tolower(*d++)) {
+          if (tolower(*s) != tolower(*d)) {
             break;
           }
+          s++;
+          d++;
         }
         if (*s == 0 && *d == 0) { // Ensure both strings end at the same point
           value_.index_ = i;


### PR DESCRIPTION
  addresses issue #415 

Variable SetString will potentially falsely match strings of the same length if all chars except for the last match.

This allows VFW1 '---N' to be loaded as '----'. 'N' and '-' are detected as not equals and then we detect that we are at the end of s and d. Incrementing s and d during the equality check causes the last char in the string to be ignored.

I tested this loading an existing project which had the ---N value for VFW1.