### PR TITLE
switched to using GetFocus to find the Table Variable

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -778,12 +778,11 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
       }
 
       // Check if on table
-      if (GetFocus() == *fieldList_.rbegin()) {
-        int i = viewData_->currentInstrumentID_;
-        InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
-        I_Instrument *instr = bank->GetInstrument(i);
-        Variable *v = instr->FindVariable(FourCC::SampleInstrumentTable);
-        v->SetInt(-1);
+      UIIntVarField *field = (UIIntVarField *)GetFocus();
+      if ((field->GetVariableID() == FourCC::SampleInstrumentTable) ||
+          (field->GetVariableID() == FourCC::MidiInstrumentTable)) {
+        Variable &v = field->GetVariable();
+        v.SetInt(-1);
         isDirty_ = true;
       };
     }


### PR DESCRIPTION
Addresses issue #440

Switched the code to use `GetFocus()` to determine the field and access the Variable/VariableID since `FindVariable()` will return for any instrument that doesn't have a `SampleInstrumentTable` variable.

This also supports clearing the Midi Instrument Table field now.

Tested saving and loading a project to make sure the table value persists and can be cleared without crashing. Also tested ENTER+EDIT on OPAL and SID instrument fields to verify the crash no longer occurs on the last field.