### PR TITLE
Preserve column when navigating up/down in grid-layout FieldViews

### DIFF
--- a/sources/Application/Views/FieldView.cpp
+++ b/sources/Application/Views/FieldView.cpp
@@ -127,8 +127,19 @@ void FieldView::ProcessButtonMask(unsigned short mask, bool pressed) {
                 if (next) {
                   if ((*it)->GetPosition()._y < next->GetPosition()._y) {
                     next = *it;
-                  } else {
-                    // if both target at same height
+                  } else if ((*it)->GetPosition()._y ==
+                             next->GetPosition()._y) {
+                    // if both targets at same height, prefer the target with an
+                    // X value closest to the current focus
+
+                    // cast to signed ints
+                    int32_t itX = (*it)->GetPosition()._x;
+                    int32_t nextX = next->GetPosition()._x;
+                    int32_t focusX = focus_->GetPosition()._x;
+
+                    if (abs(itX - focusX) < abs(nextX - focusX)) {
+                      next = *it;
+                    }
                   };
                 } else {
                   next = *it;
@@ -167,8 +178,19 @@ void FieldView::ProcessButtonMask(unsigned short mask, bool pressed) {
                 if (prev) {
                   if ((*it)->GetPosition()._y > prev->GetPosition()._y) {
                     prev = *it;
-                  } else {
-                    // if both target at same height
+                  } else if ((*it)->GetPosition()._y ==
+                             prev->GetPosition()._y) {
+                    // if both targets at same height, prefer the target with an
+                    // X value closest to the current focus
+
+                    // cast to signed ints
+                    int32_t itX = (*it)->GetPosition()._x;
+                    int32_t prevX = prev->GetPosition()._x;
+                    int32_t focusX = focus_->GetPosition()._x;
+
+                    if (abs(itX - focusX) < abs(prevX - focusX)) {
+                      prev = *it;
+                    }
                   };
                 } else {
                   prev = *it;


### PR DESCRIPTION
Multi-column views such as OPAL had the frustrating characteristic that pressing up or down would reset the column to the leftmost column in the grid. This code makes the focus shifting logic column-aware when navigating up or down, snapping to the column with the most-similar X value in the next selected row.

This produces perfect results when navigating columns where the X values match, and decent results when moving between grids with different numbers of columns on a single FieldView.

See https://github.com/xiphonics/picoTracker/issues/491