### PR TITLE
Use qmk-style debouncing, reduce debounce time to 10ms

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -12,7 +12,7 @@
 #include "picoRemoteUI.h"
 #endif
 
-#define KEY_DEBOUNCE_TIME 40
+#define KEY_DEBOUNCE_TIME 5
 
 bool picoTrackerEventManager::finished_ = false;
 bool picoTrackerEventManager::redrawing_ = false;
@@ -141,11 +141,17 @@ void picoTrackerEventManager::ProcessInputEvent() {
   unsigned long now = gTime_;
 
   if (newMask != debounceMask_) {
-    if ((now - lastDebounceTime_) < KEY_DEBOUNCE_TIME) {
-      return;
-    }
+    // Key state changed. We begin or continue debouncing.
     debounceMask_ = newMask;
     lastDebounceTime_ = now;
+    return;
+  } else {
+    // Keys have not changed since the last scan. But we cannot
+    // continue unless they have not changed for at least KEY_DEBOUNCE_TIME ms
+    unsigned long settleTime = now - lastDebounceTime_;
+    if (settleTime < KEY_DEBOUNCE_TIME) {
+      return;
+    }
   }
 
   // compute mask to send

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -12,7 +12,9 @@
 #include "picoRemoteUI.h"
 #endif
 
-#define KEY_DEBOUNCE_TIME 5
+// Key debounce time in milliseconds. No state changes for this amount of time
+// means we accept the new key state.
+#define KEY_DEBOUNCE_TIME 10
 
 bool picoTrackerEventManager::finished_ = false;
 bool picoTrackerEventManager::redrawing_ = false;


### PR DESCRIPTION
This was discussed in the thread on https://github.com/xiphonics/picoTracker/pull/481 but not implemented with that PR. The summary of the rationale is:

- keep debounce time to a minimum to keep input as responsive as possible
- use a known-good value with a known-good debounce strategy, implementing the default QMK algorithm, which is widely used by many products

This aims to correctly implement the behavior described for debounce algorithm `sym_defer_g` as detailed on https://docs.qmk.fm/feature_debounce_type

> Debouncing per keyboard. On any state change, a global timer is set. When DEBOUNCE milliseconds of no changes has occurred, all input changes are pushed. This is the highest performance algorithm with lowest memory usage and is noise-resistant. 

This is subtly different from the code introduced in 481. 481's algorithm sets a timer the first time a state changes, but does not reset it as state changes occur, pushing whatever the state happens to be after the timer expires. This necessitates a longer timeout to have a good chance of pushing updates after key chatter has settled. The new algorithm is a bit more dynamic, taking a short timeout if things stabilize quickly and a longer one if they don't.

The 10ms value for the new algorithm is chosen as a more conservative value based on QMK's 5ms default.