### PR TITLE
More UI colours to match those in latest LGPT

### DIFF
--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -118,13 +118,20 @@ private:
 
   static GUIColor backgroundColor_;
   static GUIColor normalColor_;
-  static GUIColor highlight2Color_;
   static GUIColor highlightColor_;
+  static GUIColor highlight2Color_;
   static GUIColor consoleColor_;
   static GUIColor cursorColor_;
   static GUIColor infoColor_;
   static GUIColor warnColor_;
   static GUIColor errorColor_;
+  static GUIColor playColor_;
+  static GUIColor muteColor_;
+  static GUIColor songViewFEColor_;
+  static GUIColor songView00Color_;
+  static GUIColor rowColor_;
+  static GUIColor row2Color_;
+  static GUIColor majorBeatColor_;
 
   ColorDefinition colorIndex_;
 

--- a/sources/Application/Model/Config.h
+++ b/sources/Application/Model/Config.h
@@ -16,7 +16,7 @@ public:
   bool Save();
 
 private:
-  etl::list<Variable *, 22> variables_;
+  etl::list<Variable *, 24> variables_;
 
   void SaveContent(tinyxml2::XMLPrinter *printer);
   void processParams(const char *name, int value, bool insert);

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -61,7 +61,14 @@ enum ColorDefinition {
   CD_CURSOR,
   CD_INFO,
   CD_WARN,
-  CD_ERROR
+  CD_ERROR,
+  CD_PLAY,
+  CD_MUTE,
+  CD_SONGVIEWFE,
+  CD_SONGVIEW00,
+  CD_ROW,
+  CD_ROW2,
+  CD_MAJORBEAT
 };
 
 enum ViewUpdateDirection { VUD_LEFT = 0, VUD_RIGHT, VUD_UP, VUD_DOWN };

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -143,6 +143,69 @@ DeviceView::DeviceView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
 
   addSwatchField(CD_ERROR, position);
 
+  // position._y += 1;
+  // v = config->FindVariable(FourCC::VarPlayColor);
+  // bigHexVarField_.emplace_back(position, *v, 6, "Play:       %6.6X", 0,
+  //                              MAX_COLOR_VALUE, 16);
+  // fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  // (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  // addSwatchField(CD_PLAY, position);
+
+  // position._y += 1;
+  // v = config->FindVariable(FourCC::VarMuteColor);
+  // bigHexVarField_.emplace_back(position, *v, 6, "Mute:       %6.6X", 0,
+  //                              MAX_COLOR_VALUE, 16);
+  // fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  // (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  // addSwatchField(CD_MUTE, position);
+
+  position._y += 1;
+  v = config->FindVariable(FourCC::VarSongViewFEColor);
+  bigHexVarField_.emplace_back(position, *v, 6, "SongViewFE: %6.6X", 0,
+                               MAX_COLOR_VALUE, 16);
+  fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  addSwatchField(CD_SONGVIEWFE, position);
+
+  position._y += 1;
+  v = config->FindVariable(FourCC::VarSongView00Color);
+  bigHexVarField_.emplace_back(position, *v, 6, "SongView00: %6.6X", 0,
+                               MAX_COLOR_VALUE, 16);
+  fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  addSwatchField(CD_SONGVIEW00, position);
+
+  // position._y += 1;
+  // v = config->FindVariable(FourCC::VarRowColor);
+  // bigHexVarField_.emplace_back(position, *v, 6, "Row:        %6.6X", 0,
+  //                              MAX_COLOR_VALUE, 16);
+  // fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  // (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  // addSwatchField(CD_ROW, position);
+
+  // position._y += 1;
+  // v = config->FindVariable(FourCC::VarRow2Color);
+  // bigHexVarField_.emplace_back(position, *v, 6, "Row2:       %6.6X", 0,
+  //                              MAX_COLOR_VALUE, 16);
+  // fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  // (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  // addSwatchField(CD_ROW2, position);
+
+  // position._y += 1;
+  // v = config->FindVariable(FourCC::VarMajorBeatColor);
+  // bigHexVarField_.emplace_back(position, *v, 6, "MajorBeat:  %6.6X", 0,
+  //                              MAX_COLOR_VALUE, 16);
+  // fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+  // (*bigHexVarField_.rbegin()).AddObserver(*this);
+
+  // addSwatchField(CD_MAJORBEAT, position);
+
   position._y += 2;
   actionField_.emplace_back("Update firmware", FourCC::ActionBootSelect,
                             position);
@@ -239,6 +302,13 @@ void DeviceView::Update(Observable &, I_ObservableData *data) {
   case FourCC::VarInfoColor:
   case FourCC::VarWarnColor:
   case FourCC::VarErrorColor:
+  case FourCC::VarPlayColor:
+  case FourCC::VarMuteColor:
+  case FourCC::VarSongViewFEColor:
+  case FourCC::VarSongView00Color:
+  case FourCC::VarRowColor:
+  case FourCC::VarRow2Color:
+  case FourCC::VarMajorBeatColor:
     Trace::Log("DEVICE", "Color updated!");
     ((AppWindow &)w_).UpdateColorsFromConfig();
     ((AppWindow &)w_).Clear(true);
@@ -249,6 +319,7 @@ void DeviceView::Update(Observable &, I_ObservableData *data) {
     MessageBox *mb =
         new MessageBox(*this, "Reboot for new Audio Level!", MBBF_OK);
     DoModal(mb);
+    break;
   }
 
   default:

--- a/sources/Application/Views/DeviceView.h
+++ b/sources/Application/Views/DeviceView.h
@@ -30,7 +30,7 @@ private:
 
   etl::vector<UIIntVarField, 5> intVarField_;
   etl::vector<UIActionField, 1> actionField_;
-  etl::vector<UIBigHexVarField, 9> bigHexVarField_;
-  etl::vector<UISwatchField, 9> swatchField_;
+  etl::vector<UIBigHexVarField, 16> bigHexVarField_;
+  etl::vector<UISwatchField, 16> swatchField_;
 };
 #endif

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -859,14 +859,20 @@ void SongView::DrawView() {
         }
       }
 
+      // draw current step
+      unsigned char d = *data++;
+      if (d == 0xFE) {
+        SetColor(CD_SONGVIEWFE);
+      } else if (d == 0x00) {
+        SetColor(CD_SONGVIEW00);
+      } else {
+        SetColor(CD_NORMAL);
+      }
+
       if (invert) {
         SetColor(CD_HILITE2);
         props.invert_ = true;
       }
-
-      // draw current step
-
-      unsigned char d = *data++;
       if (d == 0xFF) {
         DrawString(pos._x, pos._y, "--", props);
       } else {

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -148,7 +148,15 @@ struct FourCC {
     VarInfoColor = 109,
     VarWarnColor = 110,
     VarErrorColor = 111,
+    VarPlayColor = 152,
+    VarMuteColor = 153,
+    VarSongViewFEColor = 154,
+    VarSongView00Color = 155,
+    VarRowColor = 156,
+    VarRow2Color = 157,
+    VarMajorBeatColor = 158,
     VarMidiSync = 112,
+    VarMidiClockSync = 151,
     VarRemoteUI = 140,
     VarUIFont = 141,
     // 142 is taken for SIDInstrumentOSCNumber
@@ -160,6 +168,14 @@ struct FourCC {
     // 148 is taken for InstrumentName
     // 149 is taken for ActionRenderMixdown
     // 150 is taken for ActionRenderStems
+    // 151 is taken for VarMidiClockSync
+    // 152 is taken for VarPlayColor
+    // 153 is taken for VarMuteColor
+    // 154 is taken for VarSongViewFEColor
+    // 155 is taken for VarSongView00Color
+    // 156 is taken for VarRowColor
+    // 157 is taken for VarRow2Color
+    // 158 is taken for VarMajorBeatColor
 
     VarInstrumentType = 113,
 
@@ -217,6 +233,7 @@ struct FourCC {
   ETL_ENUM_TYPE(VarLineOut, "LINEOUT")
   ETL_ENUM_TYPE(VarMidiDevice, "MIDIDEVICE")
   ETL_ENUM_TYPE(VarMidiSync, "MIDISYNC")
+  ETL_ENUM_TYPE(VarMidiClockSync, "MIDICLOCKSYNC")
   ETL_ENUM_TYPE(VarRemoteUI, "REMOTEUI")
   ETL_ENUM_TYPE(VarUIFont, "UIFONT")
   ETL_ENUM_TYPE(MacroInstrumentShape, "shape")
@@ -299,6 +316,13 @@ struct FourCC {
   ETL_ENUM_TYPE(VarInfoColor, "INFOCOLOR")
   ETL_ENUM_TYPE(VarWarnColor, "WARNCOLOR")
   ETL_ENUM_TYPE(VarErrorColor, "ERRORCOLOR")
+  ETL_ENUM_TYPE(VarPlayColor, "PLAYCOLOR")
+  ETL_ENUM_TYPE(VarMuteColor, "MUTECOLOR")
+  ETL_ENUM_TYPE(VarSongViewFEColor, "SONGVIEWFECOLOR")
+  ETL_ENUM_TYPE(VarSongView00Color, "SONGVIEW00COLOR")
+  ETL_ENUM_TYPE(VarRowColor, "ROWCOLOR")
+  ETL_ENUM_TYPE(VarRow2Color, "ROW2COLOR")
+  ETL_ENUM_TYPE(VarMajorBeatColor, "MAJORBEATCOLOR")
   ETL_ENUM_TYPE(VarTempo, "tempo")
   ETL_ENUM_TYPE(VarMasterVolume, "master")
   ETL_ENUM_TYPE(VarWrap, "wrap")


### PR DESCRIPTION
There is not enough room for all the new UI colour fields in Device screen so for now most not yet added to the UI and only the SongViewFE and SongView00 colours are added for demonsation purposes.

This can be considered part one of this work and a subsequent PR will add a new screen for "theme" settings where all the colour fields and the font setting field will be moved into which will be accessed via a button on the Device screen.

![image](https://github.com/user-attachments/assets/cc712205-d359-4bc2-8f69-de48f7d11123)

This partially addresses #181.