### PR TITLE
Optimise drawing vu meters

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -46,8 +46,8 @@ bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
 
-  // send a clock (PICO_CLOCK) ~30Hz
-  if (gTime_ % 32 == 0) {
+  // send a clock (PICO_CLOCK)
+  if (gTime_ % PICO_CLOCK_INTERVAL == 0) {
     queue->push(picoTrackerEvent(PICO_CLOCK));
   }
   return true;

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -46,8 +46,8 @@ bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
 
-  // send a clock (PICO_CLOCK) event once every second
-  if (gTime_ % 1000 == 0) {
+  // send a clock (PICO_CLOCK) 10Hz
+  if (gTime_ % 100 == 0) {
     queue->push(picoTrackerEvent(PICO_CLOCK));
   }
   return true;

--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -46,8 +46,8 @@ bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
 
-  // send a clock (PICO_CLOCK) 10Hz
-  if (gTime_ % 100 == 0) {
+  // send a clock (PICO_CLOCK) ~30Hz
+  if (gTime_ % 32 == 0) {
     queue->push(picoTrackerEvent(PICO_CLOCK));
   }
   return true;

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -34,7 +34,7 @@
 #include "Application/Views/ThemeView.h"
 #include "BaseClasses/View.h"
 
-const uint16_t AUTOSAVE_INTERVAL_IN_SECONDS = 1 * 60 * 20;
+const uint16_t AUTOSAVE_INTERVAL_IN_SECONDS = 1 * 60;
 
 AppWindow *instance = 0;
 
@@ -582,13 +582,13 @@ void AppWindow::AnimationUpdate() {
   }
   _currentView->AnimationUpdate();
 
-  // *attempt* to auto save every AUTOSAVE_INTERVAL_IN_MILLIS
+  // *attempt* to auto save every AUTOSAVE_INTERVAL_IN_SECONDS
   // will return false if auto save was unsuccessful because eg. the sequencer
   // is running
   // we do this here because for sheer convenience because this
-  // callback is called every second and we have easy access in this class to
-  // the player, projectname and persistence service
-  if (++lastAutoSave > AUTOSAVE_INTERVAL_IN_SECONDS) {
+  // this callback is called PICO_CLOCK_HZ times a second and we have easy
+  // access in this class to the player, projectname and persistence service
+  if ((++lastAutoSave / PICO_CLOCK_HZ) > AUTOSAVE_INTERVAL_IN_SECONDS) {
     if (autoSave()) {
       lastAutoSave = 0;
     }

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -34,7 +34,7 @@
 #include "Application/Views/ThemeView.h"
 #include "BaseClasses/View.h"
 
-const uint16_t AUTOSAVE_INTERVAL_IN_SECONDS = 1 * 60;
+const uint16_t AUTOSAVE_INTERVAL_IN_SECONDS = 1 * 60 * 20;
 
 AppWindow *instance = 0;
 

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -107,13 +107,13 @@ stereosample PlayerMixer::GetMasterOutLevel() {
 
 etl::array<stereosample, SONG_CHANNEL_COUNT> *PlayerMixer::GetMixerLevels() {
   MixerService *ms = MixerService::GetInstance();
-  
+
   // Get the current mixer levels from each bus
   for (int i = 0; i < 8; i++) {
     AudioMixer *audioMixer = ms->GetMixBus(i);
     mixerLevels_[i] = audioMixer->GetMixerLevels();
   }
-  
+
   return &mixerLevels_;
 }
 

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -107,12 +107,13 @@ stereosample PlayerMixer::GetMasterOutLevel() {
 
 etl::array<stereosample, SONG_CHANNEL_COUNT> *PlayerMixer::GetMixerLevels() {
   MixerService *ms = MixerService::GetInstance();
+  
+  // Get the current mixer levels from each bus
   for (int i = 0; i < 8; i++) {
     AudioMixer *audioMixer = ms->GetMixBus(i);
     mixerLevels_[i] = audioMixer->GetMixerLevels();
-    short levelL = (mixerLevels_[i] >> 16);
-    short levelR = (mixerLevels_[i] & 0x0000FFFF);
   }
+  
   return &mixerLevels_;
 }
 

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -294,8 +294,6 @@ void View::drawVUMeter(uint8_t leftBars, uint8_t rightBars, GUIPoint pos,
   props.invert_ = false;
 }
 
-
-
 void View::drawPlayTime(Player *player, GUIPoint pos,
                         GUITextProperties &props) {
   char strbuffer[10];

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -25,8 +25,13 @@ View::View(GUIWindow &w, ViewData *viewData)
   modalView_ = 0;
   modalViewCallback_ = 0;
   hasFocus_ = false;
-};
 
+  // Initialize VU meter tracking variables
+  for (int i = 0; i < SONG_CHANNEL_COUNT + 1; i++) {
+    prevLeftVU_[i] = 0;
+    prevRightVU_[i] = 0;
+  }
+}
 GUIPoint View::GetAnchor() {
   // Original code had a dynamic anchor point dending on song count, but
   // changing the song count didn't work anyway given that there are many places
@@ -168,7 +173,8 @@ void View::drawNotes() {
   }
 }
 
-void View::drawMasterVuMeter(Player *player, GUITextProperties props) {
+void View::drawMasterVuMeter(Player *player, GUITextProperties props,
+                             bool forceRedraw) {
   stereosample playerLevel = player->GetMasterLevel();
 
   // Convert to dB
@@ -184,33 +190,83 @@ void View::drawMasterVuMeter(Player *player, GUITextProperties props) {
   pos._x += 24;
   pos._y += VU_METER_HEIGHT - 1; // -1 to align with song grid
 
-  drawVUMeter(leftBars, rightBars, pos, props);
+  // Use index 0 for the master VU meter
+  drawVUMeter(leftBars, rightBars, pos, props, 0, forceRedraw);
 }
 
 void View::drawVUMeter(uint8_t leftBars, uint8_t rightBars, GUIPoint pos,
-                       GUITextProperties props) {
+                       GUITextProperties props, int vuIndex, bool forceRedraw) {
+
+  // Clamp the values to the maximum height
+  leftBars = std::min(leftBars, (uint8_t)VU_METER_HEIGHT);
+  rightBars = std::min(rightBars, (uint8_t)VU_METER_HEIGHT);
 
   props.invert_ = true;
-  for (int i = 0; i < VU_METER_HEIGHT; i++) {
-    // first need to clear previous drawn bars
-    SetColor(CD_BACKGROUND);
-    DrawString(pos._x, pos._y - i, "  ", props);
 
-    if (i == VU_METER_CLIP_LEVEL) {
-      SetColor(CD_ERROR);
-    } else if (i > VU_METER_WARN_LEVEL) {
-      SetColor(CD_WARN);
-    } else {
-      SetColor(CD_INFO);
-    }
-    if (leftBars > i) {
+  // Left channel: Handle level changes
+  if (forceRedraw || leftBars != prevLeftVU_[vuIndex]) {
+    // If forcing redraw or level changed, redraw the entire meter
+
+    // First clear the entire meter area
+    SetColor(CD_BACKGROUND);
+    for (int i = 0; i < VU_METER_HEIGHT; i++) {
       DrawString(pos._x, pos._y - i, " ", props);
     }
-    if (rightBars > i) {
+
+    // Then draw the active cells
+    for (int i = 0; i < leftBars; i++) {
+      // Set appropriate color based on level
+      if (i == VU_METER_CLIP_LEVEL) {
+        SetColor(CD_ERROR);
+      } else if (i > VU_METER_WARN_LEVEL) {
+        SetColor(CD_WARN);
+      } else {
+        SetColor(CD_INFO);
+      }
+      DrawString(pos._x, pos._y - i, " ", props);
+    }
+  }
+  // If not forcing redraw and leftBars == prevLeftVU_[vuIndex], do nothing for
+  // left channel
+
+  // Right channel: Handle level changes
+  if (forceRedraw || rightBars != prevRightVU_[vuIndex]) {
+    // If forcing redraw or level changed, redraw the entire meter
+
+    // First clear the entire meter area
+    SetColor(CD_BACKGROUND);
+    for (int i = 0; i < VU_METER_HEIGHT; i++) {
+      DrawString(pos._x + 1, pos._y - i, " ", props);
+    }
+
+    // Then draw the active cells
+    for (int i = 0; i < rightBars; i++) {
+      // Set appropriate color based on level
+      if (i == VU_METER_CLIP_LEVEL) {
+        SetColor(CD_ERROR);
+      } else if (i > VU_METER_WARN_LEVEL) {
+        SetColor(CD_WARN);
+      } else {
+        SetColor(CD_INFO);
+      }
       DrawString(pos._x + 1, pos._y - i, " ", props);
     }
   }
+  // If not forcing redraw and rightBars == prevRightVU_[vuIndex], do nothing
+  // for right channel
+
+  // Store the current values for next time
+  prevLeftVU_[vuIndex] = leftBars;
+  prevRightVU_[vuIndex] = rightBars;
+
   props.invert_ = false;
+}
+
+void View::resetVUMeterValues() {
+  for (int i = 0; i <= SONG_CHANNEL_COUNT; i++) {
+    prevLeftVU_[i] = 0;
+    prevRightVU_[i] = 0;
+  }
 }
 
 void View::drawPlayTime(Player *player, GUIPoint pos,

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -163,7 +163,6 @@ protected:
                    GUITextProperties props, int vuIndex,
                    bool forceRedraw = false);
 
-
 public: // temp hack for modl windo constructors
   GUIWindow &w_;
   ViewData *viewData_;

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -156,20 +156,29 @@ protected:
   void drawMap();
   void drawNotes();
   void drawBattery(GUITextProperties &props);
-  void drawMasterVuMeter(Player *player, GUITextProperties props);
+  void drawMasterVuMeter(Player *player, GUITextProperties props,
+                         bool forceRedraw = false);
   void drawPlayTime(Player *player, GUIPoint pos, GUITextProperties &props);
   void drawVUMeter(uint8_t leftBars, uint8_t rightBars, GUIPoint pos,
-                   GUITextProperties props);
+                   GUITextProperties props, int vuIndex,
+                   bool forceRedraw = false);
+  void resetVUMeterValues(); // Reset all VU meter values to 0
 
 public: // temp hack for modl windo constructors
   GUIWindow &w_;
   ViewData *viewData_;
+  bool needsRedraw_;
+  bool isVisible_;
 
-protected:
+  int vuMeterCount_;
   ViewMode viewMode_;
   bool isDirty_; // .Do we need to redraw screeen
   ViewType viewType_;
   bool hasFocus_;
+
+  // Previous VU meter values for optimization (one pair per channel + master)
+  uint8_t prevLeftVU_[SONG_CHANNEL_COUNT + 1];
+  uint8_t prevRightVU_[SONG_CHANNEL_COUNT + 1];
 
 private:
   unsigned short mask_;

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -162,7 +162,7 @@ protected:
   void drawVUMeter(uint8_t leftBars, uint8_t rightBars, GUIPoint pos,
                    GUITextProperties props, int vuIndex,
                    bool forceRedraw = false);
-  void resetVUMeterValues(); // Reset all VU meter values to 0
+
 
 public: // temp hack for modl windo constructors
   GUIWindow &w_;

--- a/sources/Application/Views/MixerView.cpp
+++ b/sources/Application/Views/MixerView.cpp
@@ -70,23 +70,21 @@ void MixerView::ProcessButtonMask(unsigned short mask, bool pressed) {
     if (viewMode_ == VM_MUTEON) {
       if (mask & EPBM_NAV) {
         toggleMute();
-        // Reset VU meter values when toggling mute to force a full redraw
-        resetVUMeterValues();
       }
     };
     if (viewMode_ == VM_SOLOON) {
       if (mask & EPBM_NAV) {
         switchSoloMode();
-        // Reset VU meter values when toggling solo to force a full redraw
-        resetVUMeterValues();
       }
     };
+    // Force a full redraw of the mixer view
+    SetDirty(true);
     return;
   };
 
   viewMode_ = VM_NORMAL;
-  // Reset VU meter values when any button is pressed to force a full redraw
-  resetVUMeterValues();
+  // Force a full redraw of the mixer view when any button is pressed
+  SetDirty(true);
   processNormalButtonMask(mask);
 };
 
@@ -263,8 +261,6 @@ void MixerView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   drawNotes();
 };
 
-
-
 void MixerView::AnimationUpdate() {
   // Update battery gauge and VU meters on every clock tick (~1Hz)
   GUITextProperties props;
@@ -277,7 +273,8 @@ void MixerView::AnimationUpdate() {
 
   // Always update VU meters, whether the sequencer is running or not
   // This ensures we see VU meter updates from MIDI input even when not playing
-  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels = player->GetMixerLevels();
+  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
+      player->GetMixerLevels();
   drawChannelVUMeters(levels, player, props);
   drawMasterVuMeter(player, props);
 

--- a/sources/Application/Views/MixerView.cpp
+++ b/sources/Application/Views/MixerView.cpp
@@ -192,9 +192,9 @@ void MixerView::DrawView() {
   pos._y += VU_METER_HEIGHT - 1; // -1 to align with song grid
   props.invert_ = true;
   // get levels from the player
-  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
-      player->GetMixerLevels();
-  drawChannelVUMeters(levels, player, props);
+  // etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
+  //     player->GetMixerLevels();
+  // drawChannelVUMeters(levels, player, props);
 
   SetColor(CD_NORMAL);
   props.invert_ = false;
@@ -244,10 +244,8 @@ void MixerView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
       player->GetMixerLevels();
 
-  // Always update VU meters, whether we're playing or not
-  // This ensures we see VU meter updates from MIDI input even when not playing
-  drawChannelVUMeters(levels, player, props);
-  drawMasterVuMeter(player, props);
+  // drawing VUmeters needs to happen when sequencer is not running too so see
+  // AnimationUpdate
 
   // Handle play time display
   if (eventType != PET_STOP) {
@@ -273,6 +271,7 @@ void MixerView::AnimationUpdate() {
 
   // Always update VU meters, whether the sequencer is running or not
   // This ensures we see VU meter updates from MIDI input even when not playing
+
   etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
       player->GetMixerLevels();
   drawChannelVUMeters(levels, player, props);

--- a/sources/Application/Views/MixerView.cpp
+++ b/sources/Application/Views/MixerView.cpp
@@ -70,17 +70,23 @@ void MixerView::ProcessButtonMask(unsigned short mask, bool pressed) {
     if (viewMode_ == VM_MUTEON) {
       if (mask & EPBM_NAV) {
         toggleMute();
+        // Reset VU meter values when toggling mute to force a full redraw
+        resetVUMeterValues();
       }
     };
     if (viewMode_ == VM_SOLOON) {
       if (mask & EPBM_NAV) {
         switchSoloMode();
+        // Reset VU meter values when toggling solo to force a full redraw
+        resetVUMeterValues();
       }
     };
     return;
   };
 
   viewMode_ = VM_NORMAL;
+  // Reset VU meter values when any button is pressed to force a full redraw
+  resetVUMeterValues();
   processNormalButtonMask(mask);
 };
 
@@ -233,38 +239,82 @@ void MixerView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   GUIPoint anchor = GetAnchor();
   GUIPoint pos = anchor;
 
-  // get levels from the player
-  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
-      player->GetMixerLevels();
-
   GUITextProperties props;
   SetColor(CD_NORMAL);
 
-  drawChannelVUMeters(levels, player, props);
+  // Get levels from the player
+  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels =
+      player->GetMixerLevels();
 
+  // Always update VU meters, whether we're playing or not
+  // This ensures we see VU meter updates from MIDI input even when not playing
+  drawChannelVUMeters(levels, player, props);
   drawMasterVuMeter(player, props);
 
-  pos = 0;
-  pos._x = 27;
-  pos._y += 1;
+  // Handle play time display
   if (eventType != PET_STOP) {
+    // Draw play time when playing
+    pos = 0;
+    pos._x = 27;
+    pos._y += 1;
     drawPlayTime(player, pos, props);
   }
 
   drawNotes();
 };
 
+
+
 void MixerView::AnimationUpdate() {
-  // redraw batt gauge on every clock tick (~1Hz) even when not playing
-  // and not redrawing due to user cursor navigation
+  // Update battery gauge and VU meters on every clock tick (~1Hz)
   GUITextProperties props;
+
+  // Draw battery gauge
   drawBattery(props);
+
+  // Get the player
+  Player *player = Player::GetInstance();
+
+  // Always update VU meters, whether the sequencer is running or not
+  // This ensures we see VU meter updates from MIDI input even when not playing
+  etl::array<stereosample, SONG_CHANNEL_COUNT> *levels = player->GetMixerLevels();
+  drawChannelVUMeters(levels, player, props);
+  drawMasterVuMeter(player, props);
+
+  // Flush the window to ensure changes are displayed
   w_.Flush();
 };
 
 void MixerView::drawChannelVUMeters(
     etl::array<stereosample, SONG_CHANNEL_COUNT> *levels, Player *player,
-    GUITextProperties props) {
+    GUITextProperties props, bool forceRedraw) {
+
+  // Quick optimization: If not forcing redraw, check if any levels have changed
+  // This saves CPU cycles by avoiding unnecessary drawing operations
+  if (!forceRedraw) {
+    bool anyChanges = false;
+    for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
+      // Convert to dB
+      int leftDb = amplitudeToDb((levels->at(i) >> 16) & 0xFFFF);
+      int rightDb = amplitudeToDb(levels->at(i) & 0xFFFF);
+
+      // Map dB to bar levels
+      int leftBars = std::max(0, std::min(VU_METER_HEIGHT, (leftDb + 60) / 4));
+      int rightBars =
+          std::max(0, std::min(VU_METER_HEIGHT, (rightDb + 60) / 4));
+
+      // Check if this channel's levels have changed
+      if (leftBars != prevLeftVU_[i + 1] || rightBars != prevRightVU_[i + 1]) {
+        anyChanges = true;
+        break;
+      }
+    }
+
+    // If no changes, return early
+    if (!anyChanges) {
+      return;
+    }
+  }
 
   // we start at the bottom of the VU meter and draw it growing upwards
   GUIPoint pos = GetAnchor();
@@ -285,7 +335,8 @@ void MixerView::drawChannelVUMeters(
       rightBars = std::max(0, std::min(VU_METER_HEIGHT, (rightDb + 60) / 4));
     }
 
-    drawVUMeter(leftBars, rightBars, pos, props);
+    // Use index i+1 for channel VU meters (index 0 is reserved for master)
+    drawVUMeter(leftBars, rightBars, pos, props, i + 1, forceRedraw);
     pos._x += CHANNELS_X_OFFSET_;
   }
 }

--- a/sources/Application/Views/MixerView.h
+++ b/sources/Application/Views/MixerView.h
@@ -27,7 +27,8 @@ protected:
 
 private:
   void drawChannelVUMeters(etl::array<stereosample, SONG_CHANNEL_COUNT> *levels,
-                           Player *player, GUITextProperties props);
+                           Player *player, GUITextProperties props,
+                           bool forceRedraw = false);
   const char *song_;
   int saveX_;
   int saveY_;

--- a/sources/Services/Audio/AudioMixer.cpp
+++ b/sources/Services/Audio/AudioMixer.cpp
@@ -80,7 +80,7 @@ bool AudioMixer::Render(fixed *buffer, int samplecount) {
       }
     }
   }
-  
+
   // Always update avgMixerLevel_ regardless of whether we got data
   // This ensures VU meters update properly in all scenarios
   avgMixerLevel_ = fp2i(peakL) << 16;

--- a/sources/Services/Audio/AudioMixer.cpp
+++ b/sources/Services/Audio/AudioMixer.cpp
@@ -79,9 +79,12 @@ bool AudioMixer::Render(fixed *buffer, int samplecount) {
         }
       }
     }
-    avgMixerLevel_ = fp2i(peakL) << 16;
-    avgMixerLevel_ += fp2i(peakR);
   }
+  
+  // Always update avgMixerLevel_ regardless of whether we got data
+  // This ensures VU meters update properly in all scenarios
+  avgMixerLevel_ = fp2i(peakL) << 16;
+  avgMixerLevel_ += fp2i(peakR);
 
   if (enableRendering_ && writer_) {
     if (!gotData) {

--- a/sources/UIFramework/SimpleBaseClasses/EventManager.h
+++ b/sources/UIFramework/SimpleBaseClasses/EventManager.h
@@ -11,6 +11,9 @@
 
 #include <string>
 
+#define PICO_CLOCK_INTERVAL 40 // ~25Hz
+#define PICO_CLOCK_HZ (1000 / PICO_CLOCK_INTERVAL)
+
 enum AppButton {
   APP_BUTTON_PLAY,
   APP_BUTTON_VOLINC,


### PR DESCRIPTION
This improves performance of vumeter drawing up to a point as without vsync we can't really prevent tearing.
It also fixes vumeters to updated when the sequencer is not running for example with midi input or possible other reasons that may be introduced in the future.

This also add "inertia" to the vumeters, giving a pleasing "slower fall off" when volume levels drop suddenly (eg. when playback stops).

Fixes: #454