### PR TITLE
Separate preview volume

### DIFF
--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -194,13 +194,13 @@ bool AudioFileStreamer::Render(fixed *buffer, int samplecount) {
   // Get preview volume from project
   Variable *v = project_->FindVariable(FourCC::VarPreviewVolume);
   int previewVol = v->GetInt();
-  
+
   // Apply logarithmic scaling to match human hearing perception
-  // Using a formula that gives a more natural volume curve: volume = (value/100)^2
-  // This gives more fine control at lower volumes
+  // Using a formula that gives a more natural volume curve: volume =
+  // (value/100)^2 This gives more fine control at lower volumes
   float normalizedVol = (float)previewVol / 100.0f;
   float logVol = normalizedVol * normalizedVol; // Quadratic curve
-  
+
   // Convert to fixed point
   fixed volume = fl2fp(logVol);
 

--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -156,10 +156,10 @@ bool AudioFileStreamer::Render(fixed *buffer, int samplecount) {
           // Copy this chunk to our static buffer
           int bytesToCopy = chunkSize * channels * sizeof(short);
           memcpy(destPos, srcBuffer, bytesToCopy);
-
-          Trace::Debug("Loaded chunk of single cycle waveform: pos=%d, size=%d "
-                       "(%d bytes)",
-                       currentPos, chunkSize, bytesToCopy);
+          // Trace::Debug("Loaded chunk of single cycle waveform: pos=%d,
+          // size=%d "
+          //              "(%d bytes)",
+          //              currentPos, chunkSize, bytesToCopy);
         } else {
           Trace::Error("Failed to get sample buffer for chunk at position %d",
                        currentPos);

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -20,12 +20,14 @@ Project::Project(const char *name)
     : Persistent("PROJECT"), VariableContainer(&variables_), song_(),
       tempoNudge_(0), tempo_(FourCC::VarTempo, DEFAULT_TEMPO),
       masterVolume_(FourCC::VarMasterVolume, 100),
+      previewVolume_(FourCC::VarPreviewVolume, 50),
       wrap_(FourCC::VarWrap, false), transpose_(FourCC::VarTranspose, 0),
       scale_(FourCC::VarScale, scaleNames, numScales, 0),
       projectName_(FourCC::VarProjectName, name) {
 
   this->variables_.insert(variables_.end(), &tempo_);
   this->variables_.insert(variables_.end(), &masterVolume_);
+  this->variables_.insert(variables_.end(), &previewVolume_);
   this->variables_.insert(variables_.end(), &wrap_);
   this->variables_.insert(variables_.end(), &transpose_);
   this->variables_.insert(variables_.end(), &scale_);
@@ -67,6 +69,12 @@ int Project::GetTempo() {
 
 int Project::GetMasterVolume() {
   Variable *v = FindVariable(FourCC::VarMasterVolume);
+  NAssert(v);
+  return v->GetInt();
+};
+
+int Project::GetPreviewVolume() {
+  Variable *v = FindVariable(FourCC::VarPreviewVolume);
   NAssert(v);
   return v->GetInt();
 };

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -30,6 +30,7 @@ public:
   Song song_;
 
   int GetMasterVolume();
+  int GetPreviewVolume();
   bool Wrap();
   void OnTempoTap();
   void NudgeTempo(int value);
@@ -53,7 +54,7 @@ public:
   static etl::string<MAX_PROJECT_NAME_LENGTH> ProjectNameGlobal;
 
 private:
-  etl::list<Variable *, 6> variables_;
+  etl::list<Variable *, 7> variables_;
 
   InstrumentBank *instrumentBank_;
   int tempoNudge_;
@@ -64,6 +65,7 @@ private:
   // variables
   WatchedVariable tempo_;
   Variable masterVolume_;
+  Variable previewVolume_;
   Variable wrap_;
   Variable transpose_;
   Variable scale_;

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -358,19 +358,6 @@ void ImportView::adjustPreviewVolume(bool increase) {
 
   // Mark the view as dirty to update the status bar with the new volume
   isDirty_ = true;
-
-  // If currently previewing, restart the preview to apply the new volume
-  if (Player::GetInstance()->IsPlaying() &&
-      previewPlayingIndex_ != (size_t)-1) {
-    // Get the currently playing file name
-    auto fs = FileSystem::GetInstance();
-    char name[PFILENAME_SIZE];
-    unsigned fileIndex = fileIndexList_[previewPlayingIndex_];
-    fs->getFileName(fileIndex, name, PFILENAME_SIZE);
-
-    // Restart the preview with the new volume
-    preview(name);
-  }
 }
 
 void ImportView::setCurrentFolder(FileSystem *fs, const char *name) {

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -36,7 +36,7 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
       }
       return;
     }
-    
+
     // Check if edit key was released
     if (editKeyHeld_ && !(mask & EPBM_EDIT)) {
       // Edit key no longer pressed, redraw the view to clear status message
@@ -66,12 +66,12 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
       }
       return; // We've handled the play button, so return
     }
-    
+
     // Handle EDIT+UP and EDIT+DOWN for preview volume adjustment
     if (mask & EPBM_EDIT) {
       // Set flag to track that edit key is being held
       editKeyHeld_ = true;
-      
+
       if (mask & EPBM_UP) {
         // EDIT+UP: Increase preview volume
         adjustPreviewVolume(true);
@@ -326,41 +326,42 @@ void ImportView::import(char *name) {
 void ImportView::adjustPreviewVolume(bool increase) {
   // Get the project instance
   Project *project = viewData_->project_;
-  
+
   // Find the preview volume variable
   Variable *v = project->FindVariable(FourCC::VarPreviewVolume);
   if (!v) {
     Status::Set("Preview volume setting not found");
     return;
   }
-  
+
   // Get current value
   int currentVolume = v->GetInt();
-  
+
   // Calculate new value (increase or decrease by 5)
   int step = 5;
   int newVolume = increase ? currentVolume + step : currentVolume - step;
-  
+
   // Clamp to valid range (0-100)
   newVolume = newVolume > 100 ? 100 : newVolume;
   newVolume = newVolume < 0 ? 0 : newVolume;
-  
+
   // Set the new value
   v->SetInt(newVolume);
-  
+
   // Display status message showing the new volume
   char statusMsg[32];
   snprintf(statusMsg, sizeof(statusMsg), "Preview volume: %d%%", newVolume);
   Status::Set(statusMsg);
-  
+
   // If currently previewing, restart the preview to apply the new volume
-  if (Player::GetInstance()->IsPlaying() && previewPlayingIndex_ != (size_t)-1) {
+  if (Player::GetInstance()->IsPlaying() &&
+      previewPlayingIndex_ != (size_t)-1) {
     // Get the currently playing file name
     auto fs = FileSystem::GetInstance();
     char name[PFILENAME_SIZE];
     unsigned fileIndex = fileIndexList_[previewPlayingIndex_];
     fs->getFileName(fileIndex, name, PFILENAME_SIZE);
-    
+
     // Restart the preview with the new volume
     preview(name);
   }

--- a/sources/Application/Views/ImportView.h
+++ b/sources/Application/Views/ImportView.h
@@ -21,6 +21,7 @@ protected:
   void warpToNextSample(bool goUp);
   void import(char *name);
   void preview(char *name);
+  void adjustPreviewVolume(bool increase);
 
 private:
   size_t topIndex_ = 0;
@@ -30,6 +31,8 @@ private:
   int toInstr_ = 0;
   bool playKeyHeld_ =
       false; // Flag to track when the play key is being held down
+  bool editKeyHeld_ =
+      false; // Flag to track when the edit key is being held down
   bool inProjectSampleDir_ =
       false; // Flag to track if we're in the project's sample directory
   etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexList_;

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -112,8 +112,14 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   v = project_->FindVariable(FourCC::VarMasterVolume);
   position._y += 1;
   UIIntVarField *f1 =
-      new UIIntVarField(position, *v, "master: %d", 10, 200, 1, 10);
+      new UIIntVarField(position, *v, "master vol:  %d", 10, 200, 1, 10);
   fieldList_.insert(fieldList_.end(), f1);
+
+  v = project_->FindVariable(FourCC::VarPreviewVolume);
+  position._y += 1;
+  UIIntVarField *f1b =
+      new UIIntVarField(position, *v, "preview vol: %d", 0, 100, 1, 10);
+  fieldList_.insert(fieldList_.end(), f1b);
 
   v = project_->FindVariable(FourCC::VarTranspose);
   position._y += 1;

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -115,12 +115,6 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
       new UIIntVarField(position, *v, "master vol:  %d", 10, 200, 1, 10);
   fieldList_.insert(fieldList_.end(), f1);
 
-  v = project_->FindVariable(FourCC::VarPreviewVolume);
-  position._y += 1;
-  UIIntVarField *f1b =
-      new UIIntVarField(position, *v, "preview vol: %d", 0, 100, 1, 10);
-  fieldList_.insert(fieldList_.end(), f1b);
-
   v = project_->FindVariable(FourCC::VarTranspose);
   position._y += 1;
   UIIntVarField *f2 =

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -134,6 +134,7 @@ struct FourCC {
 
     VarTempo = 33,
     VarMasterVolume = 41,
+    VarPreviewVolume = 161,
     VarWrap = 70,
     VarTranspose = 63,
     VarScale = 16,
@@ -179,6 +180,7 @@ struct FourCC {
     // 158 is taken for VarMajorBeatColor
     // 159 is taken for ActionShowTheme
     // 160 is taken for MidiInstrumentProgram
+    // 161 is taken for VarPreviewVolume
 
     VarInstrumentType = 113,
 
@@ -330,6 +332,7 @@ struct FourCC {
   ETL_ENUM_TYPE(VarMajorBeatColor, "MAJORBEATCOLOR")
   ETL_ENUM_TYPE(VarTempo, "tempo")
   ETL_ENUM_TYPE(VarMasterVolume, "master")
+  ETL_ENUM_TYPE(VarPreviewVolume, "preview")
   ETL_ENUM_TYPE(VarWrap, "wrap")
   ETL_ENUM_TYPE(VarTranspose, "transpose")
   ETL_ENUM_TYPE(VarScale, "scale")

--- a/usermanual/content/pages/instruments.md
+++ b/usermanual/content/pages/instruments.md
@@ -84,7 +84,7 @@ The Import View includes a convenient way to adjust the volume when previewing s
 - **EDIT + UP**: Increase preview volume by 5%
 - **EDIT + DOWN**: Decrease preview volume by 5%
 
-While holding the EDIT key, the current preview volume level (0-100%) will be displayed in the onscreen. When you release the EDIT key, the file listing will be shown again.
+The current preview volume is always displayed in the status bar at the bottom of the screen as "vol:XX%" alongside the file size information. 
 
 The preview volume uses a non-linear (quadratic) scale that provides more precise control at lower volumes, making it easier to fine-tune quiet previews. This setting is saved with your project and will be restored when you reload it.
 

--- a/usermanual/content/pages/instruments.md
+++ b/usermanual/content/pages/instruments.md
@@ -63,7 +63,7 @@ You can enter the sample import file browser by hitting `EDIT EDIT` (press the `
 
 All the samples that you may want to import into a project **must** be located in a folder named `/samples` at the top-level of the sdcard. You can either put your samples in that directory or in sub-directories of it, allowing you to have a way of sorting your samples library.
 
-_In firmware version 2.1_ the restriction on placing sample files *only* in the `/samples` directory has been removed and samples can be browsed and imported from any directory. 
+The previous restriction on placing sample files *only* in the `/samples` directory has been removed and samples can be browsed and imported from any directory. 
 
 Note: sub-directories will be sorted before files, but otherwise the files will be listed in an unspecified order (ie. not necessarily alphabetical order).
 
@@ -73,9 +73,20 @@ For example:
 
 When entering the import file browser, the current folder is the library root folder `/samples`. All samples (`.wav` files) in that folder are listed.
 
-Use the `UP` and `DOWN` arrow keys to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press `EDIT` to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entery and pressing `ENTER`. Press `PLAY` to audition the currently selected sample wave file. To import the currently selected wave file press `ALT`+`PLAY`. 
+Use the `UP` and `DOWN` arrow keys to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press `EDIT` to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entery and pressing `ENTER`. Hold down `PLAY` to audition the currently selected sample wave file. To import the currently selected wave file press `ALT`+`PLAY`. 
 
 At any time, you can return to the instrument screen from the sample file browser by pressing `NAV`+`LEFT`.
+
+### Auditioning Volume Control
+
+The Import View includes a convenient way to adjust the volume when previewing samples:
+
+- **EDIT + UP**: Increase preview volume by 5%
+- **EDIT + DOWN**: Decrease preview volume by 5%
+
+While holding the EDIT key, the current preview volume level (0-100%) will be displayed in the onscreen. When you release the EDIT key, the file listing will be shown again.
+
+The preview volume uses a non-linear (quadratic) scale that provides more precise control at lower volumes, making it easier to fine-tune quiet previews. This setting is saved with your project and will be restored when you reload it.
 
 *Note:* While there is no fixed limit for the number of sub-directory levels, there is a maximum of **256** files per directory. Also please note that while FAT formatted sdcards can support upto *256* characters per filename, picoTracker only supports upto **128** character file names and only with **ASCII** characters.
 

--- a/usermanual/content/pages/keypadcombos.md
+++ b/usermanual/content/pages/keypadcombos.md
@@ -28,7 +28,7 @@ The `NAV` (`[]`) and `ALT` keys are modifier keys for the `ENTER`, `EDIT` and `A
   - `ENTER+UP/DOWN`: +/- 0x10.
   - `ENTER`+`RIGHT`/`LEFT`: +/- 1.
 - `EDIT`+`ARROWS`: Rapid Navigation.
-- `EDIT`+`UP`/`DOWN`: Page up/down in Song Screen, Next/Previous Phrase in Current Chain in Phrase Screen. Navigation +/- 0x10 in Instrument/Table Screen.
+- `EDIT`+`UP`/`DOWN`: Page up/down in Song Screen, Next/Previous Phrase in Current Chain in Phrase Screen. Navigation +/- 0x10 in Instrument/Table Screen. In Import Screen, adjusts preview volume up/down.
 - `EDIT`+`LEFT`/`RIGHT`: Next/Previous Channel in Chain/Phrase Screen. Navigation +/- 1 in Instrument/Table Screen. Switch between Song and Live Modes in Song Screen.
 - `NAV`+`ARROWS`: Navigate between the Screens.
 - `ALT`+`UP`/`DOWN`: Jump up/down to next populated row after a blank row (great for live mode entire row queuing!)


### PR DESCRIPTION
This provides for a separate volume setting for sample preview volume and provides a UI for adjusting it on the import screen using `ENTER+UP/DOWN`

Fixes: #487