### PR TITLE
Use log scale for master vol, allow max of 0dB

### DIFF
--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -108,8 +108,22 @@ void MixerService::Update(Observable &o, I_ObservableData *d) {
 }
 
 void MixerService::SetMasterVolume(int vol) {
-  fixed masterVolume = fp_mul(i2fp(vol), fl2fp(0.01f));
-
+  // Apply logarithmic scaling for better volume control
+  // vol is 0-100, where 100 is unity gain (1.0)
+  // Using a quadratic curve: (vol/100)^2 gives a more natural volume perception
+  
+  // Ensure vol is within valid range
+  if (vol < 0) vol = 0;
+  if (vol > 100) vol = 100;
+  
+  // Convert to fixed point (0-1 range)
+  fixed normalizedVol = fp_mul(i2fp(vol), fl2fp(0.01f));
+  
+  // Apply quadratic curve for logarithmic-like scaling
+  // This gives better control at lower volumes
+  fixed masterVolume = fp_mul(normalizedVol, normalizedVol);
+  
+  // Set the volume for all channels
   for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
     bus_[i].SetVolume(masterVolume);
   }

--- a/sources/Application/Mixer/MixerService.cpp
+++ b/sources/Application/Mixer/MixerService.cpp
@@ -111,18 +111,20 @@ void MixerService::SetMasterVolume(int vol) {
   // Apply logarithmic scaling for better volume control
   // vol is 0-100, where 100 is unity gain (1.0)
   // Using a quadratic curve: (vol/100)^2 gives a more natural volume perception
-  
+
   // Ensure vol is within valid range
-  if (vol < 0) vol = 0;
-  if (vol > 100) vol = 100;
-  
+  if (vol < 0)
+    vol = 0;
+  if (vol > 100)
+    vol = 100;
+
   // Convert to fixed point (0-1 range)
   fixed normalizedVol = fp_mul(i2fp(vol), fl2fp(0.01f));
-  
+
   // Apply quadratic curve for logarithmic-like scaling
   // This gives better control at lower volumes
   fixed masterVolume = fp_mul(normalizedVol, normalizedVol);
-  
+
   // Set the volume for all channels
   for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
     bus_[i].SetVolume(masterVolume);

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -112,7 +112,7 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   v = project_->FindVariable(FourCC::VarMasterVolume);
   position._y += 1;
   UIIntVarField *f1 =
-      new UIIntVarField(position, *v, "master vol: %d%%", 0, 100, 1, 10);
+      new UIIntVarField(position, *v, "master vol: %d%%", 0, 100, 1, 5);
   fieldList_.insert(fieldList_.end(), f1);
 
   v = project_->FindVariable(FourCC::VarTranspose);

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -112,7 +112,7 @@ ProjectView::ProjectView(GUIWindow &w, ViewData *data) : FieldView(w, data) {
   v = project_->FindVariable(FourCC::VarMasterVolume);
   position._y += 1;
   UIIntVarField *f1 =
-      new UIIntVarField(position, *v, "master: %d", 10, 200, 1, 10);
+      new UIIntVarField(position, *v, "master vol: %d%%", 0, 100, 1, 10);
   fieldList_.insert(fieldList_.end(), f1);
 
   v = project_->FindVariable(FourCC::VarTranspose);


### PR DESCRIPTION
This limits the master volume to now be a maxium of unity gain (0dB), displays as a percentage, allows to go down to 0% and changes the label slightly to read `master vol:`

Fixes: #453