### PR TITLE
Fix check for modified instruments

### DIFF
--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -26,7 +26,9 @@ public:
   virtual void OnFocus();
   virtual void AnimationUpdate();
   void onInstrumentTypeChange();
-  void clearInstrumentModified() { instrumentModified_ = false; }
+
+  bool checkInstrumentModified();
+  void resetInstrumentToDefaults();
 
 protected:
   void warpToNext(int offset);
@@ -48,7 +50,6 @@ private:
   FourCC lastFocusID_;
   WatchedVariable instrumentType_;
   InstrumentType currentType_ = IT_NONE;
-  bool instrumentModified_ = false;
 
   // Variables for export confirmation dialog
   I_Instrument *exportInstrument_ = nullptr;

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -26,6 +26,7 @@ public:
   virtual void OnFocus();
   virtual void AnimationUpdate();
   void onInstrumentTypeChange();
+  void applyProposedTypeChange();
 
   bool checkInstrumentModified();
   void resetInstrumentToDefaults();
@@ -50,6 +51,9 @@ private:
   FourCC lastFocusID_;
   WatchedVariable instrumentType_;
   InstrumentType currentType_ = IT_NONE;
+
+  // Store the proposed instrument type when changing types
+  InstrumentType proposedType_ = IT_NONE;
 
   // Variables for export confirmation dialog
   I_Instrument *exportInstrument_ = nullptr;

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -275,3 +275,21 @@ void Variable::setStringValue(const char *value) {
   }
   stringValue_ = new etl::string<MAX_VARIABLE_STRING_LENGTH>(value);
 }
+
+bool Variable::IsModified() {
+  switch (type_) {
+  case FLOAT:
+    return value_.float_ != defaultValue_.float_;
+  case INT:
+    return value_.int_ != defaultValue_.int_;
+  case BOOL:
+    return value_.bool_ != defaultValue_.bool_;
+  case CHAR_LIST:
+    return value_.index_ != defaultValue_.index_;
+  case STRING:
+    // For string types, we don't currently track default values
+    // Could be enhanced in the future if needed
+    return true;
+  }
+  return false;
+}

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -287,9 +287,8 @@ bool Variable::IsModified() {
   case CHAR_LIST:
     return value_.index_ != defaultValue_.index_;
   case STRING:
-    // For string types, we don't currently track default values
-    // Could be enhanced in the future if needed
-    return true;
+    // For string types, just compare against empty string
+    return (stringValue_ != nullptr) && (stringValue_->size() > 0);
   }
   return false;
 }

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -40,6 +40,9 @@ public:
   uint8_t GetListSize();
   const char *const *GetListPointer();
   void Reset();
+  
+  // Check if the current value differs from the default value
+  bool IsModified();
 
 protected:
   virtual void onChange(){};

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -40,7 +40,7 @@ public:
   uint8_t GetListSize();
   const char *const *GetListPointer();
   void Reset();
-  
+
   // Check if the current value differs from the default value
   bool IsModified();
 


### PR DESCRIPTION
This fixes the check that happens before an instrument type change by the user is attempted to see if the instrument has been modified, because if it has the user is first prompted to confirm the change and potentially lose changes.

Also fixes a bug which was changing the instrument type name field even if the user didn't confirm the instrument type change.

Finally we also have the functionality in place now to reset instruments back to default settings if we choose to have a keycombo for this in the future.

Fixes: #458