### PR TITLE
Some clock rates cause crash on boot

### DIFF
--- a/sources/UIFramework/SimpleBaseClasses/EventManager.h
+++ b/sources/UIFramework/SimpleBaseClasses/EventManager.h
@@ -11,7 +11,7 @@
 
 #include <string>
 
-#define PICO_CLOCK_INTERVAL 40 // ~25Hz
+#define PICO_CLOCK_INTERVAL 20 // ~50Hz
 #define PICO_CLOCK_HZ (1000 / PICO_CLOCK_INTERVAL)
 
 enum AppButton {


### PR DESCRIPTION
Unclear why but some tick rates like 25, 33 hz cause crash on boot
while other slower or even faster rates like 50hz work fine