### PR TITLE
Fix instrument import, export regressions

### DIFF
--- a/sources/Application/Instruments/I_Instrument.cpp
+++ b/sources/Application/Instruments/I_Instrument.cpp
@@ -1,4 +1,5 @@
 #include "I_Instrument.h"
+#include "../Model/Project.h"
 #include "Application/Utils/char.h"
 #include "System/Console/Trace.h"
 
@@ -7,6 +8,8 @@ I_Instrument::~I_Instrument() {
 }
 
 void I_Instrument::SaveContent(tinyxml2::XMLPrinter *printer) {
+  // Add firmware version information
+  printer->PushAttribute("VERSION", PROJECT_NUMBER);
   // Save the instrument type
   printer->PushAttribute("TYPE", InstrumentTypeNames[GetType()]);
 

--- a/sources/Application/Persistency/PersistencyService.cpp
+++ b/sources/Application/Persistency/PersistencyService.cpp
@@ -1,6 +1,6 @@
 #include "PersistencyService.h"
 #include "../Instruments/SamplePool.h"
-#include "../Model/Project.h"
+
 #include "Foundation/Types/Types.h"
 #include "Persistent.h"
 #include "System/Console/Trace.h"
@@ -287,17 +287,8 @@ PersistencyResult PersistencyService::ExportInstrument(
 
   tinyxml2::XMLPrinter printer(fp);
 
-  // Open root element for the instrument file
-  printer.OpenElement("INSTRUMENT");
-
-  // Add firmware version information
-  printer.PushAttribute("VERSION", PROJECT_NUMBER);
-
   // Use the instrument's Persistent interface to save its data
   instrument->Save(&printer);
-
-  // Close the root element
-  printer.CloseElement();
 
   fp->Close();
   return PERSIST_SAVED;

--- a/sources/Application/Views/InstrumentImportView.cpp
+++ b/sources/Application/Views/InstrumentImportView.cpp
@@ -268,8 +268,16 @@ void InstrumentImportView::importInstrument(char *name) {
 
     // Show success message and return to instrument view
     MessageBox *mb = new MessageBox(*this, "Import successful", MBBF_OK);
-    DoModal(mb, [](View &v, ModalView &dialog) {
+    DoModal(mb, [this, instrument](View &v, ModalView &dialog) {
       if (dialog.GetReturnCode() == MBL_OK) {
+        // Log that we're about to switch back to the instrument view
+        Trace::Log("INSTRUMENTIMPORT",
+                   "Switching back to instrument view with ID: %d", toInstrID_);
+
+        // Force another notification to ensure the UI updates when we return
+        instrument->SetChanged();
+        instrument->NotifyObservers();
+
         // Switch back to the instrument view
         ViewType vt = VT_INSTRUMENT;
         ViewEvent ve(VET_SWITCH_VIEW, &vt);


### PR DESCRIPTION
Fixes handling import/export action field event handling.

This also fixes regression that occurred in a prev change to add firmware version property that ended up creating a new seond top-level element.  Instead we fix here to just add that prop to the instrument element that already gets created by I_Instrument::SaveContent()

NOTE: this is stacked on prev PR as it relies on changes made there for dialog callback functions being std::function.

Fixes: #556