### PR TITLE
Fix sample start and end points

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -348,18 +348,21 @@ void InstrumentView::fillSampleParameters() {
     // If slices are enabled, we still allow editing the full range
     // The actual slice boundaries will be enforced during playback
   }
-  bigHexVarField_.emplace_back(position, *v, 7, "start: %7.7X", 0, maxStartValue, 16);
+  bigHexVarField_.emplace_back(position, *v, 7, "start: %7.7X", 0,
+                               maxStartValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentLoopStart);
-  // Calculate max value for loop start field - use full sample size if no slices
+  // Calculate max value for loop start field - use full sample size if no
+  // slices
   int maxLoopStartValue = instrument->GetSampleSize() - 1;
   if (s->GetInt() > 0) {
     // If slices are enabled, we still allow editing the full range
     // The actual slice boundaries will be enforced during playback
   }
-  bigHexVarField_.emplace_back(position, *v, 7, "loop start: %7.7X", 0, maxLoopStartValue, 16);
+  bigHexVarField_.emplace_back(position, *v, 7, "loop start: %7.7X", 0,
+                               maxLoopStartValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   position._y += 1;
@@ -370,7 +373,8 @@ void InstrumentView::fillSampleParameters() {
     // If slices are enabled, we still allow editing the full range
     // The actual slice boundaries will be enforced during playback
   }
-  bigHexVarField_.emplace_back(position, *v, 7, "loop end: %7.7X", 0, maxLoopEndValue, 16);
+  bigHexVarField_.emplace_back(position, *v, 7, "loop end: %7.7X", 0,
+                               maxLoopEndValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   v = instrument->FindVariable(FourCC::SampleInstrumentTableAutomation);

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -342,23 +342,35 @@ void InstrumentView::fillSampleParameters() {
 
   position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentStart);
-  bigHexVarField_.emplace_back(position, *v, 7, "start: %7.7X", 0,
-                               (instrument->GetSampleSize() / s->GetInt()) - 1,
-                               16);
+  // Calculate max value for start field - use full sample size if no slices
+  int maxStartValue = instrument->GetSampleSize() - 1;
+  if (s->GetInt() > 0) {
+    // If slices are enabled, we still allow editing the full range
+    // The actual slice boundaries will be enforced during playback
+  }
+  bigHexVarField_.emplace_back(position, *v, 7, "start: %7.7X", 0, maxStartValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentLoopStart);
-  bigHexVarField_.emplace_back(position, *v, 7, "loop start: %7.7X", 0,
-                               (instrument->GetSampleSize() / s->GetInt()) - 1,
-                               16);
+  // Calculate max value for loop start field - use full sample size if no slices
+  int maxLoopStartValue = instrument->GetSampleSize() - 1;
+  if (s->GetInt() > 0) {
+    // If slices are enabled, we still allow editing the full range
+    // The actual slice boundaries will be enforced during playback
+  }
+  bigHexVarField_.emplace_back(position, *v, 7, "loop start: %7.7X", 0, maxLoopStartValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentEnd);
-  bigHexVarField_.emplace_back(position, *v, 7, "loop end: %7.7X", 0,
-                               (instrument->GetSampleSize() / s->GetInt()) - 1,
-                               16);
+  // Calculate max value for loop end field - use full sample size if no slices
+  int maxLoopEndValue = instrument->GetSampleSize() - 1;
+  if (s->GetInt() > 0) {
+    // If slices are enabled, we still allow editing the full range
+    // The actual slice boundaries will be enforced during playback
+  }
+  bigHexVarField_.emplace_back(position, *v, 7, "loop end: %7.7X", 0, maxLoopEndValue, 16);
   fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
 
   v = instrument->FindVariable(FourCC::SampleInstrumentTableAutomation);


### PR DESCRIPTION
This also changes previous behaviour to now apply the start and end points to create the "effective" part of the sample that is sliced when slices are used.

**Note:** It can be difficult to test this PR as  you need to be aware that #567 at the moment causes fields to not correctly update when moving to/from the phrase screen on projects with more than 1 instrument.

Fixes: #556