### PR TITLE
Add tick counter to AnimationUpdate, use for batt

### DIFF
--- a/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerEventManager.cpp
@@ -46,7 +46,7 @@ bool timerHandler(repeating_timer_t *rt) {
   queue = picoTrackerEventQueue::GetInstance();
   gTime_++;
 
-  // send a clock (PICO_CLOCK)
+  // send a clock (PICO_CLOCK) with the current tick value
   if (gTime_ % PICO_CLOCK_INTERVAL == 0) {
     queue->push(picoTrackerEvent(PICO_CLOCK));
   }

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.cpp
@@ -34,7 +34,9 @@ static GUIEventPadButtonType eventMappingPico[10] = {
 
 static GUIEventPadButtonType *eventMapping = eventMappingPico;
 
-picoTrackerGUIWindowImp *instance_;
+// Initialize static members
+picoTrackerGUIWindowImp *picoTrackerGUIWindowImp::instance_ = NULL;
+uint32_t picoTrackerGUIWindowImp::tickCounter_ = 0;
 
 picoTrackerGUIWindowImp::picoTrackerGUIWindowImp(GUICreateWindowParams &p) {
   mode0_init();
@@ -196,7 +198,7 @@ void picoTrackerGUIWindowImp::ProcessEvent(picoTrackerEvent &event) {
     instance_->_window->Update(false);
     break;
   case PICO_CLOCK:
-    instance_->_window->ClockTick();
+    instance_->_window->ClockTick(instance_->tickCounter_++);
     break;
   case LAST:
     break;

--- a/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.h
+++ b/sources/Adapters/picoTracker/gui/picoTrackerGUIWindowImp.h
@@ -31,6 +31,8 @@ public: // I_GUIWindowImp implementation
   static void ProcessEvent(picoTrackerEvent &event);
   static void ProcessButtonChange(uint16_t changeMask, uint16_t buttonMask);
 
+  static picoTrackerGUIWindowImp* instance_;
+
 protected:
   static mode0_color_t GetColor(GUIColor &c);
 
@@ -39,5 +41,6 @@ protected:
 private:
   void SendFont(uint8_t uifontIndex);
   bool remoteUIEnabled_ = 0;
+  static uint32_t tickCounter_;
 };
 #endif

--- a/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerEventQueue.h
@@ -10,6 +10,7 @@ class picoTrackerEvent {
 public:
   picoTrackerEvent(picoTrackerEventType type) : type_(type) {}
   picoTrackerEventType type_;
+  unsigned long tick_;
 };
 
 inline bool operator==(const picoTrackerEvent &lhs,

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -593,12 +593,12 @@ void AppWindow::onUpdate(bool redraw) {
   Flush();
 };
 
-void AppWindow::AnimationUpdate() {
+void AppWindow::AnimationUpdate(unsigned long tick) {
   if (loadProject_) {
     LoadProject(projectName_);
     loadProject_ = false;
   }
-  _currentView->AnimationUpdate();
+  _currentView->AnimationUpdate(tick);
 
   // *attempt* to auto save every AUTOSAVE_INTERVAL_IN_SECONDS
   // will return false if auto save was unsuccessful because eg. the sequencer

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -67,7 +67,7 @@ protected: // GUIWindow implementation
   virtual void LayoutChildren();
   virtual void Flush();
   virtual void Redraw();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
   // override draw string to avoid going too far off
   // the screen.

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -10,6 +10,7 @@
 bool View::initPrivate_ = false;
 
 int View::margin_ = 0;
+uint8_t View::animationFrameCounter_ = 0;
 int View::songRowCount_; //=21 ;
 
 View::View(GUIWindow &w, ViewData *viewData)
@@ -17,7 +18,7 @@ View::View(GUIWindow &w, ViewData *viewData)
   if (!initPrivate_) {
     View::margin_ = 0;
     songRowCount_ = 16;
-
+    animationFrameCounter_ = 0;
     initPrivate_ = true;
   }
   mask_ = 0;

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -109,7 +109,7 @@ public:
   virtual void DrawView() = 0;
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick) = 0;
   virtual void OnFocus() = 0;
-  virtual void AnimationUpdate() = 0;
+  virtual void AnimationUpdate(unsigned long tick) = 0;
 
   void SetDirty(bool dirty);
 
@@ -190,6 +190,9 @@ private:
 public:
   static int margin_;
   static int songRowCount_;
+  
+  // Counter for animation frames (used for 1Hz battery updates at 50fps)
+  static uint8_t animationFrameCounter_;
 };
 
 #endif

--- a/sources/Application/Views/ChainView.cpp
+++ b/sources/Application/Views/ChainView.cpp
@@ -743,7 +743,7 @@ void ChainView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   needsUIUpdate_ = true;
 };
 
-void ChainView::AnimationUpdate() {
+void ChainView::AnimationUpdate(unsigned long tick) {
   // First call the parent class implementation to draw the battery gauge
   GUITextProperties props;
   drawBattery(props);

--- a/sources/Application/Views/ChainView.h
+++ b/sources/Application/Views/ChainView.h
@@ -12,7 +12,7 @@ public:
   virtual void DrawView();
   virtual void OnFocus();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 protected:
   void updateCursor(int dx, int dy);

--- a/sources/Application/Views/ConsoleView.h
+++ b/sources/Application/Views/ConsoleView.h
@@ -18,7 +18,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus(){};
-  virtual void AnimationUpdate(){};
+  virtual void AnimationUpdate(unsigned long tick){};
 
   // Trace Implementation
 

--- a/sources/Application/Views/DeviceView.cpp
+++ b/sources/Application/Views/DeviceView.cpp
@@ -176,7 +176,7 @@ void DeviceView::addSwatchField(ColorDefinition color, GUIPoint position) {
   fieldList_.insert(fieldList_.end(), &(*swatchField_.rbegin()));
 }
 
-void DeviceView::AnimationUpdate() {
+void DeviceView::AnimationUpdate(unsigned long tick) {
   // redraw batt gauge on every clock tick (~1Hz) even when not playing
   // and not redrawing due to user cursor navigation
   GUITextProperties props;

--- a/sources/Application/Views/DeviceView.h
+++ b/sources/Application/Views/DeviceView.h
@@ -18,7 +18,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus(){};
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
   // Observer for action callback
 

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -1108,7 +1108,7 @@ void InstrumentView::handleInstrumentExport() {
   }
 }
 
-void InstrumentView::AnimationUpdate() {
+void InstrumentView::AnimationUpdate(unsigned long tick) {
   // redraw batt gauge on every clock tick (~1Hz) even when not playing
   // and not redrawing due to user cursor navigation
   GUITextProperties props;

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -24,7 +24,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
   void onInstrumentTypeChange(bool updateUI = false);
   bool checkInstrumentModified();
   void resetInstrumentToDefaults();

--- a/sources/Application/Views/MixerView.cpp
+++ b/sources/Application/Views/MixerView.cpp
@@ -332,12 +332,13 @@ void MixerView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   needsNotesUpdate_ = true;
 };
 
-void MixerView::AnimationUpdate() {
-  // update VU meters on every clock tick (~1Hz)
+void MixerView::AnimationUpdate(unsigned long tick) {
   GUITextProperties props;
 
-  // TODO: Update battery gauge every 50 ticks, ie 1hz
-  drawBattery(props);
+  // Update battery gauge only once per second (every 50 frames at 50Hz)
+  if (tick % 50 == 0) {
+    drawBattery(props);
+  }
 
   // Get the player safely
   Player *player = Player::GetInstance();

--- a/sources/Application/Views/MixerView.h
+++ b/sources/Application/Views/MixerView.h
@@ -14,7 +14,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 protected:
   void processNormalButtonMask(unsigned int mask);

--- a/sources/Application/Views/ModalDialogs/MessageBox.h
+++ b/sources/Application/Views/ModalDialogs/MessageBox.h
@@ -29,7 +29,7 @@ public:
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick);
   virtual void OnFocus();
   virtual void ProcessButtonMask(unsigned short mask, bool pressed);
-  virtual void AnimationUpdate(){};
+  virtual void AnimationUpdate(unsigned long tick){};
 
 private:
   etl::string<SCREEN_WIDTH - 2> line1_ = "";

--- a/sources/Application/Views/ModalDialogs/RenderProgressModal.cpp
+++ b/sources/Application/Views/ModalDialogs/RenderProgressModal.cpp
@@ -93,7 +93,7 @@ void RenderProgressModal::ProcessButtonMask(unsigned short mask, bool pressed) {
   isDirty_ = true;
 }
 
-void RenderProgressModal::AnimationUpdate() {
+void RenderProgressModal::AnimationUpdate(unsigned long tick) {
   // Mark as dirty to update the render progress display
   isDirty_ = true;
 }

--- a/sources/Application/Views/ModalDialogs/RenderProgressModal.h
+++ b/sources/Application/Views/ModalDialogs/RenderProgressModal.h
@@ -23,7 +23,7 @@ public:
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick);
   virtual void OnFocus();
   virtual void ProcessButtonMask(unsigned short mask, bool pressed);
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 private:
   // Helper method to draw the render progress

--- a/sources/Application/Views/ModalDialogs/TextInputModalView.h
+++ b/sources/Application/Views/ModalDialogs/TextInputModalView.h
@@ -23,7 +23,7 @@ public:
   virtual void DrawView();
   virtual void ProcessButtonMask(unsigned short mask, bool pressed);
   virtual void OnFocus();
-  virtual void AnimationUpdate(){};
+  virtual void AnimationUpdate(unsigned long tick){};
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
 
   // Observer implementation

--- a/sources/Application/Views/NullView.h
+++ b/sources/Application/Views/NullView.h
@@ -12,7 +12,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
   virtual void OnFocus();
-  virtual void AnimationUpdate(){};
+  virtual void AnimationUpdate(unsigned long tick){};
 
 private:
 };

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1302,9 +1302,9 @@ void PhraseView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   }
 };
 
-void PhraseView::AnimationUpdate() {
+void PhraseView::AnimationUpdate(unsigned long tick) {
   // First call the parent class implementation to draw the battery gauge
-  ScreenView::AnimationUpdate();
+  ScreenView::AnimationUpdate(tick);
 
   // Get player instance safely
   Player *player = Player::GetInstance();

--- a/sources/Application/Views/PhraseView.h
+++ b/sources/Application/Views/PhraseView.h
@@ -15,7 +15,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 protected:
   void updateCursor(int dx, int dy);

--- a/sources/Application/Views/ProjectView.cpp
+++ b/sources/Application/Views/ProjectView.cpp
@@ -444,7 +444,7 @@ void ProjectView::OnFocus() {
 /// Updates the animation by redrawing the battery gauge on every clock tick
 /// (~1Hz). This occurs even when playback is not active and there is no user
 /// cursor navigation.
-void ProjectView::AnimationUpdate() {
+void ProjectView::AnimationUpdate(unsigned long tick) {
   // redraw batt gauge on every clock tick (~1Hz) even when not playing
   // and not redrawing due to user cursor navigation
   GUITextProperties props;

--- a/sources/Application/Views/ProjectView.h
+++ b/sources/Application/Views/ProjectView.h
@@ -22,7 +22,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
   etl::string<MAX_PROJECT_NAME_LENGTH> getProjectName() {
     return nameField_->GetString();
   };

--- a/sources/Application/Views/ScreenView.cpp
+++ b/sources/Application/Views/ScreenView.cpp
@@ -9,7 +9,7 @@ ScreenView::~ScreenView() {}
 /// Updates the animation by redrawing the battery gauge on every clock tick
 /// (~1Hz). This occurs even when playback is not active and there is no user
 /// cursor navigation.
-void ScreenView::AnimationUpdate() {
+void ScreenView::AnimationUpdate(unsigned long tick) {
   // redraw batt gauge on every clock tick (~1Hz) even when not playing
   // and not redrawing due to user cursor navigation
   GUITextProperties props;

--- a/sources/Application/Views/ScreenView.h
+++ b/sources/Application/Views/ScreenView.h
@@ -12,7 +12,7 @@ public:
   virtual void DrawView(){};
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0){};
   virtual void OnFocus(){};
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 private:
 };

--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -942,9 +942,9 @@ void SongView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   createMemoryBarrier();
 };
 
-void SongView::AnimationUpdate() {
+void SongView::AnimationUpdate(unsigned long tick) {
   // First call the parent class implementation to draw the battery gauge
-  ScreenView::AnimationUpdate();
+  ScreenView::AnimationUpdate(tick);
 
   // Get player instance safely
   Player *player = Player::GetInstance();

--- a/sources/Application/Views/SongView.h
+++ b/sources/Application/Views/SongView.h
@@ -16,7 +16,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 protected:
   void processNormalButtonMask(unsigned int mask);

--- a/sources/Application/Views/TableView.cpp
+++ b/sources/Application/Views/TableView.cpp
@@ -896,9 +896,9 @@ void TableView::OnPlayerUpdate(PlayerEventType eventType, unsigned int tick) {
   createMemoryBarrier();
 }
 
-void TableView::AnimationUpdate() {
+void TableView::AnimationUpdate(unsigned long tick) {
   // First call the parent class implementation to draw the battery gauge
-  ScreenView::AnimationUpdate();
+  ScreenView::AnimationUpdate(tick);
 
   // Get player instance safely
   Player *player = Player::GetInstance();

--- a/sources/Application/Views/TableView.h
+++ b/sources/Application/Views/TableView.h
@@ -14,7 +14,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int tick = 0);
   virtual void OnFocus();
-  virtual void AnimationUpdate();
+  virtual void AnimationUpdate(unsigned long tick);
 
 protected:
   void processNormalButtonMask(unsigned short mask);

--- a/sources/Application/Views/ThemeView.h
+++ b/sources/Application/Views/ThemeView.h
@@ -23,7 +23,7 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus(){};
-  virtual void AnimationUpdate(){};
+  virtual void AnimationUpdate(unsigned long tick){};
 
   // Observer for action callback
   void Update(Observable &, I_ObservableData *);

--- a/sources/UIFramework/SimpleBaseClasses/GUIWindow.cpp
+++ b/sources/UIFramework/SimpleBaseClasses/GUIWindow.cpp
@@ -54,7 +54,7 @@ void GUIWindow::Unlock() { _imp->Unlock(); }
 
 void GUIWindow::Update(bool redraw) { onUpdate(redraw); }
 
-void GUIWindow::ClockTick() { AnimationUpdate(); }
+void GUIWindow::ClockTick(unsigned long tick) { AnimationUpdate(tick); }
 
 I_GUIGraphics *GUIWindow::GetGraphics() { return this; }
 

--- a/sources/UIFramework/SimpleBaseClasses/GUIWindow.h
+++ b/sources/UIFramework/SimpleBaseClasses/GUIWindow.h
@@ -38,9 +38,9 @@ public: // I_GUIGraphics implementation
   virtual void Lock();
   virtual void Unlock();
   virtual void Update(bool redraw);
-  virtual void ClockTick();
+  virtual void ClockTick(unsigned long tick);
   virtual void onUpdate(bool redraw) = 0;
-  virtual void AnimationUpdate() = 0;
+  virtual void AnimationUpdate(unsigned long tick) = 0;
   //	virtual void Save() ;
   //	virtual void Restore() ;
   void PushEvent(GUIEvent &event);


### PR DESCRIPTION
This allows using just a modulus for downclocking the batt gauge refresh rate and importantly make use of this for future UI update needs.

While this touches **alot** of files, the changes are all mechanical just to add the tick parameter to all View subclasses.

Fixes: #561