### PR TITLE
Fix handling multiple MIDI IN notes

### DIFF
--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -395,7 +395,10 @@ bool SampleInstrument::Start(int channel, unsigned char midinote,
   return true;
 }
 
-void SampleInstrument::Stop(int channel) { running_ = false; }
+void SampleInstrument::Stop(int channel) {
+  renderParams *rp = renderParams_ + channel;
+  rp->finished_ = true; // Mark this channel as finished
+}
 
 void SampleInstrument::doTickUpdate(int channel) {
 
@@ -629,7 +632,8 @@ bool SampleInstrument::Render(int channel, fixed *buffer, int size,
               }
             }
             break;
-            /*						case SILM_OSCFINE:
+            /*						case
+               SILM_OSCFINE:
                                                             {
                                                                     int
                offset=(input-lastSample)/channelCount ;
@@ -675,7 +679,8 @@ bool SampleInstrument::Render(int channel, fixed *buffer, int size,
               }
             }
             break;
-            /*						case SILM_OSCFINE:
+            /*						case
+               SILM_OSCFINE:
                                                             {
                                                                     int
                offset=(lastSample-input)/channelCount ;
@@ -824,8 +829,8 @@ bool SampleInstrument::Render(int channel, fixed *buffer, int size,
             }
 
             *fltSpeedPtr =
-                fp_mul(*fltSpeedPtr, fltParm2); // mul by res, it's some kind of
-                                                // inertia.
+                fp_mul(*fltSpeedPtr, fltParm2); // mul by res, it's some kind
+                                                // of inertia.
             /*HOG:5*/ *fltSpeedPtr = fp_add(
                 *fltSpeedPtr,
                 fp_mul(difr, fltParm1)); // mul by cutoff, less cutoff = no
@@ -964,7 +969,8 @@ void SampleInstrument::Update(Observable &o, I_ObservableData *d) {
     Variable *nameVar = FindVariable(FourCC::InstrumentName);
 
     if (sampleVar && nameVar) {
-      // Only update the name if it's empty or matches the previous sample name
+      // Only update the name if it's empty or matches the previous sample
+      // name
       etl::string<MAX_INSTRUMENT_NAME_LENGTH> currentName =
           nameVar->GetString();
       if (currentName.empty()) {

--- a/sources/Application/Player/PlayerChannel.cpp
+++ b/sources/Application/Player/PlayerChannel.cpp
@@ -33,7 +33,6 @@ void PlayerChannel::StopInstrument() {
   if (instr_) {
     instr_->Stop(index_);
   }
-  instr_ = 0;
 };
 
 bool PlayerChannel::Render(fixed *buffer, int samplecount) {

--- a/sources/Application/Player/PlayerChannel.cpp
+++ b/sources/Application/Player/PlayerChannel.cpp
@@ -32,6 +32,7 @@ void PlayerChannel::StartInstrument(I_Instrument *instr, unsigned char note,
 void PlayerChannel::StopInstrument() {
   if (instr_) {
     instr_->Stop(index_);
+    instr_ = 0;
   }
 };
 

--- a/sources/Application/Views/ConsoleView.h
+++ b/sources/Application/Views/ConsoleView.h
@@ -18,7 +18,6 @@ public:
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
   virtual void OnFocus(){};
-  virtual void AnimationUpdate(unsigned long tick){};
 
   // Trace Implementation
 

--- a/sources/Services/Midi/CMakeLists.txt
+++ b/sources/Services/Midi/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(services_midi
   MidiInMerger.cpp
   MidiOutDevice.cpp
   MidiService.cpp
+  MidiNoteTracker.cpp
 )
 
 target_link_libraries(services_midi PUBLIC

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -73,7 +73,7 @@ private:
   uint8_t midiData1 = 0;
   uint8_t midiDataCount = 0;
   uint8_t midiDataBytes = 0;
-  
+
   // Note tracker for polyphonic note handling
   MidiNoteTracker noteTracker_;
 };

--- a/sources/Services/Midi/MidiInDevice.h
+++ b/sources/Services/Midi/MidiInDevice.h
@@ -6,6 +6,7 @@
 #include "MidiChannel.h"
 #include "MidiEvent.h"
 #include "MidiMessage.h"
+#include "MidiNoteTracker.h"
 #include "Services/Controllers/ControllerSource.h"
 
 enum MidiSyncMessage { MSM_START, MSM_STOP, MSM_TEMPOTICK };
@@ -72,6 +73,9 @@ private:
   uint8_t midiData1 = 0;
   uint8_t midiDataCount = 0;
   uint8_t midiDataBytes = 0;
+  
+  // Note tracker for polyphonic note handling
+  MidiNoteTracker noteTracker_;
 };
 
 #endif

--- a/sources/Services/Midi/MidiNoteTracker.cpp
+++ b/sources/Services/Midi/MidiNoteTracker.cpp
@@ -1,0 +1,117 @@
+#include "MidiNoteTracker.h"
+#include "System/Console/Trace.h"
+
+MidiNoteTracker::MidiNoteTracker() {
+  // Initialize all note tracking data
+  clear();
+}
+
+MidiNoteTracker::~MidiNoteTracker() {
+  // Nothing to clean up
+}
+
+bool MidiNoteTracker::registerNote(uint8_t note, uint8_t midiChannel,
+                                   uint8_t instrumentChannel,
+                                   uint8_t velocity) {
+  // Validate parameters
+  if (note > 127 || midiChannel > 15) {
+    Trace::Debug("Invalid parameters in registerNote: note=%d, midiChannel=%d", 
+                 note, midiChannel);
+    return false;
+  }
+
+  // Find an available audio channel (one that's not active)
+  int availableChannel = getNextAvailableChannel();
+
+  // If no available channel, return false
+  if (availableChannel == -1) {
+    return false;
+  }
+
+  // Register the note in the available channel
+  playingNotes_[availableChannel].active = true;
+  playingNotes_[availableChannel].midiNote = note;
+  playingNotes_[availableChannel].midiChannel = midiChannel;
+  playingNotes_[availableChannel].instrumentChannel = availableChannel; // Audio channel = array index
+  playingNotes_[availableChannel].velocity = velocity;
+  
+  Trace::Debug("Note %d registered on MIDI channel %d, audio channel %d",
+               note, midiChannel, availableChannel);
+  return true;
+}
+
+bool MidiNoteTracker::isNoteActive(uint8_t note) const {
+  // Check if the note is active on any channel
+  for (const auto &activeNote : playingNotes_) {
+    if (activeNote.active && activeNote.midiNote == note) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MidiNoteTracker::isNoteActiveOnChannel(uint8_t note,
+                                            uint8_t midiChannel) const {
+  // Check if the specific note is active on the specific MIDI channel
+  for (const auto &activeNote : playingNotes_) {
+    if (activeNote.active && activeNote.midiNote == note &&
+        activeNote.midiChannel == midiChannel) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int MidiNoteTracker::getAudioChannelForNote(uint8_t note,
+                                            uint8_t midiChannel) const {
+  // Find the audio channel assigned to this note on this MIDI channel
+  for (size_t i = 0; i < playingNotes_.size(); i++) {
+    const auto &activeNote = playingNotes_[i];
+    if (activeNote.active && activeNote.midiNote == note &&
+        activeNote.midiChannel == midiChannel) {
+      // The audio channel is the index in the array
+      return static_cast<int>(i);
+    }
+  }
+  return -1; // Note not found
+}
+
+int MidiNoteTracker::getNextAvailableChannel() const {
+  // Find an inactive channel
+  for (size_t i = 0; i < playingNotes_.size(); i++) {
+    if (!playingNotes_[i].active) {
+      return static_cast<int>(i);
+    }
+  }
+
+  // If all channels are active, return -1 (no available channels)
+  return -1;
+}
+
+int MidiNoteTracker::unregisterNote(uint8_t note, uint8_t midiChannel) {
+  // Find the note in the active notes list
+  for (size_t i = 0; i < playingNotes_.size(); i++) {
+    auto &activeNote = playingNotes_[i];
+    if (activeNote.active && activeNote.midiNote == note &&
+        activeNote.midiChannel == midiChannel) {
+      // Found the note, mark it as inactive
+      int audioChannel = static_cast<int>(i); // Audio channel = array index
+      activeNote.active = false;
+      Trace::Debug("Note %d unregistered from MIDI channel %d, stopping "
+                   "audio channel %d",
+                   note, midiChannel, audioChannel);
+      return audioChannel;
+    }
+  }
+
+  // Note not found
+  Trace::Debug("Note %d not found on MIDI channel %d", note, midiChannel);
+  return -1;
+}
+
+void MidiNoteTracker::clear() {
+  // Mark all notes as inactive
+  for (auto &note : playingNotes_) {
+    note.active = false;
+  }
+}

--- a/sources/Services/Midi/MidiNoteTracker.cpp
+++ b/sources/Services/Midi/MidiNoteTracker.cpp
@@ -15,7 +15,7 @@ bool MidiNoteTracker::registerNote(uint8_t note, uint8_t midiChannel,
                                    uint8_t velocity) {
   // Validate parameters
   if (note > 127 || midiChannel > 15) {
-    Trace::Debug("Invalid parameters in registerNote: note=%d, midiChannel=%d", 
+    Trace::Debug("Invalid parameters in registerNote: note=%d, midiChannel=%d",
                  note, midiChannel);
     return false;
   }
@@ -32,11 +32,12 @@ bool MidiNoteTracker::registerNote(uint8_t note, uint8_t midiChannel,
   playingNotes_[availableChannel].active = true;
   playingNotes_[availableChannel].midiNote = note;
   playingNotes_[availableChannel].midiChannel = midiChannel;
-  playingNotes_[availableChannel].instrumentChannel = availableChannel; // Audio channel = array index
+  playingNotes_[availableChannel].instrumentChannel =
+      availableChannel; // Audio channel = array index
   playingNotes_[availableChannel].velocity = velocity;
-  
-  Trace::Debug("Note %d registered on MIDI channel %d, audio channel %d",
-               note, midiChannel, availableChannel);
+
+  Trace::Debug("Note %d registered on MIDI channel %d, audio channel %d", note,
+               midiChannel, availableChannel);
   return true;
 }
 

--- a/sources/Services/Midi/MidiNoteTracker.h
+++ b/sources/Services/Midi/MidiNoteTracker.h
@@ -1,0 +1,96 @@
+#ifndef _MIDI_NOTE_TRACKER_H_
+#define _MIDI_NOTE_TRACKER_H_
+
+#include "Externals/etl/include/etl/array.h"
+#include <cstdint>
+
+// Maximum number of channels to track notes on
+#define MAX_NOTE_CHANNELS 8
+
+/**
+ * MidiNoteTracker - Tracks active MIDI notes across multiple channels
+ *
+ * This class keeps track of which notes are currently active on which channels,
+ * allowing for polyphonic note handling where a note is only stopped when
+ * all instances of it have been released.
+ */
+class MidiNoteTracker {
+public:
+  MidiNoteTracker();
+  ~MidiNoteTracker();
+
+  /**
+   * Register a note as active on a specific channel
+   *
+   * @param note The MIDI note number (0-127)
+   * @param midiChannel The original MIDI channel (0-15)
+   * @param instrumentChannel The instrument channel assigned (0-7)
+   * @param velocity The note velocity (0-127)
+   * @return True if the note was successfully registered
+   */
+  bool registerNote(uint8_t note, uint8_t midiChannel,
+                    uint8_t instrumentChannel, uint8_t velocity);
+
+  /**
+   * Check if a note is currently active on any channel
+   * 
+   * @param note The MIDI note number (0-127)
+   * @return True if the note is active on any channel
+   */
+  bool isNoteActive(uint8_t note) const;
+  
+  /**
+   * Check if a specific note is active on a specific MIDI channel
+   * 
+   * @param note The MIDI note number (0-127)
+   * @param midiChannel The MIDI channel (0-15)
+   * @return True if the note is active on the specified channel
+   */
+  bool isNoteActiveOnChannel(uint8_t note, uint8_t midiChannel) const;
+  
+  /**
+   * Get the audio channel assigned to a specific note on a specific MIDI channel
+   * 
+   * @param note The MIDI note number (0-127)
+   * @param midiChannel The MIDI channel (0-15)
+   * @return The audio channel assigned to the note, or -1 if not found
+   */
+  int getAudioChannelForNote(uint8_t note, uint8_t midiChannel) const;
+
+  /**
+   * Unregister a note on a specific MIDI channel
+   *
+   * @param note The MIDI note number (0-127)
+   * @param midiChannel The MIDI channel (0-15)
+   * @return The instrument channel that should be stopped, or -1 if the note
+   * should not be stopped
+   */
+  int unregisterNote(uint8_t note, uint8_t midiChannel);
+
+  /**
+   * Get the next available instrument channel
+   *
+   * @return The next available instrument channel, or -1 if all channels are in
+   * use
+   */
+  int getNextAvailableChannel() const;
+
+  /**
+   * Clear all tracked notes
+   */
+  void clear();
+
+private:
+  struct NoteInfo {
+    bool active;
+    uint8_t midiNote;          // The MIDI note number (0-127)
+    uint8_t midiChannel;       // The original MIDI channel (0-15)
+    uint8_t instrumentChannel; // The instrument channel assigned (0-7)
+    uint8_t velocity;          // The note velocity (0-127)
+  };
+
+  // Array of 8 playing notes, one for each instrument channel
+  etl::array<NoteInfo, MAX_NOTE_CHANNELS> playingNotes_;
+};
+
+#endif // _MIDI_NOTE_TRACKER_H_

--- a/sources/Services/Midi/MidiNoteTracker.h
+++ b/sources/Services/Midi/MidiNoteTracker.h
@@ -33,24 +33,25 @@ public:
 
   /**
    * Check if a note is currently active on any channel
-   * 
+   *
    * @param note The MIDI note number (0-127)
    * @return True if the note is active on any channel
    */
   bool isNoteActive(uint8_t note) const;
-  
+
   /**
    * Check if a specific note is active on a specific MIDI channel
-   * 
+   *
    * @param note The MIDI note number (0-127)
    * @param midiChannel The MIDI channel (0-15)
    * @return True if the note is active on the specified channel
    */
   bool isNoteActiveOnChannel(uint8_t note, uint8_t midiChannel) const;
-  
+
   /**
-   * Get the audio channel assigned to a specific note on a specific MIDI channel
-   * 
+   * Get the audio channel assigned to a specific note on a specific MIDI
+   * channel
+   *
    * @param note The MIDI note number (0-127)
    * @param midiChannel The MIDI channel (0-15)
    * @return The audio channel assigned to the note, or -1 if not found

--- a/usermanual/content/pages/midi.md
+++ b/usermanual/content/pages/midi.md
@@ -29,11 +29,9 @@ When a MIDI device is connected and configured, incoming MIDI notes will trigger
 
 - **Sample Instruments**: Fully support polyphonic playback. Multiple notes can be played simultaneously, and each note can be stopped independently.
 
-- **OPAL Instruments**: Should be considered monophonic from a MIDI input perspective. Playing a new note will stop any currently playing note on the same MIDI channel.
+- **OPAL Instruments**: Should be *considered* monophonic from a MIDI input perspective. However they DONT behave completely like a monophonic instrument, so care needs to be taken to ensure that only one note is played on a midi channel at a time. 
 
-- **SID Instruments**: Should be considered monophonic from a MIDI input perspective. Playing a new note will stop any currently playing note on the same MIDI channel.
-
-This limitation is due to how these instrument types handle note playback internally. Sample instruments maintain separate state for each audio channel, while OPAL and SID instruments use a single state that affects all notes played through them.
+- **SID Instruments**: Should be *considered* monophonic from a MIDI input perspective. However they DONT behave completely like a monophonic instrument, so care needs to be taken to ensure that only one note is played on a midi channel at a time. 
 
 ### Supported MIDI Messages
 

--- a/usermanual/content/pages/midi.md
+++ b/usermanual/content/pages/midi.md
@@ -3,5 +3,65 @@ title: MIDI Implementation
 template: page
 ---
 
+# MIDI Implementation
 
-## TODO
+## MIDI Input
+
+picoTracker supports MIDI input for real-time playback and control. This allows you to connect a MIDI keyboard or controller to play notes and control various parameters.
+
+### Input Methods
+
+picoTracker supports two MIDI input methods:
+
+1. **USB MIDI**: Connect any USB MIDI device directly to the picoTracker's USB port. USB MIDI is supported on all picoTracker hardware versions.
+
+2. **TRS MIDI (3.5mm)**: Connect standard MIDI devices using a MIDI to TRS adapter. **Note:** TRS MIDI input requires a v2.1 or newer picoTracker PCB _*_.
+
+Both USB and TRS MIDI inputs are always enabled by default when the picoTracker starts up.
+
+### MIDI Note Playback
+
+When a MIDI device is connected and configured, incoming MIDI notes will trigger the corresponding instruments in picoTracker. Each MIDI channel is mapped to instrument slot in picoTracker. For now this mapping is fixed, eg. MIDI channel 1 will trigger instrument 00, MIDI channel 2 will trigger instrument 01, and so on.
+
+#### Polyphonic Playback Limitations
+
+**Important:** Not all instrument types support polyphonic MIDI input playback:
+
+- **Sample Instruments**: Fully support polyphonic playback. Multiple notes can be played simultaneously, and each note can be stopped independently.
+
+- **OPAL Instruments**: Should be considered monophonic from a MIDI input perspective. Playing a new note will stop any currently playing note on the same MIDI channel.
+
+- **SID Instruments**: Should be considered monophonic from a MIDI input perspective. Playing a new note will stop any currently playing note on the same MIDI channel.
+
+This limitation is due to how these instrument types handle note playback internally. Sample instruments maintain separate state for each audio channel, while OPAL and SID instruments use a single state that affects all notes played through them.
+
+### Supported MIDI Messages
+
+picoTracker currently supports the following MIDI message types:
+
+- **Note On**: Triggers instrument playback. Each MIDI channel maps to a corresponding instrument.
+- **Note Off**: Stops the corresponding note that was previously triggered by a Note On message.
+- **Start**: Starts playback when receiving a MIDI Start message.
+- **Stop**: Stops playback when receiving a MIDI Stop message.
+
+The following message types are recognized but **not** implemented yet:
+
+- **Clock**: Synchronizes picoTracker's tempo to an external MIDI clock source.
+- **Aftertouch** (Polyphonic Pressure)
+- **Control Change** (CC)
+- **Program Change**
+- **Channel Aftertouch** (Channel Pressure)
+- **Pitch Bend**
+- **Continue**
+
+### MIDI Configuration
+
+Currently, MIDI input is always enabled by default when picoTracker starts up. There is no specific configuration required to use MIDI input.
+
+Each MIDI channel directly maps to an instrument index in picoTracker. For example, MIDI channel 1 will trigger instrument 1, MIDI channel 2 will trigger instrument 2, and so on.
+
+## MIDI Output
+
+*[MIDI output documentation to be added]*
+
+ (v1.2 and v2.0 PCBs require a soldered hardware modification to enable TRS MIDI input)


### PR DESCRIPTION
Apart from fixing MIDI note input this also cleans up code for correctly handling sampler instrument stops and adds MIDI In documentation which documents the limitation that unlike sampler instruments, synth instruments are not polyphonic with MIDI input.

Also includes some code cleanup to make format linter and compiler (for release mode) happy.

Fixes: #508 , #580 