### PR TITLE
Fix vu meter to not overlap grid on phrase screen

### DIFF
--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -172,7 +172,7 @@ void View::drawNotes() {
 }
 
 void View::drawMasterVuMeter(Player *player, GUITextProperties props,
-                             bool forceRedraw) {
+                             bool forceRedraw, uint8_t xoffset) {
   stereosample playerLevel = player->GetMasterLevel();
 
   // Convert to dB
@@ -185,7 +185,7 @@ void View::drawMasterVuMeter(Player *player, GUITextProperties props,
 
   // we start at the bottom of the VU meter and draw it growing upwards
   GUIPoint pos = GetAnchor();
-  pos._x += 24;
+  pos._x += xoffset;
   pos._y += VU_METER_HEIGHT - 1; // -1 to align with song grid
 
   // Use index 0 for the master VU meter

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -158,7 +158,7 @@ protected:
   void drawNotes();
   void drawBattery(GUITextProperties &props);
   void drawMasterVuMeter(Player *player, GUITextProperties props,
-                         bool forceRedraw = false);
+                         bool forceRedraw = false, uint8_t xoffset = 24);
   void drawPlayTime(Player *player, GUIPoint pos, GUITextProperties &props);
   void drawVUMeter(uint8_t leftBars, uint8_t rightBars, GUIPoint pos,
                    GUITextProperties props, int vuIndex,

--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -1321,7 +1321,7 @@ void PhraseView::AnimationUpdate() {
     drawNotes();
 
     // Draw VU meter
-    drawMasterVuMeter(player, props);
+    drawMasterVuMeter(player, props, false, 25);
 
     // Draw play position marker
     GUIPoint anchor = GetAnchor();


### PR DESCRIPTION
This was missed in the previous fix for #576 that only fixed the table screen.
 
Fixes: #576