### PR TITLE
Theme export broken

### DIFF
--- a/sources/Application/Model/Config.h
+++ b/sources/Application/Model/Config.h
@@ -29,15 +29,7 @@ private:
   etl::list<Variable *, 24> variables_;
 
   void SaveContent(tinyxml2::XMLPrinter *printer);
-  void processParams(const char *name, int value, bool insert);
   void useDefaultConfig();
-
-  WatchedVariable lineOut_;
-  WatchedVariable midiDevice_;
-  WatchedVariable midiSync_;
-  WatchedVariable remoteUI_;
-  WatchedVariable uiFont_;
-  Variable themeName_; // Current theme name
 };
 
 #endif

--- a/sources/Application/Model/Config.h
+++ b/sources/Application/Model/Config.h
@@ -37,6 +37,7 @@ private:
   WatchedVariable midiSync_;
   WatchedVariable remoteUI_;
   WatchedVariable uiFont_;
+  Variable themeName_; // Current theme name
 };
 
 #endif

--- a/sources/Application/Model/ThemeConstants.h
+++ b/sources/Application/Model/ThemeConstants.h
@@ -22,7 +22,9 @@ const uint32_t DEFAULT_EMPHASIS = 0xFFA500;
 // const uint32_t DEFAULT_RESERVED4 = 0xFFFF00;
 
 // Font constants
-constexpr int DEFAULT_UIFONT = 0x0;
+const int DEFAULT_UIFONT = 0x0;
+// Default theme name - using inline to avoid multiple definition errors
+inline const char *DEFAULT_THEME_NAME = "Default";
 } // namespace ThemeConstants
 
 #endif // _THEME_CONSTANTS_H_

--- a/sources/Application/Views/ThemeView.h
+++ b/sources/Application/Views/ThemeView.h
@@ -8,6 +8,8 @@
 #include "BaseClasses/UIBigHexVarField.h"
 #include "BaseClasses/UIIntVarField.h"
 #include "BaseClasses/UISwatchField.h"
+#include "BaseClasses/UITextField.h"
+#include "BaseClasses/View.h"
 #include "FieldView.h"
 #include "Foundation/Observable.h"
 #include "Foundation/T_SimpleList.h"
@@ -37,10 +39,16 @@ private:
   etl::vector<UIBigHexVarField, 16> bigHexVarField_;
   etl::vector<UISwatchField, 16> swatchField_;
   etl::vector<UIActionField, 2> actionField_; // For Import/Export buttons
-
+  etl::vector<UITextField<MAX_THEME_NAME_LENGTH>, 1> textFields_; // For theme name input
+  
+  // Reference to the theme name field for direct access
+  UITextField<MAX_THEME_NAME_LENGTH> *themeNameField_;
+  bool themeNameEditMode_; // Flag to track if we're editing the theme name
+  
   // Helper methods for theme import/export
   void handleThemeExport();
   void exportTheme();
   void importTheme();
+  void exportThemeWithName(const char* themeName, bool overwrite);
 };
 #endif

--- a/sources/Application/Views/ThemeView.h
+++ b/sources/Application/Views/ThemeView.h
@@ -24,7 +24,8 @@ public:
   virtual void ProcessButtonMask(unsigned short mask, bool pressed);
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
-  virtual void OnFocus(){};
+  virtual void OnFocus();
+
   // Observer for action callback
   void Update(Observable &, I_ObservableData *);
 
@@ -39,16 +40,18 @@ private:
   etl::vector<UIBigHexVarField, 16> bigHexVarField_;
   etl::vector<UISwatchField, 16> swatchField_;
   etl::vector<UIActionField, 2> actionField_; // For Import/Export buttons
-  etl::vector<UITextField<MAX_THEME_NAME_LENGTH>, 1> textFields_; // For theme name input
-  
+  etl::vector<UITextField<MAX_THEME_NAME_LENGTH>, 1>
+      textFields_; // For theme name input
+
   // Reference to the theme name field for direct access
   UITextField<MAX_THEME_NAME_LENGTH> *themeNameField_;
   bool themeNameEditMode_; // Flag to track if we're editing the theme name
-  
+
   // Helper methods for theme import/export
   void handleThemeExport();
   void exportTheme();
   void importTheme();
-  void exportThemeWithName(const char* themeName, bool overwrite);
+  void exportThemeWithName(const char *themeName, bool overwrite);
+  void updateThemeNameFromConfig(); // Update the theme name field from Config
 };
 #endif

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -191,6 +191,8 @@ struct FourCC {
     // 168 is taken for VarChannel6Volume
     // 169 is taken for VarChannel7Volume
     // 170 is taken for VarChannel8Volume
+    // 171 is taken for SampleInstrumentSlices
+    // 172 is taken for ActionThemeName
 
     VarChannel1Volume = 163,
     VarChannel2Volume = 164,
@@ -220,6 +222,7 @@ struct FourCC {
     ActionRenderMixdown = 149,
     ActionRenderStems = 150,
     ActionShowTheme = 159,
+    ActionThemeName = 172, // New action for theme name field
     SampleInstrumentSlices = 171,
 
     Default = 255, // "    "
@@ -372,6 +375,7 @@ struct FourCC {
   ETL_ENUM_TYPE(ActionEdit, "edit")
   ETL_ENUM_TYPE(ActionExport, "export")
   ETL_ENUM_TYPE(ActionImport, "import")
+  ETL_ENUM_TYPE(ActionThemeName, "themename")
 
   ETL_ENUM_TYPE(Default, "   ")
   ETL_END_ENUM_TYPE

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -193,6 +193,7 @@ struct FourCC {
     // 170 is taken for VarChannel8Volume
     // 171 is taken for SampleInstrumentSlices
     // 172 is taken for ActionThemeName
+    // 173 is taken for VarThemeName
 
     VarChannel1Volume = 163,
     VarChannel2Volume = 164,
@@ -202,6 +203,7 @@ struct FourCC {
     VarChannel6Volume = 168,
     VarChannel7Volume = 169,
     VarChannel8Volume = 170,
+    VarThemeName = 173, // Variable for storing the current theme name
 
     VarInstrumentType = 113,
 
@@ -222,7 +224,7 @@ struct FourCC {
     ActionRenderMixdown = 149,
     ActionRenderStems = 150,
     ActionShowTheme = 159,
-    ActionThemeName = 172, // New action for theme name field
+    ActionThemeName = 172,
     SampleInstrumentSlices = 171,
 
     Default = 255, // "    "
@@ -265,6 +267,7 @@ struct FourCC {
   ETL_ENUM_TYPE(VarMidiClockSync, "MIDICLOCKSYNC")
   ETL_ENUM_TYPE(VarRemoteUI, "REMOTEUI")
   ETL_ENUM_TYPE(VarUIFont, "UIFONT")
+  ETL_ENUM_TYPE(VarThemeName, "THEMENAME")
   ETL_ENUM_TYPE(VarScaleRoot, "scaleroot")
   ETL_ENUM_TYPE(MacroInstrumentShape, "shape")
   ETL_ENUM_TYPE(MacroInstrmentTimbre, "timbre")


### PR DESCRIPTION
In fixing the theme export UI to work I made it consistent with instrument name and project name UI in other screens.

While fixing this I also found bug in the config.xml handling that could cause the parameters to be written out to xml twice and in general cleaned up the config xml parsing to require *almost* none of the special case per variable code that was previously being used.

Fixes: #586