### PR TITLE
Fix slices being pitched

### DIFF
--- a/sources/Adapters/picoTracker/system/picoTrackerSamplePool.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSamplePool.cpp
@@ -136,7 +136,7 @@ bool picoTrackerSamplePool::LoadInFlash(WavFile *wave) {
   wave->Rewind();
   wave->Read(&readBuffer, BUFFER_SIZE, &br);
   while (br > 0) {
-    Trace::Debug("Read %i bytes", br);
+    // Trace::Debug("Read %i bytes", br);
     // We need to write double the bytes if we needed to expand to 16 bit
     // Write size will be either 256 (which is the flash page size) or 512
     uint32_t writeSize = br;
@@ -147,9 +147,9 @@ bool picoTrackerSamplePool::LoadInFlash(WavFile *wave) {
 
     // There will be trash at the end, but sampleBufferSize_ gives me the
     // bounds
-    Trace::Debug("About to write %i sectors in flash region 0x%X - 0x%X",
-                 writeSize, flashWriteOffset_ + offset,
-                 flashWriteOffset_ + offset + writeSize);
+    // Trace::Debug("About to write %i sectors in flash region 0x%X - 0x%X",
+    //              writeSize, flashWriteOffset_ + offset,
+    //              flashWriteOffset_ + offset + writeSize);
 
     flash_range_program(flashWriteOffset_, (uint8_t *)readBuffer, writeSize);
     flashWriteOffset_ += writeSize;

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -46,8 +46,6 @@ public:
   virtual void SetTableState(TableSaveState &state);
   etl::ilist<Variable *> *Variables() { return &variables_; };
 
-  bool IsMulti();
-
   // Engine playback  start callback
 
   virtual void OnStart();

--- a/sources/Application/Instruments/SoundSource.h
+++ b/sources/Application/Instruments/SoundSource.h
@@ -11,7 +11,6 @@ public:
   virtual int GetSampleRate(int note) = 0;
   virtual int GetChannelCount(int note) = 0;
   virtual void *GetSampleBuffer(int note) = 0;
-  virtual bool IsMulti() = 0;
   virtual int GetRootNote(int note) = 0;
 };
 

--- a/sources/Application/Instruments/WavFile.h
+++ b/sources/Application/Instruments/WavFile.h
@@ -29,7 +29,6 @@ public:
   bool Read(void *buff, uint32_t btr, uint32_t *bytesRead);
 
   void Close();
-  virtual bool IsMulti() { return false; };
 
 protected:
   long readBlock(long position, long count);


### PR DESCRIPTION
In process removed redundant code that doubled up and incorrectly was checking is samples were "multi" as we can tell that from the number of slices a sample has.

Fixes: #620