### PR TITLE
Fix updating sampler instrument name and the name displayed

### DIFF
--- a/sources/Application/Instruments/InstrumentNameVariable.cpp
+++ b/sources/Application/Instruments/InstrumentNameVariable.cpp
@@ -1,9 +1,10 @@
 #include "InstrumentNameVariable.h"
 
 InstrumentNameVariable::InstrumentNameVariable(I_Instrument *instrument)
-    : Variable(FourCC::InstrumentName, instrument->GetDisplayName().c_str()),
+    : Variable(FourCC::InstrumentName, instrument->GetUserSetName().c_str()),
       instrument_(instrument) {
-  // Initialize with the instrument's current display name
+  // Initialize with the instrument's user-set name only, not the display name
+  // This ensures we don't automatically populate the name field with the sample filename
 }
 
 InstrumentNameVariable::~InstrumentNameVariable() {}

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -1262,25 +1262,38 @@ void SampleInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
 };
 
 etl::string<MAX_INSTRUMENT_NAME_LENGTH> SampleInstrument::GetUserSetName() {
-  Variable *v = FindVariable(FourCC::SampleInstrumentSample);
-  return v->GetString();
+  // Return the user-set name from the base class
+  return I_Instrument::GetUserSetName();
+};
+
+// Get the sample file name from the SampleInstrumentSample variable
+etl::string<MAX_INSTRUMENT_NAME_LENGTH> SampleInstrument::GetSampleFileName() {
+  Variable *v = this->FindVariable(FourCC::SampleInstrumentSample);
+  if (v) {
+    return v->GetString();
+  }
+  return etl::string<MAX_INSTRUMENT_NAME_LENGTH>();
 };
 
 etl::string<MAX_INSTRUMENT_NAME_LENGTH> SampleInstrument::GetDisplayName() {
-  // Get the name from the base class method
-  auto name = I_Instrument::GetDisplayName();
-
-  // Strip .wav extension if present
-  size_t dotPos = name.find_last_of('.');
-  if (dotPos != etl::string<MAX_INSTRUMENT_NAME_LENGTH>::npos) {
-    // Check if the extension is .wav (case insensitive)
-    const char *ext = name.c_str() + dotPos;
-    if (strcasecmp(ext, ".wav") == 0) {
-      return name.substr(0, dotPos);
-    }
+  // Check if user has explicitly set a name
+  auto userSetName = I_Instrument::GetUserSetName();
+  if (!userSetName.empty()) {
+    // User has set a custom name, use that
+    return userSetName;
   }
 
-  return name;
+  // No user-set name, use the sample file name without file extension
+  auto sampleFileName = GetSampleFileName();
+
+  // Strip .wav extension if present
+  size_t dotPos = sampleFileName.find_last_of('.');
+  if (dotPos != etl::string<MAX_INSTRUMENT_NAME_LENGTH>::npos) {
+    // remove the filename extension
+    return sampleFileName.substr(0, dotPos);
+  }
+
+  return sampleFileName;
 };
 
 void SampleInstrument::Purge() {

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -963,23 +963,6 @@ void SampleInstrument::Update(Observable &o, I_ObservableData *d) {
 
   switch (id) {
   case FourCC::SampleInstrumentSample: {
-    // Get the sample name to use as the default instrument name if no custom
-    // name is set
-    Variable *sampleVar = FindVariable(FourCC::SampleInstrumentSample);
-    Variable *nameVar = FindVariable(FourCC::InstrumentName);
-
-    if (sampleVar && nameVar) {
-      // Only update the name if it's empty or matches the previous sample
-      // name
-      etl::string<MAX_INSTRUMENT_NAME_LENGTH> currentName =
-          nameVar->GetString();
-      if (currentName.empty()) {
-        // Set the instrument name to the sample name (without extension)
-        etl::string<MAX_INSTRUMENT_NAME_LENGTH> sampleName = GetDisplayName();
-        nameVar->SetString(sampleName.c_str());
-      }
-    }
-
     if (running_) {
       dirty_ = true; // we'll update later, when instrument gets re-triggered
     } else {

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -1269,6 +1269,11 @@ etl::string<MAX_INSTRUMENT_NAME_LENGTH> SampleInstrument::GetDisplayName() {
   // No user-set name, use the sample file name without file extension
   auto sampleFileName = GetSampleFileName();
 
+  // If no sample is set (empty filename), return "NONE"
+  if (sampleFileName.empty()) {
+    return etl::string<MAX_INSTRUMENT_NAME_LENGTH>("NONE");
+  }
+
   // Strip .wav extension if present
   size_t dotPos = sampleFileName.find_last_of('.');
   if (dotPos != etl::string<MAX_INSTRUMENT_NAME_LENGTH>::npos) {

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -63,6 +63,7 @@ public:
 
   virtual etl::string<MAX_INSTRUMENT_NAME_LENGTH> GetUserSetName();
   virtual etl::string<MAX_INSTRUMENT_NAME_LENGTH> GetDisplayName() override;
+  virtual etl::string<MAX_INSTRUMENT_NAME_LENGTH> GetSampleFileName();
 
   static void EnableDownsamplingLegacy();
 

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -40,13 +40,19 @@ void UITextField<MaxLength>::Draw(GUIWindow &w, int offset) {
   }
 
   if (focus_) {
-    char buffer[2];
-    buffer[1] = 0;
-    for (int i = 0; i < len; i++) {
-      props.invert_ = (i == currentChar_);
-      buffer[0] = value[i];
-      w.DrawString(buffer, position, props);
-      position._x += 1;
+    if (len == 0) {
+      // For empty fields, draw a cursor at the beginning position
+      props.invert_ = true;
+      w.DrawString(" ", position, props);
+    } else {
+      char buffer[2];
+      buffer[1] = 0;
+      for (int i = 0; i < len; i++) {
+        props.invert_ = (i == currentChar_);
+        buffer[0] = value[i];
+        w.DrawString(buffer, position, props);
+        position._x += 1;
+      }
     }
   } else {
     if (len != 0) {

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -58,16 +58,16 @@ InstrumentView::InstrumentView(GUIWindow &w, ViewData *data)
 InstrumentView::~InstrumentView() {}
 
 void InstrumentView::addNameTextField(I_Instrument *instr, GUIPoint &position) {
-  // Create a NameVariable that bridges between the UITextField and the
-  // instrument's name
   nameVariables_.emplace_back(instr);
   Variable &nameVar = *nameVariables_.rbegin();
 
   auto label =
       etl::make_string_with_capacity<MAX_UITEXTFIELD_LABEL_LENGTH>("name: ");
 
-  // Create a default name based on the instrument's display name
-  etl::string<MAX_INSTRUMENT_NAME_LENGTH> defaultName = instr->GetDisplayName();
+  // Use an empty default name - we don't want to populate with sample filename
+  // The display name will still be shown on the phrase screen via
+  // GetDisplayName()
+  etl::string<MAX_INSTRUMENT_NAME_LENGTH> defaultName;
 
   nameTextField_.emplace_back(nameVar, position, label, FourCC::InstrumentName,
                               defaultName);


### PR DESCRIPTION
This also fixes a related UI bug where the cursor was not shown in UITextfields with an empty string value that received focus.

Fixes: #536