### PR TITLE
MIDI Velocity - remove division from base value

### DIFF
--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -177,7 +177,7 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
   case FourCC::InstrumentCommandVelocity: {
     // VELM cmds set velocity for MIDI steps
     // Ensure velocity doesn't exceed 127 (MIDI spec maximum)
-    velocity_ = (value / 2) & 0x7F;
+    velocity_ = value & 0x7F;
   }; break;
 
   case FourCC::InstrumentCommandVolume: {


### PR DESCRIPTION
Fixes issue #664 where value was being halved before being sent. Before, setting `7F` in `VEL` would only send `63`, whereas now it sends the full 127.

This can be tested by sending `VEL` commands to a MIDI instrument.