### PR TITLE
Power button timing

### DIFF
--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -232,7 +232,7 @@ void ProcessEvent(void *) {
     //                 uxTaskGetStackHighWaterMark(NULL));
     // TODO: the event queue should be a FreeRTOS queue and this should halt
     // waiting for an event
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    vTaskDelay(20 / portTICK_PERIOD_MS);
     //    Trace::Debug("Process event");
   }
 }

--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -224,16 +224,11 @@ void ProcessEvent(void *) {
     if (!queue->empty()) {
       advEvent event(advEventType::LAST);
       queue->pop_into(event);
-      //      redrawing_ = true;
       advGUIWindowImp::ProcessEvent(event);
-      //      redrawing_ = false;
     }
-    //    Trace::Debug("Event task running, stack free: %d\n",
-    //                 uxTaskGetStackHighWaterMark(NULL));
     // TODO: the event queue should be a FreeRTOS queue and this should halt
     // waiting for an event
     vTaskDelay(20 / portTICK_PERIOD_MS);
-    //    Trace::Debug("Process event");
   }
 }
 

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -14,6 +14,7 @@
 #include "Application/Utils/mathutils.h"
 #include "ModalView.h"
 #include "System/Console/Trace.h"
+#include <UIFramework/SimpleBaseClasses/EventManager.h>
 #include <nanoprintf.h>
 
 bool View::initPrivate_ = false;
@@ -440,7 +441,7 @@ void View::drawPowerButtonUI(GUITextProperties &props) {
     char countdownMessage[40];
     powerButtonHoldCount_++;
 
-    int remainingSeconds = 3 - (powerButtonHoldCount_ / 50);
+    int remainingSeconds = 3 - (powerButtonHoldCount_ / PICO_CLOCK_HZ);
     if (remainingSeconds < 0) {
       remainingSeconds = 0;
     }

--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -438,7 +438,7 @@ void View::drawBattery(GUITextProperties &props) {
 void View::drawPowerButtonUI(GUITextProperties &props) {
   // Only process and draw UI when power button is pressed
   if (powerButtonPressed_) {
-    char countdownMessage[40];
+    char countdownMessage[SCREEN_WIDTH];
     powerButtonHoldCount_++;
 
     int remainingSeconds = 3 - (powerButtonHoldCount_ / PICO_CLOCK_HZ);
@@ -451,11 +451,6 @@ void View::drawPowerButtonUI(GUITextProperties &props) {
 
     if (remainingSeconds == 0) {
       Trace::Debug("Power button held for threshold time, Powerdown!");
-
-      // clear screen before powerdown
-      // TODO: doesn't work at the moment, adv comes back showing last screen
-      // content
-      ForceClear();
 
       System::GetInstance()->PowerDown();
     }


### PR DESCRIPTION
The power button hold message timing was not working correctly because of the underlying timing issue of the FreeRTOS task that was actually preventing AnimationUpdate from running at the correct 50Hz and instead limited it incorrectly to approx 20Hz.

Additionally I took the opportunity to clean up some nearby and related code.

@democloid : this will likely get superceded by #700 but I wasn't sure how far off that is from being ready to merge?

Fixes: #706