### PR TITLE
Cleanup adv Filesystem code

### DIFF
--- a/sources/Adapters/adv/filesystem/CMakeLists.txt
+++ b/sources/Adapters/adv/filesystem/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(platform_filesystem
-  picoFileSystem.h picoFileSystem.cpp
+  advFileSystem.h advFileSystem.cpp
 )
 
 target_link_libraries(platform_filesystem PUBLIC

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -6,7 +6,7 @@
  * This file is part of the picoTracker firmware
  */
 
-#include "picoFileSystem.h"
+#include "advFileSystem.h"
 
 FATFS SDFatFS;
 char SDPath[4];
@@ -14,7 +14,7 @@ char SDPath[4];
 // use max int value for parent dir marker
 #define PARENT_DIR_MARKER_INDEX (std::numeric_limits<int>::max())
 
-picoFileSystem::picoFileSystem() {
+advFileSystem::advFileSystem() {
 
   // Link FatFs driver
   FATFS_LinkDriver(&SD_DMA_Driver, SDPath);
@@ -33,7 +33,7 @@ picoFileSystem::picoFileSystem() {
   //  }
 }
 
-I_File *picoFileSystem::Open(const char *name, const char *mode) {
+I_File *advFileSystem::Open(const char *name, const char *mode) {
   Trace::Log("FILESYSTEM", "Open file:%s, mode:%s", name, mode);
   BYTE rmode;
   switch (*mode) {
@@ -59,7 +59,7 @@ I_File *picoFileSystem::Open(const char *name, const char *mode) {
   return wFile;
 }
 
-bool picoFileSystem::chdir(const char *name) {
+bool advFileSystem::chdir(const char *name) {
   Trace::Log("PICOFILESYSTEM", "chdir:%s", name);
 
   FRESULT res = f_chdir(name);
@@ -86,7 +86,7 @@ bool picoFileSystem::chdir(const char *name) {
   return (res == FR_OK);
 }
 
-PicoFileType picoFileSystem::getFileType(int index) {
+PicoFileType advFileSystem::getFileType(int index) {
   /*
   FsBaseFile cwd;
   if (!cwd.openCwd()) {
@@ -114,8 +114,8 @@ PicoFileType picoFileSystem::getFileType(int index) {
   return PFT_FILE;
 }
 
-void picoFileSystem::list(etl::ivector<int> *fileIndexes, const char *filter,
-                          bool subDirOnly) {
+void advFileSystem::list(etl::ivector<int> *fileIndexes, const char *filter,
+                         bool subDirOnly) {
 
   fileIndexes->clear();
 
@@ -227,7 +227,7 @@ void picoFileSystem::list(etl::ivector<int> *fileIndexes, const char *filter,
              fileIndexes->size());
 }
 
-void picoFileSystem::getFileName(int index, char *name, int length) {
+void advFileSystem::getFileName(int index, char *name, int length) {
   /*
   FsFile cwd;
   char dirname[PFILENAME_SIZE];
@@ -251,7 +251,7 @@ void picoFileSystem::getFileName(int index, char *name, int length) {
   strcpy(name, fno.fname);
 }
 
-FILINFO picoFileSystem::fileFromIndex(int index) {
+FILINFO advFileSystem::fileFromIndex(int index) {
   FILINFO fno;
   FRESULT res = f_getcwd(filepath, 256);
   int32_t count = 0;
@@ -275,7 +275,7 @@ FILINFO picoFileSystem::fileFromIndex(int index) {
   return fno;
 }
 
-bool picoFileSystem::isParentRoot() {
+bool advFileSystem::isParentRoot() {
   /*
   FsFile cwd;
   char dirname[PFILENAME_SIZE];
@@ -300,7 +300,7 @@ bool picoFileSystem::isParentRoot() {
   return false;
 }
 
-bool picoFileSystem::DeleteFile(const char *path) { /*return sd.remove(path);*/
+bool advFileSystem::DeleteFile(const char *path) { /*return sd.remove(path);*/
   FILINFO fil;
   FRESULT res;
   res = f_stat(path, &fil);
@@ -317,7 +317,7 @@ bool picoFileSystem::DeleteFile(const char *path) { /*return sd.remove(path);*/
 }
 
 // directory has to be empty
-bool picoFileSystem::DeleteDir(const char *path) {
+bool advFileSystem::DeleteDir(const char *path) {
   /*
   auto delDir = sd.open(path, O_READ);
   return delDir.rmdir();
@@ -337,7 +337,7 @@ bool picoFileSystem::DeleteDir(const char *path) {
   return res == FR_OK;
 }
 
-bool picoFileSystem::exists(const char *path) { /*return sd.exists(path);*/
+bool advFileSystem::exists(const char *path) { /*return sd.exists(path);*/
   FILINFO fno;
   FRESULT res = f_stat(path, &fno);
   return res == FR_OK;
@@ -351,7 +351,7 @@ bool picoFileSystem::exists(const char *path) { /*return sd.exists(path);*/
  *
  * \return true if the directory was successfully created, false otherwise.
  */
-bool picoFileSystem::makeDir(const char *path, bool pFlag) {
+bool advFileSystem::makeDir(const char *path, bool pFlag) {
   if (!pFlag) {
     FRESULT res = f_mkdir(path);
     return res == FR_OK;
@@ -384,7 +384,7 @@ bool picoFileSystem::makeDir(const char *path, bool pFlag) {
   return (res == FR_OK || res == FR_EXIST);
 }
 
-uint64_t picoFileSystem::getFileSize(const int index) {
+uint64_t advFileSystem::getFileSize(const int index) {
   /*
   FsBaseFile cwd;
   FsBaseFile entry;
@@ -406,7 +406,7 @@ uint64_t picoFileSystem::getFileSize(const int index) {
   return fno.fsize;
 }
 
-bool picoFileSystem::CopyFile(const char *srcPath, const char *destPath) {
+bool advFileSystem::CopyFile(const char *srcPath, const char *destPath) {
   /*
   auto fSrc = sd.open(srcPath, O_READ);
   auto fDest = sd.open(destPath, O_WRITE | O_CREAT);
@@ -463,7 +463,7 @@ bool picoFileSystem::CopyFile(const char *srcPath, const char *destPath) {
   return res == FR_OK;
 }
 
-void picoFileSystem::tolowercase(char *temp) {
+void advFileSystem::tolowercase(char *temp) {
   // Convert to upper case
   char *s = temp;
   while (*s != '\0') {

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -195,8 +195,27 @@ FILINFO advFileSystem::fileFromIndex(int index) {
 }
 
 bool advFileSystem::isParentRoot() {
-  // TODO: implement
-  return false;
+  FRESULT res = f_getcwd(filepath, sizeof(filepath));
+  if (res != FR_OK) {
+    Trace::Error("Failed to get current directory");
+    return false;
+  }
+
+  // If current path is root ("/"), then parent is also root
+  if (strcmp(filepath, "/") == 0) {
+    return true;
+  }
+
+  // Check if we're in a direct subdirectory of root
+  // Count the number of '/' characters - if only 1, we're in root's child
+  int slashCount = 0;
+  for (int i = 0; filepath[i] != '\0'; i++) {
+    if (filepath[i] == '/') {
+      slashCount++;
+    }
+  }
+  // If path is "/dirname", slashCount will be 1, meaning parent is root
+  return (slashCount == 1);
 }
 
 bool advFileSystem::DeleteFile(const char *path) {

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -367,12 +367,6 @@ void PI_File::Seek(long offset, int whence) {
   }
 }
 
-bool PI_File::DeleteFile() {
-  // TODO: implement
-  // f_unlink();                //????
-  return false;
-}
-
 int PI_File::GetC() {
   TCHAR c[2];
   f_gets(c, 2, &file_);

--- a/sources/Adapters/adv/filesystem/advFileSystem.h
+++ b/sources/Adapters/adv/filesystem/advFileSystem.h
@@ -42,10 +42,10 @@ private:
   FIL file_;
 };
 
-class picoFileSystem : public FileSystem {
+class advFileSystem : public FileSystem {
 public:
-  picoFileSystem(); // OK
-  virtual ~picoFileSystem(){};
+  advFileSystem(); // OK
+  virtual ~advFileSystem(){};
   virtual I_File *Open(const char *name, const char *mode) override; // OK
   virtual bool chdir(const char *path) override;                     // OK
   virtual void list(etl::ivector<int> *fileIndexes, const char *filter,

--- a/sources/Adapters/adv/filesystem/advFileSystem.h
+++ b/sources/Adapters/adv/filesystem/advFileSystem.h
@@ -29,14 +29,13 @@ class PI_File : public I_File {
 public:
   PI_File(FIL file); // OK
   ~PI_File(){};
-  int Read(void *ptr, int size); // OK
-  int GetC();
-  int Write(const void *ptr, int size, int nmemb);
-  void Seek(long offset, int whence); // OK
-  long Tell();
-  bool Close();
-  bool DeleteFile();
-  int Error();
+  int Read(void *ptr, int size) override; // OK
+  int GetC() override;
+  int Write(const void *ptr, int size, int nmemb) override;
+  void Seek(long offset, int whence) override; // OK
+  long Tell() override;
+  bool Close() override;
+  int Error() override;
 
 private:
   FIL file_;

--- a/sources/Adapters/adv/gui/advGUIWindowImp.cpp
+++ b/sources/Adapters/adv/gui/advGUIWindowImp.cpp
@@ -19,7 +19,7 @@
 #ifdef USB_REMOTE_UI
 #include "picoRemoteUI.h"
 #endif
-#include "Adapters/adv/filesystem/picoFileSystem.h"
+#include "Adapters/adv/filesystem/advFileSystem.h"
 #include <string>
 
 #define to_rgb565(color)                                                       \

--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -8,7 +8,7 @@
 
 #include "advSystem.h"
 #include "Adapters/adv/audio/advAudio.h"
-#include "Adapters/adv/filesystem/picoFileSystem.h"
+#include "Adapters/adv/filesystem/advFileSystem.h"
 #include "Adapters/adv/gui/GUIFactory.h"
 #include "Adapters/adv/midi/advMidiService.h"
 #include "Adapters/adv/system/advSamplePool.h"
@@ -66,8 +66,8 @@ void advSystem::Boot() {
 
   // Install FileSystem
   __attribute__((
-      section(".DATA_RAM"))) static char fsMemBuf[sizeof(picoFileSystem)];
-  FileSystem::Install(new (fsMemBuf) picoFileSystem());
+      section(".DATA_RAM"))) static char fsMemBuf[sizeof(advFileSystem)];
+  FileSystem::Install(new (fsMemBuf) advFileSystem());
 
   // First check for SDCard
   auto fs = FileSystem::GetInstance();

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -296,11 +296,6 @@ void picoTrackerFile::Seek(long offset, int whence) {
   }
 }
 
-bool picoTrackerFile::DeleteFile() {
-  std::lock_guard<Mutex> lock(mutex);
-  return file_.remove();
-}
-
 int picoTrackerFile::GetC() {
   std::lock_guard<Mutex> lock(mutex);
   return file_.read();

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -63,7 +63,6 @@ public:
   virtual void Seek(long offset, int whence) override;
   virtual long Tell() override;
   virtual bool Close() override;
-  virtual bool DeleteFile() override;
   virtual int Error() override;
 
 private:

--- a/sources/System/FileSystem/I_File.h
+++ b/sources/System/FileSystem/I_File.h
@@ -21,7 +21,6 @@ public:
   virtual void Seek(long offset, int whence) = 0;
   virtual long Tell() = 0;
   virtual bool Close() = 0;
-  virtual bool DeleteFile() = 0;
   virtual int Error() = 0;
 };
 


### PR DESCRIPTION
Cleans up old commented out code in advance filesystem, renames the class to match convention and implements missing isParentRoot().

Also removes unused duplicate DeleteFile() function on I_file as its already provided by the FileSystem interface class.

Fixes: #733