### PR TITLE
Increase size of input event task

### DIFF
--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -297,9 +297,9 @@ int advEventManager::MainLoop() {
   sd_bench();
 #endif
 
-  static StackType_t InputEventsStack[1000];
+  static StackType_t InputEventsStack[2000];
   static StaticTask_t InputEventsTCB;
-  xTaskCreateStatic(ProcessInputEvent, "InEvent", 1000, NULL, 2,
+  xTaskCreateStatic(ProcessInputEvent, "InEvent", 2000, NULL, 2,
                     InputEventsStack, &InputEventsTCB);
 
 #ifdef SERIAL_REPL


### PR DESCRIPTION
This to prevents a hardfault when importing sample files via the import browser which was occurring due to stackoverflow on the input task.

Fixes: #736