### PR TITLE
Record to files with wav header

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,20 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+//
+// Debugging with GDB+OpenOCD not yet available in Zed see:
+//https://github.com/zed-industries/zed/discussions/31577#discussioncomment-13761205
+[
+  {
+    "label": "Debug native binary",
+    "build": {
+      "command": "make",
+      "args": ["-j8"],
+      "cwd": "$ZED_WORKTREE_ROOT"
+    },
+    "program": "$ZED_WORKTREE_ROOT/build/Adapters/adv/picoTrackerAdvance.elf",
+    "request": "launch",
+    "adapter": "GDB"
+  }
+]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,39 @@
+// Project tasks configuration. See https://zed.dev/docs/tasks for documentation.
+[
+  {
+    "label": "CMake configure Debug",
+    "command": "cmake",
+    "args": ["-DCMAKE_BUILD_TYPE=Debug", "-B", "build/", "-S", "sources/"],
+    "env": {},
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always"
+  },
+  {
+    "label": "CMake build",
+    "command": "cmake",
+    "args": ["--build", "build"],
+    "env": {},
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always"
+  },
+  {
+    "label": "CMake configure Debug and build",
+    "command": "cmake -DCMAKE_BUILD_TYPE=Debug -S sources/ -B build/ && cmake --build build/",
+    "args": [],
+    "env": {},
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always"
+  },
+  {
+    "label": "CMake configure Release and build",
+    "command": "cmake -DCMAKE_BUILD_TYPE=Release -S sources/ -B optbuild/ && cmake --build optbuild/",
+    "args": [],
+    "env": {},
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always"
+  }
+]

--- a/sources/Adapters/adv/audio/advAudioDriver.cpp
+++ b/sources/Adapters/adv/audio/advAudioDriver.cpp
@@ -47,6 +47,10 @@ void advAudioDriver::IRQHandler() { instance_->OnChunkDone(); }
 void AudioThread(void *) {
   while (true) {
     xSemaphoreTake(core1_audio, portMAX_DELAY);
+
+    // Process MIDI
+    MidiService::GetInstance()->Flush();
+
     advAudioDriver::BufferNeeded();
   }
 }
@@ -129,9 +133,6 @@ void advAudioDriver::StopDriver() {
 
 void advAudioDriver::OnChunkDone() {
   if (isPlaying_) {
-
-    // Process MIDI
-    MidiService::GetInstance()->Flush();
 
     // We got an IRQ so we know we finished playing from poolPlayPosition_
     // We mark it as empty and inspect the next buffer, if the buffer is not

--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -125,8 +125,7 @@ void Record(void *) {
                                            RECORD_BUFFER_SIZE, 1);
       // sync immediately after writing the buffer for consistent if not fastest
       // perf
-      // TODO: need to add Sync() to FileSystem interface API
-      // RecordFile->Sync();
+      RecordFile->Sync();
       writeInProgress = false;
       if (bytesWritten != RECORD_BUFFER_SIZE) {
         Trace::Error("write failed\r\n");

--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -1,7 +1,7 @@
 #include "record.h"
+#include "Application/Instruments/WavHeaderWriter.h"
 #include "Application/Player/Player.h"
 #include "System/Console/Trace.h"
-#include "Application/Instruments/WavHeaderWriter.h"
 #include "System/FileSystem/FileSystem.h"
 #include "sai.h"
 #include "sd_diskio.h"
@@ -9,7 +9,7 @@
 #include <cstdio>
 #include <cstring>
 
-static I_File* RecordFile = nullptr;
+static I_File *RecordFile = nullptr;
 
 uint8_t *activeBuffer;
 uint8_t *writeBuffer;
@@ -32,7 +32,7 @@ bool StartRecording(const char *filename, uint8_t threshold,
                     uint32_t milliseconds) {
   thresholdOK = false;
   first_pass = true;
-  
+
   // Create or truncate the file using FileSystem
   RecordFile = FileSystem::GetInstance()->Open(filename, "wb");
   if (!RecordFile) {
@@ -86,19 +86,19 @@ void Record(void *) {
 
     if (!recordingActive) {
       HAL_SAI_DMAStop(&hsai_BlockB1);
-      
+
       if (RecordFile) {
         // Update WAV header with final file size
         if (!WavHeaderWriter::UpdateFileSize(RecordFile, totalSamplesWritten)) {
           Trace::Log("RECORD", "Failed to update WAV header");
         }
-        
+
         // Close file
         RecordFile->Close();
         delete RecordFile;
         RecordFile = nullptr;
       }
-      
+
       Player::GetInstance()->StopRecordStreaming();
       vTaskSuspend(nullptr); // Suspend self until StartRecording resumes it
     }
@@ -122,12 +122,14 @@ void Record(void *) {
     writeInProgress = true;
     // Write raw audio data (uint16_t samples as bytes)
     if (RecordFile) {
-      int bytesWritten = RecordFile->Write((uint8_t *)(recordBuffer + offset), RECORD_BUFFER_SIZE, 1);
+      int bytesWritten = RecordFile->Write((uint8_t *)(recordBuffer + offset),
+                                           RECORD_BUFFER_SIZE, 1);
       writeInProgress = false;
       if (bytesWritten != RECORD_BUFFER_SIZE) {
         Trace::Error("write failed\r\n");
       } else {
-        // Track total samples written (RECORD_BUFFER_SIZE bytes = RECORD_BUFFER_SIZE/4 stereo samples)
+        // Track total samples written (RECORD_BUFFER_SIZE bytes =
+        // RECORD_BUFFER_SIZE/4 stereo samples)
         totalSamplesWritten += RECORD_BUFFER_SIZE / 4;
       }
     } else {

--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -1,13 +1,15 @@
 #include "record.h"
 #include "Application/Player/Player.h"
 #include "System/Console/Trace.h"
+#include "Application/Instruments/WavHeaderWriter.h"
+#include "System/FileSystem/FileSystem.h"
 #include "sai.h"
 #include "sd_diskio.h"
 #include "tlv320aic3204.h"
 #include <cstdio>
 #include <cstring>
 
-static FIL RecordFile;
+static I_File* RecordFile = nullptr;
 
 uint8_t *activeBuffer;
 uint8_t *writeBuffer;
@@ -24,21 +26,31 @@ static volatile bool isHalfBuffer = false;
 static volatile bool thresholdOK = false;
 static bool first_pass = true;
 static uint32_t start = 0;
+static uint32_t totalSamplesWritten = 0;
 
 bool StartRecording(const char *filename, uint8_t threshold,
                     uint32_t milliseconds) {
   thresholdOK = false;
   first_pass = true;
-  // Create or truncate the file
-  auto fs_status =
-      f_open(&RecordFile, filename, FA_READ | FA_WRITE | FA_CREATE_ALWAYS);
-  if (fs_status != FR_OK) {
+  
+  // Create or truncate the file using FileSystem
+  RecordFile = FileSystem::GetInstance()->Open(filename, "wb");
+  if (!RecordFile) {
     Trace::Log("RECORD", "Could not create file");
     return false;
   }
 
-  // If file already exists, truncate it
-  f_truncate(&RecordFile);
+  // Write WAV header (44.1kHz, 16-bit, stereo)
+  if (!WavHeaderWriter::WriteHeader(RecordFile, 44100, 2, 16)) {
+    Trace::Log("RECORD", "Failed to write WAV header");
+    RecordFile->Close();
+    delete RecordFile;
+    RecordFile = nullptr;
+    return false;
+  }
+
+  // Reset sample counter
+  totalSamplesWritten = 0;
 
   // Setup the codec
   tlv320_enable_linein();
@@ -74,9 +86,19 @@ void Record(void *) {
 
     if (!recordingActive) {
       HAL_SAI_DMAStop(&hsai_BlockB1);
-      // sync file and close (if open)
-      f_sync(&RecordFile);
-      f_close(&RecordFile);
+      
+      if (RecordFile) {
+        // Update WAV header with final file size
+        if (!WavHeaderWriter::UpdateFileSize(RecordFile, totalSamplesWritten)) {
+          Trace::Log("RECORD", "Failed to update WAV header");
+        }
+        
+        // Close file
+        RecordFile->Close();
+        delete RecordFile;
+        RecordFile = nullptr;
+      }
+      
       Player::GetInstance()->StopRecordStreaming();
       vTaskSuspend(nullptr); // Suspend self until StartRecording resumes it
     }
@@ -98,13 +120,19 @@ void Record(void *) {
       }
       }*/
     writeInProgress = true;
-    // full buffer length as uint8_t (which is half of the uint16_t buffer)
-    f_write(&RecordFile, (uint8_t *)(recordBuffer + offset), RECORD_BUFFER_SIZE,
-            &bw);
-    f_sync(&RecordFile);
-    writeInProgress = false;
-    if (bw != RECORD_BUFFER_SIZE) {
-      Trace::Error("write failed\r\n");
+    // Write raw audio data (uint16_t samples as bytes)
+    if (RecordFile) {
+      int bytesWritten = RecordFile->Write((uint8_t *)(recordBuffer + offset), RECORD_BUFFER_SIZE, 1);
+      writeInProgress = false;
+      if (bytesWritten != RECORD_BUFFER_SIZE) {
+        Trace::Error("write failed\r\n");
+      } else {
+        // Track total samples written (RECORD_BUFFER_SIZE bytes = RECORD_BUFFER_SIZE/4 stereo samples)
+        totalSamplesWritten += RECORD_BUFFER_SIZE / 4;
+      }
+    } else {
+      writeInProgress = false;
+      Trace::Error("RecordFile is null\r\n");
     }
     // start playing
     if (first_pass) {

--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -77,6 +77,7 @@ void StopRecording() { recordingActive = false; }
 
 void Record(void *) {
   UINT bw;
+  uint32_t lastLoggedTime = xTaskGetTickCount();
   for (;;) {
     if (!recordingActive) {
       HAL_SAI_DMAStop(&hsai_BlockB1);
@@ -133,8 +134,10 @@ void Record(void *) {
         // RECORD_BUFFER_SIZE/4 stereo samples)
         totalSamplesWritten += RECORD_BUFFER_SIZE / 4;
 
-        if (xTaskGetTickCount() % 1000) {
-          Trace::Debug("RECORDING...");
+        auto now = xTaskGetTickCount();
+        if ((now - lastLoggedTime) > 1000) { // log every sec
+          Trace::Debug("RECORDING [%i]s", (xTaskGetTickCount() - start) / 1000);
+          lastLoggedTime = now;
         }
       }
     } else {

--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -34,7 +34,7 @@ bool StartRecording(const char *filename, uint8_t threshold,
   first_pass = true;
 
   // Create or truncate the file using FileSystem
-  RecordFile = FileSystem::GetInstance()->Open(filename, "wb");
+  RecordFile = FileSystem::GetInstance()->Open(filename, "w");
   if (!RecordFile) {
     Trace::Log("RECORD", "Could not create file");
     return false;
@@ -44,7 +44,6 @@ bool StartRecording(const char *filename, uint8_t threshold,
   if (!WavHeaderWriter::WriteHeader(RecordFile, 44100, 2, 16)) {
     Trace::Log("RECORD", "Failed to write WAV header");
     RecordFile->Close();
-    delete RecordFile;
     RecordFile = nullptr;
     return false;
   }
@@ -95,7 +94,6 @@ void Record(void *) {
 
         // Close file
         RecordFile->Close();
-        delete RecordFile;
         RecordFile = nullptr;
       }
 

--- a/sources/Adapters/adv/audio/record.h
+++ b/sources/Adapters/adv/audio/record.h
@@ -23,6 +23,6 @@ extern TaskHandle_t RecordHandle;
 void Record(void *);
 bool StartRecording(const char *filename, uint8_t threshold,
                     uint32_t milliseconds);
-void stopRecording();
+void StopRecording();
 
 #endif

--- a/sources/Adapters/adv/filesystem/CMakeLists.txt
+++ b/sources/Adapters/adv/filesystem/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(platform_filesystem
-  picoFileSystem.h picoFileSystem.cpp
+  advFileSystem.h advFileSystem.cpp
 )
 
 target_link_libraries(platform_filesystem PUBLIC

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -407,7 +407,7 @@ bool PI_File::Close() {
   return res == FR_OK;
 }
 
-void PI_File::Sync() {
-  FRESULT res = f_sync();
+bool PI_File::Sync() {
+  FRESULT res = f_sync(&file_);
   return res == FR_OK;
 }

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -406,3 +406,8 @@ bool PI_File::Close() {
   FRESULT res = f_close(&file_);
   return res == FR_OK;
 }
+
+void PI_File::Sync() {
+  FRESULT res = f_sync();
+  return res == FR_OK;
+}

--- a/sources/Adapters/adv/filesystem/advFileSystem.h
+++ b/sources/Adapters/adv/filesystem/advFileSystem.h
@@ -29,23 +29,22 @@ class PI_File : public I_File {
 public:
   PI_File(FIL file); // OK
   ~PI_File(){};
-  int Read(void *ptr, int size); // OK
-  int GetC();
-  int Write(const void *ptr, int size, int nmemb);
-  void Seek(long offset, int whence); // OK
-  long Tell();
-  bool Close();
-  bool DeleteFile();
-  int Error();
+  int Read(void *ptr, int size) override; // OK
+  int GetC() override;
+  int Write(const void *ptr, int size, int nmemb) override;
+  void Seek(long offset, int whence) override; // OK
+  long Tell() override;
+  bool Close() override;
+  int Error() override;
 
 private:
   FIL file_;
 };
 
-class picoFileSystem : public FileSystem {
+class advFileSystem : public FileSystem {
 public:
-  picoFileSystem(); // OK
-  virtual ~picoFileSystem(){};
+  advFileSystem(); // OK
+  virtual ~advFileSystem(){};
   virtual I_File *Open(const char *name, const char *mode) override; // OK
   virtual bool chdir(const char *path) override;                     // OK
   virtual void list(etl::ivector<int> *fileIndexes, const char *filter,

--- a/sources/Adapters/adv/filesystem/advFileSystem.h
+++ b/sources/Adapters/adv/filesystem/advFileSystem.h
@@ -36,6 +36,7 @@ public:
   long Tell() override;
   bool Close() override;
   int Error() override;
+  bool Sync() override;
 
 private:
   FIL file_;

--- a/sources/Adapters/adv/gui/SerialDebugUI.cpp
+++ b/sources/Adapters/adv/gui/SerialDebugUI.cpp
@@ -8,6 +8,7 @@
 
 #include "SerialDebugUI.h"
 #include "../system/advSystem.h"
+#include "Adapters/adv/audio/record.h"
 #include "Application/Model/Config.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/FileSystem/I_File.h"
@@ -137,6 +138,17 @@ void SerialDebugUI::dispatchCmd(char *input) {
     shutdown();
   } else if (strcmp(cmd, "battery") == 0) {
     readBattery();
+  } else if (strcmp(cmd, "startrec") == 0) {
+    // char *filename = strtok(NULL, " ");
+    // uint32_t milliseconds = atoi(strtok(NULL, " "));
+    // uint32_t threshold = atoi(strtok(NULL, " "));
+
+    FileSystem::GetInstance()->chdir("/");
+
+    const char *filename = "testrecord.wav";
+    StartRecording(filename, 1, 0);
+  } else if (strcmp(cmd, "stoprec") == 0) {
+    StopRecording();
   } else if (strcmp(cmd, "help") == 0) {
     Trace::Log("SERIALDEBUG", "cat, ls, rm, mkdir, rmdir, save, battery, help");
   } else {

--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -202,7 +202,7 @@ void timerStatsHandler(TimerHandle_t xTimer) {
 }
 #endif
 
-// timer callback at a rate of 50Hz
+// timer callback at a rate of PICO_CLOCK_HZ
 void timerHandler(TimerHandle_t xTimer) {
   UNUSED(xTimer);
   Event ev(CLOCK);
@@ -265,8 +265,9 @@ bool advEventManager::Init() {
                          /* The timer period in ticks, must be greater than
                          0.
                           */
-                         PICO_CLOCK_INTERVAL, // 50Hz timer for timeHanlder to
-                                              // create UI redraw events
+                         PICO_CLOCK_INTERVAL, // PICO_CLOCK_HZ timer for
+                                              // timeHandler to create UI redraw
+                                              // events
 
                          /* The timers will auto-reload themselves when they
                           * expire.
@@ -298,9 +299,9 @@ int advEventManager::MainLoop() {
   sd_bench();
 #endif
 
-  static StackType_t InputEventsStack[1000];
+  static StackType_t InputEventsStack[2000];
   static StaticTask_t InputEventsTCB;
-  xTaskCreateStatic(ProcessInputEvent, "InEvent", 1000, NULL, 2,
+  xTaskCreateStatic(ProcessInputEvent, "InEvent", 2000, NULL, 2,
                     InputEventsStack, &InputEventsTCB);
 
 #ifdef SERIAL_REPL

--- a/sources/Adapters/adv/gui/advGUIWindowImp.cpp
+++ b/sources/Adapters/adv/gui/advGUIWindowImp.cpp
@@ -19,7 +19,7 @@
 #ifdef USB_REMOTE_UI
 #include "picoRemoteUI.h"
 #endif
-#include "Adapters/adv/filesystem/picoFileSystem.h"
+#include "Adapters/adv/filesystem/advFileSystem.h"
 #include <string>
 
 #define to_rgb565(color)                                                       \

--- a/sources/Adapters/adv/midi/advMidiOutDevice.cpp
+++ b/sources/Adapters/adv/midi/advMidiOutDevice.cpp
@@ -23,15 +23,15 @@ bool advMidiOutDevice::Start() { return true; };
 void advMidiOutDevice::Stop() {}
 
 void advMidiOutDevice::SendMessage(MidiMessage &msg) {
-  //  uart_putc_raw(MIDI_UART, msg.status_);
-  HAL_UART_Transmit(&MIDI_UART, (const uint8_t *)msg.status_, 1, 10);
+  uint8_t status = msg.status_;
+  HAL_UART_Transmit(&MIDI_UART, &status, 1, 10);
 
   if (msg.status_ < 0xF0) {
-    //    uart_putc_raw(MIDI_UART, msg.data1_);
-    HAL_UART_Transmit(&MIDI_UART, (const uint8_t *)msg.data1_, 1, 10);
+    uint8_t data1 = msg.data1_;
+    HAL_UART_Transmit(&MIDI_UART, &data1, 1, 10);
     if (msg.data2_ != MidiMessage::UNUSED_BYTE) {
-      // uart_putc_raw(MIDI_UART, msg.data2_);
-      HAL_UART_Transmit(&MIDI_UART, (const uint8_t *)msg.data2_, 1, 10);
+      uint8_t data2 = msg.data2_;
+      HAL_UART_Transmit(&MIDI_UART, &data2, 1, 10);
     }
   }
 }

--- a/sources/Adapters/adv/system/advSamplePool.cpp
+++ b/sources/Adapters/adv/system/advSamplePool.cpp
@@ -9,9 +9,9 @@
 #include "advSamplePool.h"
 
 // TODO: Only using sampleStore1 for now
-__attribute__((section(".SDRAM1"))) __attribute__((aligned(32)))
-uint8_t sampleStore1[STORE1_SIZE];
 __attribute__((section(".SDRAM2"))) __attribute__((aligned(32)))
+uint8_t sampleStore1[STORE1_SIZE];
+__attribute__((section(".SDRAM1"))) __attribute__((aligned(32)))
 uint8_t sampleStore2[STORE2_SIZE];
 
 uint32_t advSamplePool::writeOffset1_ = 0;
@@ -76,6 +76,9 @@ bool advSamplePool::Load(WavFile *wave) {
     return false;
   }
 
+  // Ensure 4-byte alignment for SDRAM access at start of each file
+  writeOffset1_ = (writeOffset1_ + 3) & ~3;
+
   // Set wave base
   wave->SetSampleBuffer((short *)(sampleStore1 + writeOffset1_));
 
@@ -85,7 +88,7 @@ bool advSamplePool::Load(WavFile *wave) {
   wave->Rewind();
   wave->Read(sampleStore1 + writeOffset1_, BUFFER_SIZE, &br);
   while (br > 0) {
-    Trace::Debug("Wrote %i bytes", br);
+    // Trace::Debug("Wrote %i bytes", br);
     writeOffset1_ += br;
     wave->Read(sampleStore1 + writeOffset1_, BUFFER_SIZE, &br);
   }

--- a/sources/Adapters/adv/system/advSamplePool.h
+++ b/sources/Adapters/adv/system/advSamplePool.h
@@ -11,8 +11,8 @@
 #include "Application/Instruments/WavFile.h"
 #include "System/Console/Trace.h"
 
-#define STORE1_SIZE 16 * 1024 * 1024
-#define STORE2_SIZE 32 * 1024 * 1024
+#define STORE1_SIZE 32 * 1024 * 1024
+#define STORE2_SIZE 16 * 1024 * 1024
 
 extern uint8_t sampleStore1[];
 extern uint8_t sampleStore2[];

--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -8,7 +8,7 @@
 
 #include "advSystem.h"
 #include "Adapters/adv/audio/advAudio.h"
-#include "Adapters/adv/filesystem/picoFileSystem.h"
+#include "Adapters/adv/filesystem/advFileSystem.h"
 #include "Adapters/adv/gui/GUIFactory.h"
 #include "Adapters/adv/midi/advMidiService.h"
 #include "Adapters/adv/system/advSamplePool.h"
@@ -66,8 +66,8 @@ void advSystem::Boot() {
 
   // Install FileSystem
   __attribute__((
-      section(".DATA_RAM"))) static char fsMemBuf[sizeof(picoFileSystem)];
-  FileSystem::Install(new (fsMemBuf) picoFileSystem());
+      section(".DATA_RAM"))) static char fsMemBuf[sizeof(advFileSystem)];
+  FileSystem::Install(new (fsMemBuf) advFileSystem());
 
   // First check for SDCard
   auto fs = FileSystem::GetInstance();

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -296,11 +296,6 @@ void picoTrackerFile::Seek(long offset, int whence) {
   }
 }
 
-bool picoTrackerFile::DeleteFile() {
-  std::lock_guard<Mutex> lock(mutex);
-  return file_.remove();
-}
-
 int picoTrackerFile::GetC() {
   std::lock_guard<Mutex> lock(mutex);
   return file_.read();

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.cpp
@@ -320,3 +320,8 @@ bool picoTrackerFile::Close() {
   std::lock_guard<Mutex> lock(mutex);
   return file_.close();
 }
+
+bool picoTrackerFile::Sync() {
+  std::lock_guard<Mutex> lock(mutex);
+  return file_.sync();
+}

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -64,6 +64,7 @@ public:
   virtual long Tell() override;
   virtual bool Close() override;
   virtual int Error() override;
+  virtual bool Sync() override;
 
 private:
   FsBaseFile file_;

--- a/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
+++ b/sources/Adapters/picoTracker/filesystem/picoTrackerFileSystem.h
@@ -63,7 +63,6 @@ public:
   virtual void Seek(long offset, int whence) override;
   virtual long Tell() override;
   virtual bool Close() override;
-  virtual bool DeleteFile() override;
   virtual int Error() override;
 
 private:

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -155,7 +155,7 @@ private:
 
   uint32_t lastAutoSave = 0;
 
-  // Counter for animation frames, updated once per frame at 50hz
+  // Counter for animation frames, updated once per frame at PICO_CLOCK_HZ
   static uint32_t animationFrameCounter_;
 
 public:

--- a/sources/Application/Instruments/CMakeLists.txt
+++ b/sources/Application/Instruments/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(application_instruments
   SoundSource.cpp
   WavFile.cpp
   WavFileWriter.cpp
+  WavHeaderWriter.cpp
 )
 
 target_link_libraries(application_instruments PUBLIC

--- a/sources/Application/Instruments/WavFileWriter.cpp
+++ b/sources/Application/Instruments/WavFileWriter.cpp
@@ -8,10 +8,10 @@
  */
 
 #include "WavFileWriter.h"
-#include "WavHeaderWriter.h"
 #include "System/Console/Trace.h"
 #include "System/FileSystem/I_File.h"
 #include "System/System/System.h"
+#include "WavHeaderWriter.h"
 
 WavFileWriter::WavFileWriter(const char *path)
     : sampleCount_(0), buffer_(0), bufferSize_(0), file_(0) {

--- a/sources/Application/Instruments/WavHeaderWriter.cpp
+++ b/sources/Application/Instruments/WavHeaderWriter.cpp
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#include "WavHeaderWriter.h"
+#include "System/FileSystem/I_File.h"
+#include "System/Console/Trace.h"
+
+uint32_t WavHeaderWriter::Swap32(uint32_t value) {
+    return ((value & 0xFF) << 24) | 
+           ((value & 0xFF00) << 8) | 
+           ((value & 0xFF0000) >> 8) | 
+           ((value & 0xFF000000) >> 24);
+}
+
+uint16_t WavHeaderWriter::Swap16(uint16_t value) {
+    return ((value & 0xFF) << 8) | ((value & 0xFF00) >> 8);
+}
+
+bool WavHeaderWriter::WriteHeader(I_File* file, uint32_t sampleRate, 
+                                 uint16_t channels, uint16_t bitsPerSample) {
+    if (!file) return false;
+    
+    // RIFF chunk
+    uint32_t chunk = Swap32(0x46464952); // "RIFF"
+    if (file->Write(&chunk, 1, 4) != 4) return false;
+    
+    uint32_t size = 0; // to be filled later
+    if (file->Write(&size, 1, 4) != 4) return false;
+
+    // WAVE chunk
+    chunk = Swap32(0x45564157); // "WAVE"
+    if (file->Write(&chunk, 1, 4) != 4) return false;
+    
+    chunk = Swap32(0x20746D66); // "fmt "
+    if (file->Write(&chunk, 1, 4) != 4) return false;
+    
+    size = Swap32(16); // fmt chunk size
+    if (file->Write(&size, 1, 4) != 4) return false;
+
+    uint16_t ushort = Swap16(1); // PCM compression
+    if (file->Write(&ushort, 1, 2) != 2) return false;
+    
+    ushort = Swap16(channels); // number of channels
+    if (file->Write(&ushort, 1, 2) != 2) return false;
+    
+    uint32_t swappedSampleRate = Swap32(sampleRate);
+    if (file->Write(&swappedSampleRate, 1, 4) != 4) return false;
+
+    uint32_t byteRate = Swap32((bitsPerSample / 8) * channels * sampleRate);
+    if (file->Write(&byteRate, 1, 4) != 4) return false;
+
+    ushort = Swap16((bitsPerSample / 8) * channels); // block align
+    if (file->Write(&ushort, 1, 2) != 2) return false;
+
+    ushort = Swap16(bitsPerSample); // bits per sample
+    if (file->Write(&ushort, 1, 2) != 2) return false;
+
+    // data subchunk
+    chunk = Swap32(0x61746164); // "data"
+    if (file->Write(&chunk, 1, 4) != 4) return false;
+
+    size = 0; // to be updated later
+    if (file->Write(&size, 1, 4) != 4) return false;
+    
+    return true;
+}
+
+bool WavHeaderWriter::UpdateFileSize(I_File* file, uint32_t sampleCount) {
+    if (!file) return false;
+    
+    // Calculate data size (sampleCount * channels * bytes per sample)
+    uint32_t dataSize = sampleCount * 2 * 2; // stereo * 16-bit
+    
+    // Update total file size (file size - 8 bytes for RIFF header)
+    size_t currentPos = file->Tell();
+    file->Seek(4, SEEK_SET);
+    uint32_t totalSize = Swap32(currentPos - 8);
+    file->Write(&totalSize, 4, 1);
+
+    // Update data chunk size
+    file->Seek(40, SEEK_SET);
+    uint32_t swappedDataSize = Swap32(dataSize);
+    file->Write(&swappedDataSize, 4, 1);
+
+    file->Seek(currentPos, SEEK_SET);
+    return true;
+}

--- a/sources/Application/Instruments/WavHeaderWriter.cpp
+++ b/sources/Application/Instruments/WavHeaderWriter.cpp
@@ -71,15 +71,19 @@ bool WavHeaderWriter::WriteHeader(I_File *file, uint32_t sampleRate,
   if (file->Write(&size, 1, 4) != 4)
     return false;
 
+  // TODO: need to add Sync() to FileSystem interface API
+  // file->Sync();
   return true;
 }
 
-bool WavHeaderWriter::UpdateFileSize(I_File *file, uint32_t sampleCount) {
+bool WavHeaderWriter::UpdateFileSize(I_File *file, uint32_t sampleCount,
+                                     uint16_t channels,
+                                     uint16_t bytesPerSample) {
   if (!file)
     return false;
 
   // Calculate data size (sampleCount * channels * bytes per sample)
-  uint32_t dataSize = sampleCount * 2 * 2; // stereo * 16-bit
+  uint32_t dataSize = sampleCount * channels * bytesPerSample;
 
   // Update total file size (file size - 8 bytes for RIFF header)
   size_t currentPos = file->Tell();

--- a/sources/Application/Instruments/WavHeaderWriter.cpp
+++ b/sources/Application/Instruments/WavHeaderWriter.cpp
@@ -71,8 +71,8 @@ bool WavHeaderWriter::WriteHeader(I_File *file, uint32_t sampleRate,
   if (file->Write(&size, 1, 4) != 4)
     return false;
 
-  // TODO: need to add Sync() to FileSystem interface API
-  // file->Sync();
+  // explicit file sync
+  file->Sync();
   return true;
 }
 

--- a/sources/Application/Instruments/WavHeaderWriter.cpp
+++ b/sources/Application/Instruments/WavHeaderWriter.cpp
@@ -9,15 +9,7 @@
 #include "WavHeaderWriter.h"
 #include "System/Console/Trace.h"
 #include "System/FileSystem/I_File.h"
-
-uint32_t WavHeaderWriter::Swap32(uint32_t value) {
-  return ((value & 0xFF) << 24) | ((value & 0xFF00) << 8) |
-         ((value & 0xFF0000) >> 8) | ((value & 0xFF000000) >> 24);
-}
-
-uint16_t WavHeaderWriter::Swap16(uint16_t value) {
-  return ((value & 0xFF) << 8) | ((value & 0xFF00) >> 8);
-}
+#include "WavFile.h"
 
 bool WavHeaderWriter::WriteHeader(I_File *file, uint32_t sampleRate,
                                   uint16_t channels, uint16_t bitsPerSample) {

--- a/sources/Application/Instruments/WavHeaderWriter.cpp
+++ b/sources/Application/Instruments/WavHeaderWriter.cpp
@@ -7,86 +7,99 @@
  */
 
 #include "WavHeaderWriter.h"
-#include "System/FileSystem/I_File.h"
 #include "System/Console/Trace.h"
+#include "System/FileSystem/I_File.h"
 
 uint32_t WavHeaderWriter::Swap32(uint32_t value) {
-    return ((value & 0xFF) << 24) | 
-           ((value & 0xFF00) << 8) | 
-           ((value & 0xFF0000) >> 8) | 
-           ((value & 0xFF000000) >> 24);
+  return ((value & 0xFF) << 24) | ((value & 0xFF00) << 8) |
+         ((value & 0xFF0000) >> 8) | ((value & 0xFF000000) >> 24);
 }
 
 uint16_t WavHeaderWriter::Swap16(uint16_t value) {
-    return ((value & 0xFF) << 8) | ((value & 0xFF00) >> 8);
+  return ((value & 0xFF) << 8) | ((value & 0xFF00) >> 8);
 }
 
-bool WavHeaderWriter::WriteHeader(I_File* file, uint32_t sampleRate, 
-                                 uint16_t channels, uint16_t bitsPerSample) {
-    if (!file) return false;
-    
-    // RIFF chunk
-    uint32_t chunk = Swap32(0x46464952); // "RIFF"
-    if (file->Write(&chunk, 1, 4) != 4) return false;
-    
-    uint32_t size = 0; // to be filled later
-    if (file->Write(&size, 1, 4) != 4) return false;
+bool WavHeaderWriter::WriteHeader(I_File *file, uint32_t sampleRate,
+                                  uint16_t channels, uint16_t bitsPerSample) {
+  if (!file)
+    return false;
 
-    // WAVE chunk
-    chunk = Swap32(0x45564157); // "WAVE"
-    if (file->Write(&chunk, 1, 4) != 4) return false;
-    
-    chunk = Swap32(0x20746D66); // "fmt "
-    if (file->Write(&chunk, 1, 4) != 4) return false;
-    
-    size = Swap32(16); // fmt chunk size
-    if (file->Write(&size, 1, 4) != 4) return false;
+  // RIFF chunk
+  uint32_t chunk = Swap32(0x46464952); // "RIFF"
+  if (file->Write(&chunk, 1, 4) != 4)
+    return false;
 
-    uint16_t ushort = Swap16(1); // PCM compression
-    if (file->Write(&ushort, 1, 2) != 2) return false;
-    
-    ushort = Swap16(channels); // number of channels
-    if (file->Write(&ushort, 1, 2) != 2) return false;
-    
-    uint32_t swappedSampleRate = Swap32(sampleRate);
-    if (file->Write(&swappedSampleRate, 1, 4) != 4) return false;
+  uint32_t size = 0; // to be filled later
+  if (file->Write(&size, 1, 4) != 4)
+    return false;
 
-    uint32_t byteRate = Swap32((bitsPerSample / 8) * channels * sampleRate);
-    if (file->Write(&byteRate, 1, 4) != 4) return false;
+  // WAVE chunk
+  chunk = Swap32(0x45564157); // "WAVE"
+  if (file->Write(&chunk, 1, 4) != 4)
+    return false;
 
-    ushort = Swap16((bitsPerSample / 8) * channels); // block align
-    if (file->Write(&ushort, 1, 2) != 2) return false;
+  chunk = Swap32(0x20746D66); // "fmt "
+  if (file->Write(&chunk, 1, 4) != 4)
+    return false;
 
-    ushort = Swap16(bitsPerSample); // bits per sample
-    if (file->Write(&ushort, 1, 2) != 2) return false;
+  size = Swap32(16); // fmt chunk size
+  if (file->Write(&size, 1, 4) != 4)
+    return false;
 
-    // data subchunk
-    chunk = Swap32(0x61746164); // "data"
-    if (file->Write(&chunk, 1, 4) != 4) return false;
+  uint16_t ushort = Swap16(1); // PCM compression
+  if (file->Write(&ushort, 1, 2) != 2)
+    return false;
 
-    size = 0; // to be updated later
-    if (file->Write(&size, 1, 4) != 4) return false;
-    
-    return true;
+  ushort = Swap16(channels); // number of channels
+  if (file->Write(&ushort, 1, 2) != 2)
+    return false;
+
+  uint32_t swappedSampleRate = Swap32(sampleRate);
+  if (file->Write(&swappedSampleRate, 1, 4) != 4)
+    return false;
+
+  uint32_t byteRate = Swap32((bitsPerSample / 8) * channels * sampleRate);
+  if (file->Write(&byteRate, 1, 4) != 4)
+    return false;
+
+  ushort = Swap16((bitsPerSample / 8) * channels); // block align
+  if (file->Write(&ushort, 1, 2) != 2)
+    return false;
+
+  ushort = Swap16(bitsPerSample); // bits per sample
+  if (file->Write(&ushort, 1, 2) != 2)
+    return false;
+
+  // data subchunk
+  chunk = Swap32(0x61746164); // "data"
+  if (file->Write(&chunk, 1, 4) != 4)
+    return false;
+
+  size = 0; // to be updated later
+  if (file->Write(&size, 1, 4) != 4)
+    return false;
+
+  return true;
 }
 
-bool WavHeaderWriter::UpdateFileSize(I_File* file, uint32_t sampleCount) {
-    if (!file) return false;
-    
-    // Calculate data size (sampleCount * channels * bytes per sample)
-    uint32_t dataSize = sampleCount * 2 * 2; // stereo * 16-bit
-    
-    // Update total file size (file size - 8 bytes for RIFF header)
-    size_t currentPos = file->Tell();
-    file->Seek(4, SEEK_SET);
-    uint32_t totalSize = Swap32(currentPos - 8);
-    file->Write(&totalSize, 4, 1);
+bool WavHeaderWriter::UpdateFileSize(I_File *file, uint32_t sampleCount) {
+  if (!file)
+    return false;
 
-    // Update data chunk size
-    file->Seek(40, SEEK_SET);
-    uint32_t swappedDataSize = Swap32(dataSize);
-    file->Write(&swappedDataSize, 4, 1);
+  // Calculate data size (sampleCount * channels * bytes per sample)
+  uint32_t dataSize = sampleCount * 2 * 2; // stereo * 16-bit
 
-    file->Seek(currentPos, SEEK_SET);
-    return true;
+  // Update total file size (file size - 8 bytes for RIFF header)
+  size_t currentPos = file->Tell();
+  file->Seek(4, SEEK_SET);
+  uint32_t totalSize = Swap32(currentPos - 8);
+  file->Write(&totalSize, 4, 1);
+
+  // Update data chunk size
+  file->Seek(40, SEEK_SET);
+  uint32_t swappedDataSize = Swap32(dataSize);
+  file->Write(&swappedDataSize, 4, 1);
+
+  file->Seek(currentPos, SEEK_SET);
+  return true;
 }

--- a/sources/Application/Instruments/WavHeaderWriter.h
+++ b/sources/Application/Instruments/WavHeaderWriter.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _WAV_HEADER_WRITER_H_
+#define _WAV_HEADER_WRITER_H_
+
+#include "System/FileSystem/FileSystem.h"
+
+class WavHeaderWriter {
+public:
+  // Write WAV header to I_File
+  static bool WriteHeader(I_File *file, uint32_t sampleRate = 44100,
+                          uint16_t channels = 2, uint16_t bitsPerSample = 16);
+
+  // Update file size in WAV header for I_File
+  static bool UpdateFileSize(I_File *file, uint32_t sampleCount);
+
+private:
+  static uint32_t Swap32(uint32_t value);
+  static uint16_t Swap16(uint16_t value);
+};
+
+#endif

--- a/sources/Application/Instruments/WavHeaderWriter.h
+++ b/sources/Application/Instruments/WavHeaderWriter.h
@@ -19,10 +19,6 @@ public:
 
   // Update file size in WAV header for I_File
   static bool UpdateFileSize(I_File *file, uint32_t sampleCount);
-
-private:
-  static uint32_t Swap32(uint32_t value);
-  static uint16_t Swap16(uint16_t value);
 };
 
 #endif

--- a/sources/Application/Instruments/WavHeaderWriter.h
+++ b/sources/Application/Instruments/WavHeaderWriter.h
@@ -18,7 +18,9 @@ public:
                           uint16_t channels = 2, uint16_t bitsPerSample = 16);
 
   // Update file size in WAV header for I_File
-  static bool UpdateFileSize(I_File *file, uint32_t sampleCount);
+  static bool UpdateFileSize(I_File *file, uint32_t sampleCount,
+                             uint16_t channels = 2,
+                             uint16_t bytesPerSample = 16);
 };
 
 #endif

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -193,6 +193,8 @@ void ImportView::DrawView() {
       // Handle directories
       char tempBuffer[PFILENAME_SIZE];
       displayName = "/";
+      // clear temp buffer
+      memset(tempBuffer, 0, PFILENAME_SIZE);
       fs->getFileName(fileIndex, tempBuffer, PFILENAME_SIZE);
       displayName += tempBuffer;
     }

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -133,7 +133,7 @@ else()
   message("picoTracker Advance Build")
   add_definitions(-DADV)
   # Enable basic control REPL over serial port. NOTE: uses extra ~112bytes of *stack*
-  # add_definitions(-DSERIAL_REPL)
+  add_definitions(-DSERIAL_REPL)
 
   # Advance displays battery level as percentage instead of bars
   add_definitions(-DBATTERY_LEVEL_AS_PERCENTAGE)

--- a/sources/Services/Midi/MidiService.cpp
+++ b/sources/Services/Midi/MidiService.cpp
@@ -129,21 +129,9 @@ void MidiService::Update(Observable &o, I_ObservableData *d) {
   }
 }
 
-void MidiService::onAudioTick() {
-  if (tickToFlush_ > 0) {
-    if (--tickToFlush_ == 0) {
-      flushOutQueue();
-    }
-  }
-}
+void MidiService::onAudioTick() { flushOutQueue(); }
 
-void MidiService::Flush() {
-
-  tickToFlush_ = midiDelay_;
-  if (tickToFlush_ == 0) {
-    flushOutQueue();
-  }
-};
+void MidiService::Flush() { flushOutQueue(); };
 
 void MidiService::OnMidiStart() {
   // Start the Player in song mode

--- a/sources/Services/Midi/MidiService.h
+++ b/sources/Services/Midi/MidiService.h
@@ -78,8 +78,6 @@ private:
   int currentOutQueue_;
 
   MidiInMerger *merger_;
-  int midiDelay_;
-  int tickToFlush_;
   bool sendSync_;
 };
 #endif

--- a/sources/System/FileSystem/I_File.h
+++ b/sources/System/FileSystem/I_File.h
@@ -21,7 +21,6 @@ public:
   virtual void Seek(long offset, int whence) = 0;
   virtual long Tell() = 0;
   virtual bool Close() = 0;
-  virtual bool DeleteFile() = 0;
   virtual int Error() = 0;
 };
 

--- a/sources/System/FileSystem/I_File.h
+++ b/sources/System/FileSystem/I_File.h
@@ -22,6 +22,7 @@ public:
   virtual long Tell() = 0;
   virtual bool Close() = 0;
   virtual int Error() = 0;
+  virtual bool Sync() = 0;
 };
 
 #endif // _I_FILE_H_

--- a/sources/UIFramework/SimpleBaseClasses/EventManager.h
+++ b/sources/UIFramework/SimpleBaseClasses/EventManager.h
@@ -20,7 +20,7 @@
 
 #include <string>
 
-#define PICO_CLOCK_INTERVAL 20 // ~50Hz
+#define PICO_CLOCK_INTERVAL 33 // ~30Hz
 #define PICO_CLOCK_HZ (1000 / PICO_CLOCK_INTERVAL)
 
 enum AppButton {


### PR DESCRIPTION
This refactors existing wave header code out on `WaveFileWriter` into a separate utility class that can then be used by both the `WaveFileWriter` and by `record.cpp`.

Fixes: #717