### PR TITLE
Send MIDI pitch bend on PSL and LEG commands

### DIFF
--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -156,12 +156,14 @@ bool MidiInstrument::Render(int channel, fixed *buffer, int size,
         }
       } else {
         if (useLogCurve_) {
-          int diff = pitchBendTarget_ - pitchBendCurrent_;
-          if (diff > 0) {
-            pitchBendCurrent_ += std::max(1, diff * pitchBendSpeed_);
-          } else {
-            pitchBendCurrent_ -= std::max(1, -diff * pitchBendSpeed_);
-          }
+          //int diff = pitchBendTarget_ - pitchBendCurrent_;
+          //if (abs(diff) > 0) {
+          //  int step = diff / pitchBendSpeed_;
+          //  if (step == 0) {
+          //    step = (diff > 0 ? 1 : -1);
+          //  }
+          //  pitchBendCurrent_ += step;
+          //}
         } else {
           int diff = pitchBendTarget_ - pitchBendCurrent_;
           int step = (diff > 0 ? 1 : -1) * std::max(1, abs(diff) / pitchBendSpeed_);
@@ -237,6 +239,15 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
     }
   } break;
 
+  case FourCC::InstrumentCommandLegato: {
+    int target = (char)(value & 0xFF);
+    float speed = float(value >> 8);
+    pitchBend_ = true;
+    pitchBendTarget_ = target;
+    pitchBendSpeed_ = speed;
+    useLogCurve_ = true;
+  } break;
+
   case FourCC::InstrumentCommandPitchSlide: {
     int target = (char)(value & 0xFF);
     float speed = float(value >> 8);
@@ -245,15 +256,6 @@ void MidiInstrument::ProcessCommand(int channel, FourCC cc, ushort value) {
     pitchBendSpeed_ = speed;
     useLogCurve_ = false;
   } break;
-
-  case FourCC::InstrumentCommandLegato:{
-    int target = (char)(value & 0xFF);
-    float speed = float(value >> 8);
-    pitchBend_ = true;
-    pitchBendTarget_ = target;
-    pitchBendSpeed_ = speed;
-    useLogCurve_ = true;
-  }
 
   case FourCC::InstrumentCommandVelocity: {
     // VELM cmds set velocity for MIDI steps

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -162,7 +162,7 @@ bool MidiInstrument::Render(int channel, fixed *buffer, int size,
             pitchBendCurrent_ += static_cast<int>(sign * pitchBendStep_);
             pitchBendStep_ *= growthFactor_;
           } else {
-            pitchBendStep_ = (diff > 0 ? 1 : -1) * std::max(1, abs(diff) / pitchBendSpeed_);
+            pitchBendStep_ = (diff > 0 ? 1 : -1) * (abs(diff) / static_cast<float>(pitchBendSpeed_));
             pitchBendCurrent_ += pitchBendStep_;
           }
         }  

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -141,7 +141,7 @@ bool MidiInstrument::Render(int channel, fixed *buffer, int size,
     first_[channel] = false;
   }
 
-  // If the instrument is not playing, we don't need to do anything// Update pitch bend.
+  // Update pitch bend.
   if (updateTick) {
     if (pitchBend_) {
       int prev = pitchBendCurrent_;

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -84,6 +84,10 @@ private:
   int pitchBendTarget_;
   int pitchBendSpeed_;
   float pitchBendCurrent_;
+  float pitchBendStep_;
+  float minGrowth_ = 1.01f;
+  float maxGrowth_ = 1.2f;
+  float growthFactor_ = 1.0f;
   bool useLogCurve_;
 
   Variable channel_;

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -85,8 +85,8 @@ private:
   int pitchBendSpeed_;
   float pitchBendCurrent_;
   float pitchBendStep_;
-  float minGrowth_ = 1.01f;
-  float maxGrowth_ = 1.2f;
+  float minGrowth_ = 1.001f;
+  float maxGrowth_ = 1.5f;
   float growthFactor_ = 1.0f;
   bool useLogCurve_;
 

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -84,6 +84,7 @@ private:
   int pitchBendTarget_;
   int pitchBendSpeed_;
   float pitchBendCurrent_;
+  bool useLogCurve_;
 
   Variable channel_;
   Variable noteLen_;

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -80,6 +80,10 @@ private:
   char velocity_ = 127;
   TableSaveState tableState_;
   bool first_[SONG_CHANNEL_COUNT];
+  bool pitchBend_;
+  int pitchBendTarget_;
+  int pitchBendSpeed_;
+  float pitchBendCurrent_;
 
   Variable channel_;
   Variable noteLen_;


### PR DESCRIPTION
Issue: [#511](https://github.com/xiphonics/picoTracker/issues/511)

Adds MIDI pitch bend messages on tick update when `PSL` and `LEG` commands are used with the MIDI instrument.

- `PSL` - linear curve
- `LEG` - exponential curve