### PR TITLE
Bitmap graphics and Sample Editor screen

### DIFF
--- a/sources/Adapters/adv/display/CMakeLists.txt
+++ b/sources/Adapters/adv/display/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(platform_display
   display.c
+  advBitmapGraphics.cpp
 )
 
 #target_link_libraries(platform_display

--- a/sources/Adapters/adv/display/CMakeLists.txt
+++ b/sources/Adapters/adv/display/CMakeLists.txt
@@ -3,9 +3,6 @@ add_library(platform_display
   advBitmapGraphics.cpp
 )
 
-#target_link_libraries(platform_display
-#)
-
 target_include_directories(platform_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(${PROJECT_SOURCE_DIR})

--- a/sources/Adapters/adv/display/advBitmapGraphics.cpp
+++ b/sources/Adapters/adv/display/advBitmapGraphics.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#include "advBitmapGraphics.h"
+
+void advBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                                uint16_t height, const uint8_t *bitmap_data,
+                                uint16_t fg_color, uint16_t bg_color) {
+//TODO
+}
+
+void advBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
+                                 uint16_t height) {
+ //TODO
+}
+
+void advBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
+                              uint16_t y, bool value) {
+ //TODO
+}
+
+bool advBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
+                              uint16_t y) {
+ //TODO
+ return false;
+}
+
+void advBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
+                              uint16_t x0, uint16_t y0, uint16_t x1,
+                              uint16_t y1, bool value) {
+  //TODO
+}
+
+void advBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
+                              uint16_t x, uint16_t y, uint16_t rect_width,
+                              uint16_t rect_height, bool filled, bool value) {
+  //TODO
+}

--- a/sources/Adapters/adv/display/advBitmapGraphics.cpp
+++ b/sources/Adapters/adv/display/advBitmapGraphics.cpp
@@ -7,38 +7,156 @@
  */
 
 #include "advBitmapGraphics.h"
+#include "display.h"
+#include "dma2d.h"
+#include <cassert>
+#include <cmath>   // For std::abs
+#include <cstring> // For std::memset
 
-void advBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
-                                   uint16_t height, const uint8_t *bitmap_data,
-                                   uint16_t fg_color, uint16_t bg_color) {
-  // TODO
-}
+/**
+ * @file advBitmapGraphics.cpp
+ * @brief Implements the BitmapGraphics interface for an STM32 device
+ * with direct framebuffer access.
+ */
 
-void advBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
-                                    uint16_t height) {
-  // TODO
-}
+#define CHAR_WIDTH 22
+#define CHAR_HEIGHT 30
 
 void advBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
                                  uint16_t y, bool value) {
-  // TODO
+  // Ensure we are drawing within the horizontal bounds of the buffer
+  if (x >= width) {
+    return;
+  }
+
+  // Calculate which byte contains the pixel
+  uint16_t bytes_per_row = width / 8;
+  uint32_t byte_index = (y * bytes_per_row) + (x / 8);
+
+  // Calculate the specific bit within that byte (MSB-first format)
+  uint8_t bit_position = 7 - (x % 8);
+
+  if (value) {
+    // Set the bit to 1
+    buffer[byte_index] |= (1 << bit_position);
+  } else {
+    // Clear the bit to 0
+    buffer[byte_index] &= ~(1 << bit_position);
+  }
 }
 
 bool advBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width,
                                  uint16_t x, uint16_t y) {
-  // TODO
-  return false;
+  if (x >= width) {
+    return false;
+  }
+
+  uint16_t bytes_per_row = width / 8;
+  uint32_t byte_index = (y * bytes_per_row) + (x / 8);
+  uint8_t bit_position = 7 - (x % 8);
+
+  // Return true if the bit is set, false otherwise
+  return (buffer[byte_index] & (1 << bit_position)) != 0;
+}
+
+void advBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
+                                    uint16_t height) {
+  uint32_t buffer_size_bytes = (width / 8) * height;
+  std::memset(buffer, 0, buffer_size_bytes);
 }
 
 void advBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width,
                                  uint16_t height, uint16_t x0, uint16_t y0,
                                  uint16_t x1, uint16_t y1, bool value) {
-  // TODO
+  int dx = std::abs(x1 - x0);
+  int sx = x0 < x1 ? 1 : -1;
+  int dy = -std::abs(y1 - y0);
+  int sy = y0 < y1 ? 1 : -1;
+  int err = dx + dy;
+
+  while (true) {
+    // Set the current pixel if it's within the buffer bounds
+    if (x0 < width && y0 < height) {
+      setPixel(buffer, width, x0, y0, value);
+    }
+    if (x0 == x1 && y0 == y1) {
+      break;
+    }
+    int e2 = 2 * err;
+    if (e2 >= dy) {
+      err += dy;
+      x0 += sx;
+    }
+    if (e2 <= dx) {
+      err += dx;
+      y0 += sy;
+    }
+  }
 }
 
 void advBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width,
                                  uint16_t height, uint16_t x, uint16_t y,
                                  uint16_t rect_width, uint16_t rect_height,
                                  bool filled, bool value) {
-  // TODO
+  if (filled) {
+    // For a filled rectangle, draw every pixel inside its bounds
+    for (uint16_t i = 0; i < rect_height; ++i) {
+      for (uint16_t j = 0; j < rect_width; ++j) {
+        setPixel(buffer, width, x + j, y + i, value);
+      }
+    }
+  } else {
+    // For an outline, draw four separate lines
+    if (rect_width > 0 && rect_height > 0) {
+      uint16_t x_end = x + rect_width - 1;
+      uint16_t y_end = y + rect_height - 1;
+      drawLine(buffer, width, height, x, y, x_end, y, value);         // Top
+      drawLine(buffer, width, height, x, y_end, x_end, y_end, value); // Bottom
+      drawLine(buffer, width, height, x, y, x, y_end, value);         // Left
+      drawLine(buffer, width, height, x_end, y, x_end, y_end, value); // Right
+    }
+  }
+}
+
+void advBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                                   uint16_t height, const uint8_t *bitmap_data,
+                                   uint16_t fg_color, uint16_t bg_color) {
+  // Convert character cell coordinates to the top-left pixel coordinate on
+  // screen
+  uint16_t start_x = x * CHAR_WIDTH;
+  uint16_t start_y = y * CHAR_HEIGHT;
+
+  // Pre-convert the 16-bit colors to the 32-bit format of the framebuffer
+  uint32_t final_fg_color = rgb565_to_abgr8888(fg_color);
+  uint32_t final_bg_color = rgb565_to_abgr8888(bg_color);
+
+  // Iterate over every pixel of the source bitmap
+  for (uint16_t h = 0; h < height; ++h) {
+    uint16_t dest_y = start_y + h;
+
+    // Clip vertically: if we're outside the screen, stop drawing
+    if (dest_y >= FRAMEBUFFER_HEIGHT) {
+      break;
+    }
+
+    for (uint16_t w = 0; w < width; ++w) {
+      uint16_t dest_x = start_x + w;
+
+      // Clip horizontally: if we're outside the screen, skip this pixel
+      if (dest_x >= FRAMEBUFFER_WIDTH) {
+        continue;
+      }
+
+      // Read the bit from the source bitmap to see if the pixel is "on" or
+      // "off"
+      bool pixel_is_set = getPixel(bitmap_data, width, w, h);
+
+      // Select the appropriate color and write it directly to the framebuffer
+      if (pixel_is_set) {
+        framebuffer[dest_y * FRAMEBUFFER_WIDTH + dest_x] = final_fg_color;
+      } else {
+        framebuffer[dest_y * FRAMEBUFFER_WIDTH + dest_x] = final_bg_color;
+      }
+    }
+  }
 }

--- a/sources/Adapters/adv/display/advBitmapGraphics.cpp
+++ b/sources/Adapters/adv/display/advBitmapGraphics.cpp
@@ -9,35 +9,36 @@
 #include "advBitmapGraphics.h"
 
 void advBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
-                                uint16_t height, const uint8_t *bitmap_data,
-                                uint16_t fg_color, uint16_t bg_color) {
-//TODO
+                                   uint16_t height, const uint8_t *bitmap_data,
+                                   uint16_t fg_color, uint16_t bg_color) {
+  // TODO
 }
 
 void advBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
-                                 uint16_t height) {
- //TODO
+                                    uint16_t height) {
+  // TODO
 }
 
 void advBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
-                              uint16_t y, bool value) {
- //TODO
+                                 uint16_t y, bool value) {
+  // TODO
 }
 
-bool advBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
-                              uint16_t y) {
- //TODO
- return false;
+bool advBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width,
+                                 uint16_t x, uint16_t y) {
+  // TODO
+  return false;
 }
 
-void advBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
-                              uint16_t x0, uint16_t y0, uint16_t x1,
-                              uint16_t y1, bool value) {
-  //TODO
+void advBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width,
+                                 uint16_t height, uint16_t x0, uint16_t y0,
+                                 uint16_t x1, uint16_t y1, bool value) {
+  // TODO
 }
 
-void advBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
-                              uint16_t x, uint16_t y, uint16_t rect_width,
-                              uint16_t rect_height, bool filled, bool value) {
-  //TODO
+void advBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width,
+                                 uint16_t height, uint16_t x, uint16_t y,
+                                 uint16_t rect_width, uint16_t rect_height,
+                                 bool filled, bool value) {
+  // TODO
 }

--- a/sources/Adapters/adv/display/advBitmapGraphics.h
+++ b/sources/Adapters/adv/display/advBitmapGraphics.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _ADV_BITMAPGRAPHICS_H
+#define _ADV_BITMAPGRAPHICS_H
+
+#include "System/Display/BitmapGraphics.h"
+#include "display.h"
+#include <cstdint>
+
+class advBitmapGraphics : public BitmapGraphics {
+public:
+  virtual void drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                          uint16_t height, const uint8_t *bitmap_data,
+                          uint16_t fg_color, uint16_t bg_color) override;
+
+  virtual void clearBuffer(uint8_t *buffer, uint16_t width, uint16_t height);
+
+  virtual void setPixel(uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y,
+                        bool value) override;
+
+  virtual bool getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
+                        uint16_t y) override;
+
+  virtual void drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
+                        bool value) override;
+
+  virtual void drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x, uint16_t y, uint16_t rect_width,
+                        uint16_t rect_height, bool filled, bool value) override;
+};
+
+#endif

--- a/sources/Adapters/adv/display/advBitmapGraphics.h
+++ b/sources/Adapters/adv/display/advBitmapGraphics.h
@@ -10,7 +10,6 @@
 #define _ADV_BITMAPGRAPHICS_H
 
 #include "System/Display/BitmapGraphics.h"
-#include "display.h"
 #include <cstdint>
 
 class advBitmapGraphics : public BitmapGraphics {

--- a/sources/Adapters/adv/display/display.c
+++ b/sources/Adapters/adv/display/display.c
@@ -14,11 +14,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define TEXT_WIDTH 33 // extra half empty char
-#define TEXT_HEIGHT 24
-#define CHAR_HEIGHT 30
-#define CHAR_WIDTH 22
-
 static color_t screen_bg_color = COLOR_BG;
 static color_t screen_fg_color = COLOR_NORMAL;
 static int cursor_x = 0;

--- a/sources/Adapters/adv/display/display.h
+++ b/sources/Adapters/adv/display/display.h
@@ -15,6 +15,13 @@ extern "C" {
 #include "ltdc.h"
 #include <stdbool.h>
 
+
+#define TEXT_WIDTH 32
+#define TEXT_HEIGHT 24
+#define CHAR_HEIGHT 10
+#define CHAR_WIDTH 10
+#define BUFFER_CHARS 12
+
 // ARNE-16 palette converted to RGB565 --
 // https://lospec.com/palette-list/arne-16
 typedef enum {

--- a/sources/Adapters/adv/display/display.h
+++ b/sources/Adapters/adv/display/display.h
@@ -15,12 +15,10 @@ extern "C" {
 #include "ltdc.h"
 #include <stdbool.h>
 
-
-#define TEXT_WIDTH 32
+#define TEXT_WIDTH 33 // extra half empty char
 #define TEXT_HEIGHT 24
-#define CHAR_HEIGHT 10
-#define CHAR_WIDTH 10
-#define BUFFER_CHARS 12
+#define CHAR_HEIGHT 30
+#define CHAR_WIDTH 22
 
 // ARNE-16 palette converted to RGB565 --
 // https://lospec.com/palette-list/arne-16
@@ -56,6 +54,8 @@ void display_draw_screen();
 void display_draw_region(uint8_t x, uint8_t y, uint8_t width, uint8_t height);
 void display_draw_sub_region(uint8_t x, uint8_t y, uint8_t width,
                              uint8_t height);
+
+uint32_t rgb565_to_abgr8888(uint16_t rgb565);
 
 #ifdef __cplusplus
 }

--- a/sources/Adapters/adv/platform/platform.cpp
+++ b/sources/Adapters/adv/platform/platform.cpp
@@ -7,10 +7,12 @@
  */
 
 #include "platform.h"
+#include "Adapters/adv/display/advBitmapGraphics.h"
 #include "Adapters/adv/mutex/advMutex.h"
 #include "System/Console/Trace.h"
 #include "rng.h"
 #include "tim.h"
+#include <System/Display/BitmapGraphics.h>
 
 int32_t platform_get_rand() {
   uint32_t random32;
@@ -66,6 +68,9 @@ void platform_bootloader() {
 
   // Set MSP
   __set_MSP(appStack);
+
+  // setup bitmap graphics access
+  BitmapGraphics::Install(new advBitmapGraphics());
 
   // Jump to application
   appEntry();

--- a/sources/Adapters/adv/platform/platform.cpp
+++ b/sources/Adapters/adv/platform/platform.cpp
@@ -12,7 +12,6 @@
 #include "System/Console/Trace.h"
 #include "rng.h"
 #include "tim.h"
-#include <System/Display/BitmapGraphics.h>
 
 int32_t platform_get_rand() {
   uint32_t random32;
@@ -68,9 +67,6 @@ void platform_bootloader() {
 
   // Set MSP
   __set_MSP(appStack);
-
-  // setup bitmap graphics access
-  BitmapGraphics::Install(new advBitmapGraphics());
 
   // Jump to application
   appEntry();

--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -8,6 +8,7 @@
 
 #include "advSystem.h"
 #include "Adapters/adv/audio/advAudio.h"
+#include "Adapters/adv/display/advBitmapGraphics.h"
 #include "Adapters/adv/filesystem/advFileSystem.h"
 #include "Adapters/adv/gui/GUIFactory.h"
 #include "Adapters/adv/midi/advMidiService.h"
@@ -69,6 +70,9 @@ void advSystem::Boot() {
   __attribute__((
       section(".DATA_RAM"))) static char fsMemBuf[sizeof(advFileSystem)];
   FileSystem::Install(new (fsMemBuf) advFileSystem());
+
+  // Install Bitmap graphics
+  BitmapGraphics::Install(new advBitmapGraphics());
 
   // First check for SDCard
   auto fs = FileSystem::GetInstance();

--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -217,3 +217,5 @@ void advSystem::SystemBootloader() { platform_bootloader(); }
 void advSystem::SystemReboot() { platform_reboot(); }
 
 uint32_t advSystem::Micros() { return micros(); }
+
+uint32_t advSystem::Millis() { return millis(); }

--- a/sources/Adapters/adv/system/advSystem.h
+++ b/sources/Adapters/adv/system/advSystem.h
@@ -39,6 +39,7 @@ public: // System implementation
   virtual void SystemPutChar(int c);
   virtual int32_t GetRandomNumber();
   virtual uint32_t Micros();
+  virtual uint32_t Millis();
 
 private:
   static bool invert_;

--- a/sources/Adapters/picoTracker/display/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/display/CMakeLists.txt
@@ -6,9 +6,6 @@ add_library(platform_display
 
 target_link_libraries(platform_display PUBLIC pico_sdk_bundle)
 
-target_include_directories(platform_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_link_libraries(platform_display PUBLIC
-    pico_stdlib
-    hardware_spi
+target_include_directories(platform_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                                ${CMAKE_SOURCE_DIR}
 )

--- a/sources/Adapters/picoTracker/display/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/display/CMakeLists.txt
@@ -1,8 +1,15 @@
 add_library(platform_display
   ili9341.c
   chargfx.c
+  picoBitmapGraphics.cpp
 )
 
-target_include_directories(platform_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(platform_display PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${PROJECT_SOURCE_DIR}
+)
 
-include_directories(${PROJECT_SOURCE_DIR})
+target_link_libraries(platform_display PUBLIC
+    pico_stdlib
+    hardware_spi
+)

--- a/sources/Adapters/picoTracker/display/chargfx.c
+++ b/sources/Adapters/picoTracker/display/chargfx.c
@@ -16,12 +16,6 @@
 
 /* Character graphics mode */
 
-#define TEXT_WIDTH 32
-#define TEXT_HEIGHT 24
-#define CHAR_HEIGHT 10
-#define CHAR_WIDTH 10
-#define BUFFER_CHARS 12
-
 #define SWAP_BYTES(color) ((uint16_t)(color >> 8) | (uint16_t)(color << 8))
 
 static chargfx_color_t screen_bg_color = CHARGFX_BG;

--- a/sources/Adapters/picoTracker/display/chargfx.h
+++ b/sources/Adapters/picoTracker/display/chargfx.h
@@ -15,6 +15,12 @@ extern "C" {
 
 #include "ili9341.h"
 
+#define TEXT_WIDTH 32
+#define TEXT_HEIGHT 24
+#define CHAR_HEIGHT 10
+#define CHAR_WIDTH 10
+#define BUFFER_CHARS 12
+
 // ARNE-16 palette converted to RGB565 --
 // https://lospec.com/palette-list/arne-16
 typedef enum {

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "picoBitmapGraphics.h"
-#include "picoDisplay.h"
 #include "pico/stdlib.h"
 #include <cstring>
 

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -11,8 +11,8 @@
 #include <cstring>
 
 void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
-                                uint16_t height, const uint8_t *bitmap_data,
-                                uint16_t fg_color, uint16_t bg_color) {
+                                    uint16_t height, const uint8_t *bitmap_data,
+                                    uint16_t fg_color, uint16_t bg_color) {
   /// Convert character cell coordinates to pixel coordinates
   uint16_t x_pixel = x * CHAR_WIDTH;
   uint16_t y_pixel = y * CHAR_HEIGHT;
@@ -55,14 +55,15 @@ void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
     }
 
     // Write this column to the display
-    picoDisplay.ili9341_write_data_continuous(buffer, height * sizeof(uint16_t));
+    picoDisplay.ili9341_write_data_continuous(buffer,
+                                              height * sizeof(uint16_t));
   }
 
   ili9341_stop_writing();
 }
 
 void picoBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
-                                 uint16_t height) {
+                                     uint16_t height) {
   assert(buffer != NULL);
 
   // For our bitmap format, width must be rounded up to the nearest multiple of
@@ -75,7 +76,7 @@ void picoBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
 }
 
 void picoBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
-                              uint16_t y, bool value) {
+                                  uint16_t y, bool value) {
   assert(width % 8 == 0);
   assert(buffer != NULL);
   assert(x < width);
@@ -94,8 +95,8 @@ void picoBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
   }
 }
 
-bool picoBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
-                              uint16_t y) {
+bool picoBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width,
+                                  uint16_t x, uint16_t y) {
   assert(width % 8 == 0);
   assert(buffer != NULL);
   assert(x < width);
@@ -109,9 +110,9 @@ bool picoBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width, uint16_
   return (buffer[byte_idx] & (1 << bit_pos)) != 0;
 }
 
-void picoBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
-                              uint16_t x0, uint16_t y0, uint16_t x1,
-                              uint16_t y1, bool value) {
+void picoBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width,
+                                  uint16_t height, uint16_t x0, uint16_t y0,
+                                  uint16_t x1, uint16_t y1, bool value) {
   assert(width % 8 == 0);
   assert(buffer != NULL);
 
@@ -150,9 +151,10 @@ void picoBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width, uint16_t heig
   }
 }
 
-void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
-                              uint16_t x, uint16_t y, uint16_t rect_width,
-                              uint16_t rect_height, bool filled, bool value) {
+void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width,
+                                  uint16_t height, uint16_t x, uint16_t y,
+                                  uint16_t rect_width, uint16_t rect_height,
+                                  bool filled, bool value) {
   assert(width % 8 == 0);
   assert(buffer != NULL);
 
@@ -191,20 +193,19 @@ void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width, uint16_t heig
 
         // Bottom edge (if in bounds)
         if (y + rect_height - 1 < height) {
-    }
+        }
 
-    // Left and right edges
-    for (uint16_t row = 1; row < rect_height - 1; row++) {
-      if (y + row < height) {
-        // Left edge
-        setPixel(buffer, width, x, y + row, value);
+        // Left and right edges
+        for (uint16_t row = 1; row < rect_height - 1; row++) {
+          if (y + row < height) {
+            // Left edge
+            setPixel(buffer, width, x, y + row, value);
 
-        // Right edge (if in bounds)
-        if (x + rect_width - 1 < width) {
-          setPixel(buffer, width, x + rect_width - 1, y + row,
-                              value);
+            // Right edge (if in bounds)
+            if (x + rect_width - 1 < width) {
+              setPixel(buffer, width, x + rect_width - 1, y + row, value);
+            }
+          }
         }
       }
     }
-  }
-}

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -1,0 +1,211 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#include "picoBitmapGraphics.h"
+#include "picoDisplay.h"
+#include "pico/stdlib.h"
+#include <cstring>
+
+void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                                uint16_t height, const uint8_t *bitmap_data,
+                                uint16_t fg_color, uint16_t bg_color) {
+  /// Convert character cell coordinates to pixel coordinates
+  uint16_t x_pixel = x * CHAR_WIDTH;
+  uint16_t y_pixel = y * CHAR_HEIGHT;
+
+  // Because of the rotated display swap x & y when sending commands to display
+  // Use ILI9341_TFTWIDTH (240) for the calculation
+  uint16_t display_x = ILI9341_TFTWIDTH - y_pixel - height;
+  uint16_t display_y = x_pixel;
+
+  // Width must be a multiple of 8 pixels for bitmap byte alignment
+  // This is a requirement for our bitmap format
+  int bytes_per_row = width / 8;
+
+  // Set display window with swapped dimensions for rotation
+  ili9341_set_command(ILI9341_CASET);
+  ili9341_command_param16(display_x);
+  ili9341_command_param16(display_x + height - 1);
+
+  ili9341_set_command(ILI9341_PASET);
+  ili9341_command_param16(display_y);
+  ili9341_command_param16(display_y + width - 1);
+
+  ili9341_set_command(ILI9341_RAMWR);
+  ili9341_start_writing();
+
+  // Process bitmap column by column for rotated display
+  for (int col = 0; col < width; col++) {
+    uint16_t buffer[height];
+    uint16_t *buffer_ptr = buffer;
+
+    for (int row = 0; row < height; row++) {
+      // Extract the bit from the bitmap data
+      int byte_idx = col / 8;
+      int bit_pos = 7 - (col % 8); // MSB first
+      uint8_t byte_data = bitmap_data[row * bytes_per_row + byte_idx];
+      bool pixel_set = (byte_data & (1 << bit_pos)) != 0;
+
+      // Store the pixel color
+      *buffer_ptr++ = pixel_set ? fg_color : bg_color;
+    }
+
+    // Write this column to the display
+    picoDisplay.ili9341_write_data_continuous(buffer, height * sizeof(uint16_t));
+  }
+
+  ili9341_stop_writing();
+}
+
+void picoBitmapGraphics::clearBuffer(uint8_t *buffer, uint16_t width,
+                                 uint16_t height) {
+  assert(buffer != NULL);
+
+  // For our bitmap format, width must be rounded up to the nearest multiple of
+  // 8 to calculate the correct buffer size in bytes
+  uint16_t bytes_per_row = (width + 7) / 8; // Round up to nearest byte
+  uint16_t buffer_size = bytes_per_row * height;
+
+  // Clear the buffer
+  memset(buffer, 0, buffer_size);
+}
+
+void picoBitmapGraphics::setPixel(uint8_t *buffer, uint16_t width, uint16_t x,
+                              uint16_t y, bool value) {
+  assert(width % 8 == 0);
+  assert(buffer != NULL);
+  assert(x < width);
+
+  // Calculate byte index and bit position
+  uint16_t bytes_per_row = width / 8;
+  uint16_t byte_idx = (y * bytes_per_row) + (x / 8);
+  uint8_t bit_pos = 7 - (x % 8); // MSB first
+
+  if (value) {
+    // Set the bit
+    buffer[byte_idx] |= (1 << bit_pos);
+  } else {
+    // Clear the bit
+    buffer[byte_idx] &= ~(1 << bit_pos);
+  }
+}
+
+bool picoBitmapGraphics::getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
+                              uint16_t y) {
+  assert(width % 8 == 0);
+  assert(buffer != NULL);
+  assert(x < width);
+
+  // Calculate byte index and bit position
+  uint16_t bytes_per_row = width / 8;
+  uint16_t byte_idx = (y * bytes_per_row) + (x / 8);
+  uint8_t bit_pos = 7 - (x % 8); // MSB first
+
+  // Return the bit value
+  return (buffer[byte_idx] & (1 << bit_pos)) != 0;
+}
+
+void picoBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
+                              uint16_t x0, uint16_t y0, uint16_t x1,
+                              uint16_t y1, bool value) {
+  assert(width % 8 == 0);
+  assert(buffer != NULL);
+
+  // Bresenham's line algorithm
+  int dx = abs(x1 - x0);
+  int sx = x0 < x1 ? 1 : -1;
+  int dy = -abs(y1 - y0);
+  int sy = y0 < y1 ? 1 : -1;
+  int err = dx + dy;
+  int e2;
+
+  while (1) {
+    // Set pixel if it's within bounds
+    if (x0 < width && y0 < height) {
+      setPixel(buffer, width, x0, y0, value);
+    }
+
+    // Check if we've reached the end point
+    if (x0 == x1 && y0 == y1) {
+      break;
+    }
+
+    e2 = 2 * err;
+    if (e2 >= dy) {
+      if (x0 == x1)
+        break;
+      err += dy;
+      x0 += sx;
+    }
+    if (e2 <= dx) {
+      if (y0 == y1)
+        break;
+      err += dx;
+      y0 += sy;
+    }
+  }
+}
+
+void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
+                              uint16_t x, uint16_t y, uint16_t rect_width,
+                              uint16_t rect_height, bool filled, bool value) {
+  assert(width % 8 == 0);
+  assert(buffer != NULL);
+
+  // Ensure we don't draw outside the bitmap
+  if (x >= width)
+    return;
+  if (y >= height)
+    return;
+
+  // Clip rectangle if it extends beyond bitmap boundaries
+  if (x + rect_width > width) {
+    rect_width = width - x;
+  }
+  if (y + rect_height > height) {
+    rect_height = height - y;
+  }
+
+  // If filled, draw each row of the rectangle
+  if (filled) {
+    for (uint16_t row = 0; row < rect_height; row++) {
+      if (y + row < height) { // Check height bounds
+        for (uint16_t col = 0; col < rect_width; col++) {
+          if (x + col < width) { // Check width bounds
+            setPixel(buffer, width, x + col, y + row, value);
+          }
+        }
+      }
+    }
+  } else {
+    // Draw the outline only
+    // Top and bottom edges
+    for (uint16_t col = 0; col < rect_width; col++) {
+      if (x + col < width) {
+        // Top edge
+        setPixel(buffer, width, x + col, y, value);
+
+        // Bottom edge (if in bounds)
+        if (y + rect_height - 1 < height) {
+    }
+
+    // Left and right edges
+    for (uint16_t row = 1; row < rect_height - 1; row++) {
+      if (y + row < height) {
+        // Left edge
+        setPixel(buffer, width, x, y + row, value);
+
+        // Right edge (if in bounds)
+        if (x + rect_width - 1 < width) {
+          setPixel(buffer, width, x + rect_width - 1, y + row,
+                              value);
+        }
+      }
+    }
+  }
+}

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -15,7 +15,8 @@ void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
                                     uint16_t height, const uint8_t *bitmap_data,
                                     uint16_t fg_color, uint16_t bg_color) {
 
-  assert(height > ILI9341_TFTWIDTH);
+  // check width const because the physical screen is actually rotated 90deg
+  assert(height < ILI9341_TFTWIDTH);
 
   /// Convert character cell coordinates to pixel coordinates
   uint16_t x_pixel = x * CHAR_WIDTH;

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -8,11 +8,15 @@
 
 #include "picoBitmapGraphics.h"
 #include "pico/stdlib.h"
+#include <cstdlib>
 #include <cstring>
 
 void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
                                     uint16_t height, const uint8_t *bitmap_data,
                                     uint16_t fg_color, uint16_t bg_color) {
+
+  assert(height > ILI9341_TFTWIDTH);
+
   /// Convert character cell coordinates to pixel coordinates
   uint16_t x_pixel = x * CHAR_WIDTH;
   uint16_t y_pixel = y * CHAR_HEIGHT;
@@ -40,7 +44,7 @@ void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
 
   // Process bitmap column by column for rotated display
   for (int col = 0; col < width; col++) {
-    uint16_t buffer[height];
+    uint16_t buffer[ILI9341_TFTWIDTH];
     uint16_t *buffer_ptr = buffer;
 
     for (int row = 0; row < height; row++) {
@@ -55,8 +59,7 @@ void picoBitmapGraphics::drawBitmap(uint16_t x, uint16_t y, uint16_t width,
     }
 
     // Write this column to the display
-    picoDisplay.ili9341_write_data_continuous(buffer,
-                                              height * sizeof(uint16_t));
+    ili9341_write_data_continuous(buffer, height * sizeof(uint16_t));
   }
 
   ili9341_stop_writing();
@@ -209,3 +212,5 @@ void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width,
         }
       }
     }
+  }
+}

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.cpp
@@ -159,7 +159,7 @@ void picoBitmapGraphics::drawLine(uint8_t *buffer, uint16_t width,
   }
 }
 
-void picoBitmapGraphics::drawRect(const uint8_t *buffer, uint16_t width,
+void picoBitmapGraphics::drawRect(uint8_t *buffer, uint16_t width,
                                   uint16_t height, uint16_t x, uint16_t y,
                                   uint16_t rect_width, uint16_t rect_height,
                                   bool filled, bool value) {

--- a/sources/Adapters/picoTracker/display/picoBitmapGraphics.h
+++ b/sources/Adapters/picoTracker/display/picoBitmapGraphics.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _PICO_BITMAPGRAPHICS_H
+#define _PICO_BITMAPGRAPHICS_H
+
+#include "System/Display/BitmapGraphics.h"
+#include "chargfx.h"
+#include <cstdint>
+
+class picoBitmapGraphics : public BitmapGraphics {
+public:
+  virtual void drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                          uint16_t height, const uint8_t *bitmap_data,
+                          uint16_t fg_color, uint16_t bg_color) override;
+
+  virtual void clearBuffer(uint8_t *buffer, uint16_t width,
+                           uint16_t height) override;
+
+  virtual void setPixel(uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y,
+                        bool value) override;
+
+  virtual bool getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
+                        uint16_t y) override;
+
+  virtual void drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
+                        bool value) override;
+
+  virtual void drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x, uint16_t y, uint16_t rect_width,
+                        uint16_t rect_height, bool filled, bool value) override;
+};
+
+#endif

--- a/sources/Adapters/picoTracker/platform/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/platform/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(platform
 
 target_link_libraries(platform PUBLIC
   platform_mutex
+  pico_stdlib
+  hardware_spi
 )
 
 target_include_directories(platform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sources/Adapters/picoTracker/platform/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/platform/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(platform
   platform.cpp
 )
 
-target_link_libraries(platform PUBLIC pico_sdk_bundle)
+target_link_libraries(platform PUBLIC pico_sdk_bundle platform_display)
 
 target_include_directories(platform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/sources/Adapters/picoTracker/platform/platform.cpp
+++ b/sources/Adapters/picoTracker/platform/platform.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "platform.h"
+#include "Adapters/picoTracker/display/picoBitmapGraphics.h"
 #include "Adapters/picoTracker/mutex/picoTrackerMutex.h"
 #include "hardware/clocks.h"
 #include "hardware/gpio.h"
@@ -20,7 +21,6 @@
 #include "pico/bootrom.h"
 #include "pico/rand.h"
 #include "pico/stdlib.h"
-#include "Adapters/picoTracker/display/picoBitmapGraphics.h"
 #include <System/Console/Trace.h>
 #include <System/Console/nanoprintf.h>
 #include <System/Display/BitmapGraphics.h>

--- a/sources/Adapters/picoTracker/platform/platform.cpp
+++ b/sources/Adapters/picoTracker/platform/platform.cpp
@@ -20,8 +20,10 @@
 #include "pico/bootrom.h"
 #include "pico/rand.h"
 #include "pico/stdlib.h"
+#include "Adapters/picoTracker/display/picoBitmapGraphics.h"
 #include <System/Console/Trace.h>
 #include <System/Console/nanoprintf.h>
+#include <System/Display/BitmapGraphics.h>
 #include <cstdio>
 
 #define RP2040_RAM_BASE 0x20000000U
@@ -29,6 +31,8 @@
 void platform_init() {
   // Platform setup
   stdio_init_all();
+
+  BitmapGraphics::Install(new picoBitmapGraphics());
 
   ////////////
   // CLOCKS //

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -204,3 +204,5 @@ void picoTrackerSystem::SystemBootloader() { platform_bootloader(); }
 void picoTrackerSystem::SystemReboot() { platform_reboot(); }
 
 uint32_t picoTrackerSystem::Micros() { return micros(); }
+
+uint32_t picoTrackerSystem::Micros() { return millis(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -205,4 +205,4 @@ void picoTrackerSystem::SystemReboot() { platform_reboot(); }
 
 uint32_t picoTrackerSystem::Micros() { return micros(); }
 
-uint32_t picoTrackerSystem::Micros() { return millis(); }
+uint32_t picoTrackerSystem::Millis() { return millis(); }

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.h
@@ -40,6 +40,7 @@ public: // System implementation
   virtual void SystemPutChar(int c);
   virtual int32_t GetRandomNumber();
   virtual uint32_t Micros();
+  virtual uint32_t Millis();
 
 private:
   static bool invert_;

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -27,6 +27,7 @@
 #include "Application/Views/NullView.h"
 #include "Application/Views/PhraseView.h"
 #include "Application/Views/ProjectView.h"
+#include "Application/Views/SampleEditorView.h"
 #include "Application/Views/SelectProjectView.h"
 #include "Application/Views/SongView.h"
 #include "Application/Views/TableView.h"
@@ -114,6 +115,7 @@ AppWindow::AppWindow(I_GUIWindowImp &imp) : GUIWindow(imp) {
   _instrumentView = 0;
   _tableView = 0;
   _mixerView = 0;
+  _sampleEditorView = 0;
   _nullView = 0;
   _grooveView = 0;
   _closeProject = 0;
@@ -467,6 +469,12 @@ void AppWindow::LoadProject(const char *projectName) {
   _mixerView = new (mixerViewMemBuf) MixerView((*this), _viewData);
   _mixerView->AddObserver((*this));
 
+  alignas(SampleEditorView) static char
+      sampleEditorViewMemBuf[sizeof(SampleEditorView)];
+  _sampleEditorView =
+      new (sampleEditorViewMemBuf) SampleEditorView((*this), _viewData);
+  _sampleEditorView->AddObserver((*this));
+
   _currentView = _songView;
   _currentView->OnFocus();
 
@@ -742,6 +750,8 @@ void AppWindow::Update(Observable &o, I_ObservableData *d) {
     case VT_SELECTTHEME:
       _currentView = _themeView;
       break;
+    case VT_SAMPLE_EDITOR:
+      _currentView = _sampleEditorView;
     default:
       break;
     }

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -16,6 +16,7 @@
 #include "System/Process/SysMutex.h"
 #include "System/io/Status.h"
 #include "UIFramework/SimpleBaseClasses/GUIWindow.h"
+#include <UIFramework/SimpleBaseClasses/EventManager.h>
 
 #define PROP_INVERT 0x80
 #define CHAR_WIDTH 10
@@ -27,7 +28,7 @@
 #define BATTERY_GAUGE_WIDTH 5
 #define SCREEN_CHARS SCREEN_WIDTH *SCREEN_HEIGHT
 #define MAX_FIELD_WIDTH 26
-#define SCREEN_REDRAW_RATE 50 // in Hz
+#define SCREEN_REDRAW_RATE PICO_CLOCK_HZ
 
 // need this forward declaration to break out of circular dependency as
 // ProjectView uses a UITextfield which in turn had dependency on AppWindow

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -27,6 +27,7 @@
 #define BATTERY_GAUGE_WIDTH 5
 #define SCREEN_CHARS SCREEN_WIDTH *SCREEN_HEIGHT
 #define MAX_FIELD_WIDTH 26
+#define SCREEN_REDRAW_RATE 50 // in Hz
 
 // need this forward declaration to break out of circular dependency as
 // ProjectView uses a UITextfield which in turn had dependency on AppWindow
@@ -49,6 +50,7 @@ class ScreenView;
 class MixerView;
 class ThemeView;
 class ThemeImportView;
+class SampleEditorView;
 class View;
 
 class AppWindow : public GUIWindow, I_Observer, Status {
@@ -113,6 +115,7 @@ private:
   ThemeImportView *_themeImportView;
   MixerView *_mixerView;
   SelectProjectView *_selectProjectView;
+  SampleEditorView *_sampleEditorView;
   NullView *_nullView;
 
   bool _isDirty; // Flag to indicate a full redraw is needed on next

--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -38,15 +38,16 @@ AudioFileStreamer::AudioFileStreamer() {
 
 AudioFileStreamer::~AudioFileStreamer() { SAFE_DELETE(wav_); };
 
-bool AudioFileStreamer::Start(char *name) {
-  Trace::Debug("Starting to stream:%s", name);
+bool AudioFileStreamer::Start(const char *name, int startSample) {
+  Trace::Debug("Starting to stream:%s from sample %d", name, startSample);
   strcpy(name_, name);
   newPath_ = true;
   mode_ = AFSM_PLAYING;
+  position_ = (startSample > 0) ? float(startSample) : 0.0f;
   return true;
 };
 
-bool AudioFileStreamer::StartLooping(char *name) {
+bool AudioFileStreamer::StartLooping(const char *name) {
   Trace::Debug("Starting to loop:%s", name);
   strcpy(name_, name);
   newPath_ = true;

--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -91,7 +91,6 @@ bool AudioFileStreamer::Render(fixed *buffer, int samplecount) {
       mode_ = AFSM_STOPPED;
       return false;
     }
-    position_ = 0;
 
     // Get sample rate information and calculate speed factor
     fileSampleRate_ = wav_->GetSampleRate(-1);

--- a/sources/Application/Audio/AudioFileStreamer.h
+++ b/sources/Application/Audio/AudioFileStreamer.h
@@ -23,7 +23,8 @@ public:
   AudioFileStreamer();
   virtual ~AudioFileStreamer();
   virtual bool Render(fixed *buffer, int samplecount);
-  bool Start(char *name); // Automatically detects single cycle waveforms
+  // Automatically detects single cycle waveforms
+  bool Start(const char *name, int startSample = 0);
   void Stop();
   bool IsPlaying();
 
@@ -54,7 +55,7 @@ public:
   void SetProject(Project *project) { project_ = project; }
 
   // Single cycle waveform methods
-  bool StartLooping(char *name);
+  bool StartLooping(const char *name);
   void StopLooping() { mode_ = AFSM_STOPPED; }
 };
 

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -820,6 +820,14 @@ int SampleInstrument::GetSampleSize(int channel) {
   return 0;
 };
 
+float SampleInstrument::GetLengthInSec() {
+  if (source_) {
+    return source_->GetLengthInSec();
+  } else {
+    return 0.0f;
+  }
+};
+
 bool SampleInstrument::IsInitialized() { return (source_ != 0); };
 
 void SampleInstrument::updateInstrumentData(bool search) {

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -69,6 +69,7 @@ public:
   int GetVolume();
   void SetVolume(int);
   int GetSampleSize(int channel = -1);
+  float GetLengthInSec();
 
   virtual etl::string<MAX_INSTRUMENT_NAME_LENGTH> GetUserSetName();
   virtual etl::string<MAX_INSTRUMENT_NAME_LENGTH> GetDisplayName() override;

--- a/sources/Application/Instruments/SoundSource.h
+++ b/sources/Application/Instruments/SoundSource.h
@@ -22,6 +22,7 @@ public:
   virtual void *GetSampleBuffer(int note) = 0;
   virtual bool IsMulti() = 0;
   virtual int GetRootNote(int note) = 0;
+  virtual float GetLengthInSec() = 0;
 };
 
 #endif

--- a/sources/Application/Instruments/WavFile.cpp
+++ b/sources/Application/Instruments/WavFile.cpp
@@ -227,6 +227,8 @@ int WavFile::GetChannelCount(int note) { return channelCount_; };
 
 int WavFile::GetSampleRate(int note) { return sampleRate_; };
 
+float WavFile::GetLengthInSec() { return (float)size_ / sampleRate_; };
+
 long WavFile::readBlock(long start, long size) {
   if (size > readBufferSize_) {
     readBufferSize_ = size;

--- a/sources/Application/Instruments/WavFile.h
+++ b/sources/Application/Instruments/WavFile.h
@@ -30,7 +30,8 @@ public:
   virtual int GetSampleRate(int note);
   virtual int GetChannelCount(int note);
   virtual int GetRootNote(int note);
-  bool GetBuffer(long start, long sampleCount); // values in smples
+  bool GetBuffer(long start, long sampleCount); // values in samples
+  virtual float GetLengthInSec();
 
   uint32_t GetDiskSize(int note);
   bool Rewind();

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -1182,9 +1182,11 @@ PlayerEventType PlayerEvent::GetType() { return type_; };
 
 unsigned int PlayerEvent::GetTickCount() { return tickCount_; };
 
-void Player::StartStreaming(char *name) { mixer_.StartStreaming(name); }
+void Player::StartStreaming(const char *name, int startSample) {
+  mixer_.StartStreaming(name, startSample);
+}
 
-void Player::StartLoopingStreaming(char *name) {
+void Player::StartLoopingStreaming(const char *name) {
   mixer_.StartLoopingStreaming(name);
 }
 

--- a/sources/Application/Player/Player.h
+++ b/sources/Application/Player/Player.h
@@ -82,8 +82,8 @@ public:
   void ProcessCommands();
   bool ProcessChannelCommand(int channel, FourCC cmd, ushort param);
 
-  void StartStreaming(char *name);
-  void StartLoopingStreaming(char *name);
+  void StartStreaming(const char *name, int startSample = 0);
+  void StartLoopingStreaming(const char *name);
   void StopStreaming();
 
   void StartRecordStreaming(uint16_t *srcBuffer, uint32_t size, bool stereo);

--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -169,9 +169,11 @@ bool PlayerMixer::IsChannelMuted(int channel) {
   return channel_[channel]->IsMuted();
 }
 
-void PlayerMixer::StartStreaming(char *name) { fileStreamer_.Start(name); };
+void PlayerMixer::StartStreaming(const char *name, int startSample) {
+  fileStreamer_.Start(name, startSample);
+};
 
-void PlayerMixer::StartLoopingStreaming(char *name) {
+void PlayerMixer::StartLoopingStreaming(const char *name) {
   fileStreamer_.StartLooping(name);
 };
 

--- a/sources/Application/Player/PlayerMixer.h
+++ b/sources/Application/Player/PlayerMixer.h
@@ -54,8 +54,8 @@ public:
 
   bool IsChannelPlaying(int channel);
 
-  void StartStreaming(char *name);
-  void StartLoopingStreaming(char *name);
+  void StartStreaming(const char *name, int startSample = 0);
+  void StartLoopingStreaming(const char *name);
   void StopStreaming();
 
   void StartRecordStreaming(uint16_t *srcBuffer, uint32_t size, bool stereo);

--- a/sources/Application/Views/BaseClasses/CMakeLists.txt
+++ b/sources/Application/Views/BaseClasses/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(application_views_baseclasses
   UITempoField.cpp
   UISwatchField.cpp
   UIBitmaskVarField.cpp
+  UIBitmapField.cpp
   View.cpp
   ViewEvent.cpp
 )

--- a/sources/Application/Views/BaseClasses/UIBitmapField.cpp
+++ b/sources/Application/Views/BaseClasses/UIBitmapField.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#include "UIBitmapField.h"
+#include "System/Display/BitmapGraphics.h"
+
+UIBitmapField::UIBitmapField(GUIPoint &position, uint16_t width,
+                             uint16_t height, const uint8_t *bitmap_data,
+                             uint16_t fg_color, uint16_t bg_color)
+    : UIField(position), width_(width), height_(height),
+      bitmap_data_(bitmap_data), fg_color_(fg_color), bg_color_(bg_color) {}
+
+UIBitmapField::~UIBitmapField() {
+  // No dynamic memory to clean up
+}
+
+void UIBitmapField::Draw(GUIWindow &w, int offset) {
+  // Draw the bitmap using our new chargfx_draw_bitmap function
+  BitmapGraphics *gfx = BitmapGraphics::GetInstance();
+  gfx->drawBitmap(x_, y_, width_, height_, bitmap_data_, fg_color_, bg_color_);
+}
+
+void UIBitmapField::OnClick() {
+  // Default implementation - can be overridden by derived classes
+  // For now, just toggle focus
+  if (HasFocus()) {
+    ClearFocus();
+  } else {
+    SetFocus();
+  }
+}
+
+void UIBitmapField::ProcessArrow(unsigned short mask) {
+  // Default implementation - can be overridden by derived classes
+  // No default behavior for arrow keys
+}
+
+void UIBitmapField::SetBitmap(const uint8_t *bitmap_data) {
+  bitmap_data_ = bitmap_data;
+}
+
+void UIBitmapField::SetColors(uint16_t fg_color, uint16_t bg_color) {
+  fg_color_ = fg_color;
+  bg_color_ = bg_color;
+}

--- a/sources/Application/Views/BaseClasses/UIBitmapField.cpp
+++ b/sources/Application/Views/BaseClasses/UIBitmapField.cpp
@@ -21,43 +21,10 @@ UIBitmapField::~UIBitmapField() {
 
 void UIBitmapField::Draw(GUIWindow &w, int offset) {
   BitmapGraphics *gfx = BitmapGraphics::GetInstance();
-  if (gfx == nullptr) {
-    Trace::Error("BitmapGraphics instance is null");
-    return;
+  if (gfx) {
+    gfx->drawBitmap(x_, y_, width_, height_, bitmap_data_, fg_color_,
+                    bg_color_);
   }
-
-#ifdef ADV
-  const int scale = 2;
-  uint16_t scaled_width = width_ * scale;
-  uint16_t scaled_height = height_ * scale;
-
-  // Ensure scaled_width is a multiple of 8 for byte alignment
-  int bytes_per_row = (scaled_width + 7) / 8;
-  uint16_t buffer_size = bytes_per_row * scaled_height;
-  uint8_t *scaled_buffer = new uint8_t[buffer_size];
-  gfx->clearBuffer(scaled_buffer, scaled_width, scaled_height);
-
-  for (int y = 0; y < height_; ++y) {
-    for (int x = 0; x < width_; ++x) {
-      if (gfx->getPixel(bitmap_data_, width_, x, y)) {
-        int sx = x * scale;
-        int sy = y * scale;
-        for (int i = 0; i < scale; ++i) {
-          for (int j = 0; j < scale; ++j) {
-            gfx->setPixel(scaled_buffer, scaled_width, sx + i, sy + j, true);
-          }
-        }
-      }
-    }
-  }
-
-  gfx->drawBitmap(x_, y_, scaled_width, scaled_height, scaled_buffer, fg_color_,
-                  bg_color_);
-
-  delete[] scaled_buffer;
-#else
-  gfx->drawBitmap(x_, y_, width_, height_, bitmap_data_, fg_color_, bg_color_);
-#endif
 }
 
 void UIBitmapField::OnClick() {

--- a/sources/Application/Views/BaseClasses/UIBitmapField.cpp
+++ b/sources/Application/Views/BaseClasses/UIBitmapField.cpp
@@ -20,9 +20,44 @@ UIBitmapField::~UIBitmapField() {
 }
 
 void UIBitmapField::Draw(GUIWindow &w, int offset) {
-  // Draw the bitmap using our new chargfx_draw_bitmap function
   BitmapGraphics *gfx = BitmapGraphics::GetInstance();
+  if (gfx == nullptr) {
+    Trace::Error("BitmapGraphics instance is null");
+    return;
+  }
+
+#ifdef ADV
+  const int scale = 2;
+  uint16_t scaled_width = width_ * scale;
+  uint16_t scaled_height = height_ * scale;
+
+  // Ensure scaled_width is a multiple of 8 for byte alignment
+  int bytes_per_row = (scaled_width + 7) / 8;
+  uint16_t buffer_size = bytes_per_row * scaled_height;
+  uint8_t *scaled_buffer = new uint8_t[buffer_size];
+  gfx->clearBuffer(scaled_buffer, scaled_width, scaled_height);
+
+  for (int y = 0; y < height_; ++y) {
+    for (int x = 0; x < width_; ++x) {
+      if (gfx->getPixel(bitmap_data_, width_, x, y)) {
+        int sx = x * scale;
+        int sy = y * scale;
+        for (int i = 0; i < scale; ++i) {
+          for (int j = 0; j < scale; ++j) {
+            gfx->setPixel(scaled_buffer, scaled_width, sx + i, sy + j, true);
+          }
+        }
+      }
+    }
+  }
+
+  gfx->drawBitmap(x_, y_, scaled_width, scaled_height, scaled_buffer, fg_color_,
+                  bg_color_);
+
+  delete[] scaled_buffer;
+#else
   gfx->drawBitmap(x_, y_, width_, height_, bitmap_data_, fg_color_, bg_color_);
+#endif
 }
 
 void UIBitmapField::OnClick() {

--- a/sources/Application/Views/BaseClasses/UIBitmapField.h
+++ b/sources/Application/Views/BaseClasses/UIBitmapField.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _UI_BITMAP_FIELD_H_
+#define _UI_BITMAP_FIELD_H_
+
+#include "UIField.h"
+
+class UIBitmapField : public UIField {
+public:
+  UIBitmapField(GUIPoint &position, uint16_t width, uint16_t height,
+                const uint8_t *bitmap_data, uint16_t fg_color,
+                uint16_t bg_color);
+
+  virtual ~UIBitmapField();
+
+  // Implement UIField virtual methods
+  virtual void Draw(GUIWindow &w, int offset = 0);
+  virtual void OnClick(); // ENTER pressed
+  virtual void ProcessArrow(unsigned short mask);
+
+  // Methods to update bitmap properties
+  void SetBitmap(const uint8_t *bitmap_data);
+  void SetColors(uint16_t fg_color, uint16_t bg_color);
+
+private:
+  uint16_t width_;
+  uint16_t height_;
+  const uint8_t *bitmap_data_;
+  uint16_t fg_color_;
+  uint16_t bg_color_;
+};
+
+#endif // _UI_BITMAP_FIELD_H_

--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -55,7 +55,8 @@ enum ViewType {
   VT_SELECTPROJECT,     // Select project
   VT_THEME,             // Theme settings
   VT_SELECTTHEME,       // Theme selection
-  VT_THEME_IMPORT       // Theme file import
+  VT_THEME_IMPORT,      // Theme file import
+  VT_SAMPLE_EDITOR      // Sample Editor
 };
 
 enum ViewMode {

--- a/sources/Application/Views/CMakeLists.txt
+++ b/sources/Application/Views/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(application_views
   ViewData.cpp
   ScreenView.cpp
   MixerView.cpp
+  SampleEditorView.cpp
 )
 
 target_link_libraries(application_views PUBLIC

--- a/sources/Application/Views/CMakeLists.txt
+++ b/sources/Application/Views/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(application_views PUBLIC
   application_instruments
   etl
   application_utils
+  platform_display
 )
 
 target_include_directories(application_views PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -52,15 +52,15 @@ InstrumentView::InstrumentView(GUIWindow &w, ViewData *data)
   // add ui action fields for exporting and importing instrument settings
   position._y = 2;
 
-  actionField_.emplace_back("Import", FourCC::ActionImport, position);
-  fieldList_.insert(fieldList_.end(), &(*actionField_.rbegin()));
-  (*actionField_.rbegin()).AddObserver(*this);
+  persistentActionField_.emplace_back("Import", FourCC::ActionImport, position);
+  fieldList_.insert(fieldList_.end(), &(*persistentActionField_.rbegin()));
+  (*persistentActionField_.rbegin()).AddObserver(*this);
   lastFocusID_ = FourCC::ActionImport;
 
   position._x += 8;
-  actionField_.emplace_back("Export", FourCC::ActionExport, position);
-  fieldList_.insert(fieldList_.end(), &(*actionField_.rbegin()));
-  (*actionField_.rbegin()).AddObserver(*this);
+  persistentActionField_.emplace_back("Export", FourCC::ActionExport, position);
+  fieldList_.insert(fieldList_.end(), &(*persistentActionField_.rbegin()));
+  (*persistentActionField_.rbegin()).AddObserver(*this);
   lastFocusID_ = FourCC::ActionExport;
 }
 
@@ -173,6 +173,7 @@ void InstrumentView::refreshInstrumentFields() {
   bitmaskVarField_.clear();
   nameTextField_.clear();
   nameVariables_.clear();
+  actionField_.clear();
 
   // first put back the type field as its shown on *all* instrument types
   fieldList_.insert(fieldList_.end(), &(*typeIntVarField_.rbegin()));
@@ -180,7 +181,7 @@ void InstrumentView::refreshInstrumentFields() {
 
   // Re-add the action fields for export and import only if not IT_NONE
   if (instrumentType_.GetInt() != IT_NONE) {
-    for (auto &action : actionField_) {
+    for (auto &action : persistentActionField_) {
       fieldList_.insert(fieldList_.end(), &action);
       action.AddObserver(*this); // Make sure observers are re-added
     }
@@ -188,8 +189,8 @@ void InstrumentView::refreshInstrumentFields() {
     // add back only the import field for IT_NONE
     // bit of a hack !!since we just assume that import is the first action
     // field
-    fieldList_.insert(fieldList_.end(), &(*actionField_.begin()));
-    (*actionField_.rbegin()).AddObserver(*this);
+    fieldList_.insert(fieldList_.end(), &(*persistentActionField_.begin()));
+    (*persistentActionField_.rbegin()).AddObserver(*this);
   }
 
   // Create a new nameTextField_ if the instrument type supports it

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -274,6 +274,12 @@ void InstrumentView::fillSampleParameters() {
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
 
   position._y += 1;
+  actionField_.emplace_back("Sample Editor", FourCC::ActionShowSampleEditor,
+                            position);
+  fieldList_.insert(fieldList_.end(), &(*actionField_.rbegin()));
+  (*actionField_.rbegin()).AddObserver(*this);
+
+  position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentPan);
   intVarField_.emplace_back(position, *v, "pan: %2.2X", 0, 0xFE, 1, 0x10);
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
@@ -989,6 +995,13 @@ void InstrumentView::Update(Observable &o, I_ObservableData *data) {
         midiInstr->SendProgramChangeWithNote(channel, program);
       }
     }
+  } break;
+  case FourCC::ActionShowSampleEditor: {
+    // Switch to the SampleEditorView
+    ViewType vt = VT_SAMPLE_EDITOR;
+    ViewEvent ve(VET_SWITCH_VIEW, &vt);
+    SetChanged();
+    NotifyObservers(&ve);
   } break;
   default:
     break;

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -64,7 +64,7 @@ private:
   etl::string<MAX_INSTRUMENT_NAME_LENGTH> exportName_;
 
   etl::vector<UIIntVarField, 1> typeIntVarField_;
-  etl::vector<UIActionField, 2> actionField_;
+  etl::vector<UIActionField, 3> actionField_;
   etl::vector<UIIntVarField, 40> intVarField_;
   etl::vector<UINoteVarField, 1> noteVarField_;
   etl::vector<UIStaticField, 4> staticField_;

--- a/sources/Application/Views/InstrumentView.h
+++ b/sources/Application/Views/InstrumentView.h
@@ -64,7 +64,7 @@ private:
   etl::string<MAX_INSTRUMENT_NAME_LENGTH> exportName_;
 
   etl::vector<UIIntVarField, 1> typeIntVarField_;
-  etl::vector<UIActionField, 3> actionField_;
+  etl::vector<UIActionField, 2> persistentActionField_;
   etl::vector<UIIntVarField, 40> intVarField_;
   etl::vector<UINoteVarField, 1> noteVarField_;
   etl::vector<UIStaticField, 4> staticField_;
@@ -72,6 +72,7 @@ private:
   etl::vector<UIIntVarOffField, 2> intVarOffField_;
   etl::vector<UIBitmaskVarField, 3> bitmaskVarField_;
   etl::vector<UITextField<MAX_INSTRUMENT_NAME_LENGTH>, 1> nameTextField_;
+  etl::vector<UIActionField, 1> actionField_;
   etl::vector<InstrumentNameVariable, 1> nameVariables_;
 };
 #endif

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -370,7 +370,7 @@ void SampleEditorView::AnimationUpdate() {
           // Calculate the normalized playback position (0.0 to 1.0) based on
           // full sample duration
           float normalizedPos =
-              (float)elapsedFrames / (duration * SCREEN_REDRAW_RATE) * 3;
+              (float)elapsedFrames / (duration * SCREEN_REDRAW_RATE);
 
           // Calculate the position in the sample, accounting for the start
           // position

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -555,11 +555,10 @@ void SampleEditorView::updateWaveformDisplay() {
   // Draw a border around the waveform display
 #ifdef ADV
   // Draw rectangle using direct buffer access for 8bpp
-  for (int x = 0; x < scaled_width; x++) {
-    buffer[x] = 1;                                      // Top edge
-    buffer[(scaled_height - 1) * scaled_width + x] = 1; // Bottom edge
-  }
-  for (int y = 0; y < scaled_height; y++) {
+  memset(buffer, 1, scaled_width); // Top edge
+  memset(buffer + (scaled_height - 1) * scaled_width, 1,
+         scaled_width); // Bottom edge
+  for (int y = 1; y < scaled_height - 1; y++) {
     buffer[y * scaled_width] = 1;                    // Left edge
     buffer[y * scaled_width + scaled_width - 1] = 1; // Right edge
   }
@@ -592,15 +591,13 @@ void SampleEditorView::updateWaveformDisplay() {
 #ifdef ADV
       if (pixelHeight < 1) {
         // For very quiet signals, draw a single pixel line
-        for (int i = 0; i < scale; i++) {
-          buffer[(centerY * scaled_width) + scaledX + i] = 1;
-        }
+        memset(buffer + (centerY * scaled_width) + scaledX, 1, scale);
       } else {
         // For non-zero signals, draw the full height
-        for (int i = 0; i < scale; i++) {
-          for (int y = centerY - pixelHeight; y <= centerY + pixelHeight; y++) {
-            buffer[(y * scaled_width) + scaledX + i] = 1;
-          }
+        int startY = centerY - pixelHeight;
+        int endY = centerY + pixelHeight;
+        for (int y = startY; y <= endY; y++) {
+          memset(buffer + (y * scaled_width) + scaledX, 1, scale);
         }
       }
 #else

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -36,7 +36,7 @@ SampleEditorView::SampleEditorView(GUIWindow &w, ViewData *data)
   BitmapGraphics *gfx = BitmapGraphics::GetInstance();
 
   // TODO: enable after fixing crash on advance
-  // gfx->clearBuffer(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT);
+  gfx->clearBuffer(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT);
 
   addAllFields();
 }
@@ -91,11 +91,11 @@ void SampleEditorView::addAllFields() {
     // TODO: enable after fixing crash on advance
 
     // Add waveform display field
-    // position._y = 2;
-    // position._x = 0; // start at the left edge of the window
-    // waveformField_.emplace_back(position, BITMAPWIDTH, BITMAPHEIGHT,
-    //                             bitmapBuffer_, 0xFFFF, 0x0000);
-    // fieldList_.insert(fieldList_.end(), &(*waveformField_.rbegin()));
+    position._y = 2;
+    position._x = 0; // start at the left edge of the window
+    waveformField_.emplace_back(position, BITMAPWIDTH, BITMAPHEIGHT,
+                                bitmapBuffer_, 0xFFFF, 0x0000);
+    fieldList_.insert(fieldList_.end(), &(*waveformField_.rbegin()));
 
     int sampleSize = currentInstrument_->GetSampleSize();
 
@@ -383,7 +383,7 @@ void SampleEditorView::AnimationUpdate() {
 
     // TODO: enable after fixing crash on advance
     // Update the waveform display
-    // updateWaveformDisplay();
+    updateWaveformDisplay();
     forceRedraw_ = false;
   }
 

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -569,23 +569,6 @@ void SampleEditorView::updateWaveformDisplay() {
   int sampleSize = currentInstrument_->GetSampleSize();
   int start = 0, end = sampleSize - 1, loopStart = 0, loopMode = 0;
 
-  Variable *startVar =
-      currentInstrument_->FindVariable(FourCC::SampleInstrumentStart);
-  if (startVar)
-    start = startVar->GetInt();
-  Variable *endVar =
-      currentInstrument_->FindVariable(FourCC::SampleInstrumentEnd);
-  if (endVar)
-    end = endVar->GetInt();
-  Variable *loopStartVar =
-      currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopStart);
-  if (loopStartVar)
-    loopStart = loopStartVar->GetInt();
-  Variable *loopModeVar =
-      currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopMode);
-  if (loopModeVar)
-    loopMode = loopModeVar->GetInt();
-
   // Draw markers directly to the final buffer
   {
     Profiler p("updateWaveformDisplay: draw markers");
@@ -653,7 +636,8 @@ void SampleEditorView::updateWaveformDisplay() {
 #endif
     SetDirty(true);
     if (isPlaying_) {
-      Redraw();
+      Profiler p("updateWaveformDisplay: REDRAW");
+      waveformField_.rbegin()->Draw(w_);
     }
   }
 }

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1,0 +1,665 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2018 Discodirt
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#include "SampleEditorView.h"
+#include "Application/AppWindow.h"
+#include "Application/Instruments/SamplePool.h"
+#include "Application/Model/Config.h"
+#include "Application/Utils/char.h"
+#include "BaseClasses/UIBigHexVarField.h"
+#include "BaseClasses/UIBitmapField.h"
+#include "BaseClasses/UIIntVarField.h"
+#include "BaseClasses/UIStaticField.h"
+#include "Foundation/Types/Types.h"
+#include "Services/Midi/MidiService.h"
+#include "System/Console/Trace.h"
+#include "System/Display/BitmapGraphics.h"
+#include "UIController.h"
+#include <cmath>
+#include <cstdint>
+
+SampleEditorView::SampleEditorView(GUIWindow &w, ViewData *data)
+    : FieldView(w, data), currentInstrument_(NULL), forceRedraw_(false),
+      isPlaying_(false), isSingleCycle_(false), playKeyHeld_(false),
+      waveformCacheValid_(false), playbackPosition_(0.0f),
+      playbackStartFrame_(0) {
+  // Initialize waveform cache to zero
+  memset(waveformCache_, 0, sizeof(waveformCache_));
+
+  // Clear the buffer
+  BitmapGraphics *gfx = BitmapGraphics::GetInstance();
+
+  // TODO: enable after fixing crash on advance
+  // gfx->clearBuffer(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT);
+
+  addAllFields();
+}
+
+SampleEditorView::~SampleEditorView() {}
+
+SampleInstrument *SampleEditorView::getCurrentSampleInstrument() {
+  int id = viewData_->currentInstrumentID_;
+  InstrumentBank *bank = viewData_->project_->GetInstrumentBank();
+  I_Instrument *instr = bank->GetInstrument(id);
+
+  // Check if this is a sample instrument
+  if (instr && instr->GetType() == IT_SAMPLE) {
+    return static_cast<SampleInstrument *>(instr);
+  }
+
+  return nullptr;
+}
+
+void SampleEditorView::OnFocus() {
+  // Update the current instrument reference
+  currentInstrument_ = getCurrentSampleInstrument();
+
+  // Force redraw of waveform
+  forceRedraw_ = true;
+
+  // Invalidate cache on focus to ensure we always have the right waveform
+  updateWaveformCache();
+
+  FieldView::OnFocus();
+  addAllFields();
+}
+
+void SampleEditorView::addAllFields() {
+  // We currently have no way to update fields with the variable they are
+  // assinged so instead we need to first clear out all the previous fields
+  // and then re-add them just like we do on the InstrumentView
+  fieldList_.clear();
+  bigHexVarField_.clear();
+  intVarField_.clear();
+  actionField_.clear();
+  waveformField_.clear();
+  nameTextField_.clear();
+  nameVariables_.clear();
+  // no need to clear staticField_ as they are not added to fieldList_
+
+  GUIPoint position = GetAnchor();
+
+  // update the other fields using the current instrument just like we do
+  // initially Add sample parameters if we have a valid instrument
+  if (currentInstrument_) {
+    // TODO: enable after fixing crash on advance
+
+    // Add waveform display field
+    // position._y = 2;
+    // position._x = 0; // start at the left edge of the window
+    // waveformField_.emplace_back(position, BITMAPWIDTH, BITMAPHEIGHT,
+    //                             bitmapBuffer_, 0xFFFF, 0x0000);
+    // fieldList_.insert(fieldList_.end(), &(*waveformField_.rbegin()));
+
+    int sampleSize = currentInstrument_->GetSampleSize();
+
+    position._y = 12; // offset enough for bitmap field
+    position._x = 5;
+
+    nameVariables_.emplace_back(currentInstrument_);
+    Variable &nameVar = *nameVariables_.rbegin();
+
+    auto label =
+        etl::make_string_with_capacity<MAX_UITEXTFIELD_LABEL_LENGTH>("name: ");
+
+    // Use an empty default name - we don't want to populate with sample
+    // filename The display name will still be shown on the phrase screen via
+    // GetDisplayName()
+    etl::string<MAX_INSTRUMENT_NAME_LENGTH> defaultName;
+
+    nameTextField_.emplace_back(nameVar, position, label,
+                                FourCC::InstrumentName, defaultName);
+    fieldList_.insert(fieldList_.end(), &(*nameTextField_.rbegin()));
+
+    position._y += 1;
+
+    Variable *startVar =
+        currentInstrument_->FindVariable(FourCC::SampleInstrumentStart);
+    if (startVar) {
+      bigHexVarField_.emplace_back(position, *startVar, 7, "start: %7.7X", 0,
+                                   sampleSize - 1, 16);
+      fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+      (*bigHexVarField_.rbegin()).AddObserver(*this);
+    }
+
+    // Add loop start control
+    position._y += 1;
+    Variable *loopStartVar =
+        currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopStart);
+    if (loopStartVar) {
+      bigHexVarField_.emplace_back(position, *loopStartVar, 7,
+                                   "loop start: %7.7X", 0, sampleSize - 1, 16);
+      fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+      (*bigHexVarField_.rbegin()).AddObserver(*this);
+    }
+
+    // Add end position control
+    position._y += 1;
+    Variable *endVar =
+        currentInstrument_->FindVariable(FourCC::SampleInstrumentEnd);
+    if (endVar) {
+      bigHexVarField_.emplace_back(position, *endVar, 7, "loop end: %7.7X", 0,
+                                   sampleSize - 1, 16);
+      fieldList_.insert(fieldList_.end(), &(*bigHexVarField_.rbegin()));
+      (*bigHexVarField_.rbegin()).AddObserver(*this);
+    }
+
+    // Add loop mode control
+    position._y += 1;
+    Variable *loopModeVar =
+        currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopMode);
+    if (loopModeVar) {
+      intVarField_.emplace_back(position, *loopModeVar, "loop mode: %s", 0, 2,
+                                1, 1);
+      fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
+      (*intVarField_.rbegin()).AddObserver(*this);
+    }
+  }
+}
+
+void SampleEditorView::ProcessButtonMask(unsigned short mask, bool pressed) {
+  // Check for key release events
+  if (!pressed) {
+    // Check if play key was released (exactly like ImportView approach)
+    if (playKeyHeld_ && !(mask & EPBM_PLAY)) {
+      // Play key no longer pressed so should stop playback
+      playKeyHeld_ = false;
+
+      if (Player::GetInstance()->IsPlaying()) {
+        // Stop playback regardless of whether it's regular or looping
+        Player::GetInstance()->StopStreaming();
+        isPlaying_ = false;
+
+        // Force redraw to remove the playhead
+        forceRedraw_ = true;
+      }
+      return;
+    }
+  }
+
+  // If not pressed, let parent handle it and return
+  if (!pressed) {
+    FieldView::ProcessButtonMask(mask, pressed);
+    return;
+  }
+
+  if (mask & EPBM_NAV) {
+    if (mask & EPBM_LEFT) {
+      // Go back to Instrument view with NAV+LEFT
+      ViewType vt = VT_INSTRUMENT;
+      ViewEvent ve(VET_SWITCH_VIEW, &vt);
+      SetChanged();
+      NotifyObservers(&ve);
+      return;
+    }
+    // For other NAV combinations, let parent handle it
+    FieldView::ProcessButtonMask(mask, pressed);
+    return;
+  } else if (mask & EPBM_PLAY) {
+    // Set flag to track that play key is being held down (like in ImportView)
+    playKeyHeld_ = true;
+
+    // Start sample playback if we have a valid instrument
+    if (currentInstrument_ && !isPlaying_) {
+      // Get the sample file name from the instrument's variable
+      Variable *sampleVar =
+          currentInstrument_->FindVariable(FourCC::SampleInstrumentSample);
+
+      if (sampleVar && sampleVar->GetInt() >= 0) {
+        // Get the sample filename from the variable
+        etl::string<MAX_INSTRUMENT_NAME_LENGTH> sampleFileName =
+            sampleVar->GetString();
+
+        // Get sample size to check if it's a single cycle waveform
+        uint32_t sampleSize = currentInstrument_->GetSampleSize();
+        isSingleCycle_ = (sampleSize <= SINGLE_CYCLE_MAX_SAMPLE_SIZE);
+
+        Trace::Debug("DEBUG: Starting playback of sample '%s' (size=%d, "
+                     "singleCycle=%s)\n",
+                     sampleFileName.c_str(), sampleSize,
+                     isSingleCycle_ ? "true" : "false");
+
+        // Reset playback state
+        isPlaying_ = true;
+
+        // Get the start position which is where playback will begin
+        Variable *startVar =
+            currentInstrument_->FindVariable(FourCC::SampleInstrumentStart);
+        uint32_t startSample = startVar->GetInt();
+        if (startVar && startSample < sampleSize) {
+          // Initialize normalized playback position (0.0 - 1.0)
+          playbackPosition_ = (float)startSample / sampleSize;
+        } else {
+          playbackPosition_ = 0.0f;
+        }
+
+        // Store the current animation frame as our start frame
+        playbackStartFrame_ = AppWindow::GetAnimationFrameCounter();
+        forceRedraw_ = true;
+
+        // If something is already playing, stop it first
+        if (Player::GetInstance()->IsPlaying()) {
+          Player::GetInstance()->StopStreaming();
+        }
+
+        // First change to the current project directory
+        auto fs = FileSystem::GetInstance();
+        fs->chdir("projects");
+
+        // Get the current project name from view data
+        if (viewData_ && viewData_->project_) {
+          char projectName[MAX_PROJECT_NAME_LENGTH + 1];
+          viewData_->project_->GetProjectName(projectName);
+
+          // Change to the project directory
+          if (fs->chdir(projectName)) {
+            // Change to the samples directory
+            fs->chdir("samples");
+          } else {
+            Trace::Error("SampleEditorView: Failed to chdir to project dir: %s",
+                         projectName);
+          }
+        } else {
+          Trace::Error("SampleEditorView: No project data available");
+          return;
+        }
+
+        // Start playing the sample with just the filename
+        if (isSingleCycle_) {
+          Player::GetInstance()->StartLoopingStreaming(sampleFileName.c_str());
+        } else {
+          // Start playback from the specified start position
+          Player::GetInstance()->StartStreaming(sampleFileName.c_str(),
+                                                startSample);
+        }
+
+        isPlaying_ = true;
+
+        // Force redraw to show the playhead
+        forceRedraw_ = true;
+      }
+    }
+    return;
+  }
+
+  // For all other button presses, let the parent class handle navigation
+  FieldView::ProcessButtonMask(mask, pressed);
+}
+
+void SampleEditorView::DrawView() {
+  Clear();
+
+  GUITextProperties props;
+  GUIPoint pos = GetTitlePosition();
+
+  // Draw title
+  char titleString[SCREEN_WIDTH];
+  strcpy(titleString, "Sample Edit");
+
+  SetColor(CD_NORMAL);
+  DrawString(pos._x, pos._y, titleString, props);
+
+  FieldView::Redraw();
+
+  SetColor(CD_NORMAL);
+}
+
+void SampleEditorView::AnimationUpdate() {
+  // Update playhead position if sample is playing
+  if (isPlaying_ && currentInstrument_) {
+    // Check if the Player is still playing the sample
+    if (!Player::GetInstance()->IsPlaying()) {
+      // Playback has stopped (reached the end of non-looping sample)
+      isPlaying_ = false;
+      playbackPosition_ = 0;
+      forceRedraw_ = true;
+      Trace::Debug("DEBUG: Playback stopped, resetting playhead\n");
+    } else {
+      // Get the current instrument
+      SampleInstrument *currentInstrument_ = getCurrentSampleInstrument();
+      if (currentInstrument_) {
+        uint32_t sampleSize = currentInstrument_->GetSampleSize();
+        if (sampleSize > 0) {
+          // Get the start and end positions for the active sample range
+          uint32_t start = 0;
+          uint32_t end = sampleSize - 1;
+
+          Variable *startVar =
+              currentInstrument_->FindVariable(FourCC::SampleInstrumentStart);
+          if (startVar)
+            start = startVar->GetInt();
+
+          Variable *endVar =
+              currentInstrument_->FindVariable(FourCC::SampleInstrumentEnd);
+          if (endVar)
+            end = endVar->GetInt();
+
+          // Ensure parameters are within valid range
+          if (start >= sampleSize)
+            start = sampleSize - 1;
+          if (end >= sampleSize)
+            end = sampleSize - 1;
+          if (start > end)
+            start = end;
+
+          // Get the current frame count since playback started
+          uint32_t currentFrame = AppWindow::GetAnimationFrameCounter();
+          uint32_t elapsedFrames = currentFrame - playbackStartFrame_;
+
+          // Get the sample duration in seconds
+          float duration = currentInstrument_->GetLengthInSec();
+
+          // Calculate the normalized playback position (0.0 to 1.0) based on
+          // full sample duration
+          float normalizedPos =
+              (float)elapsedFrames / (duration * SCREEN_REDRAW_RATE);
+
+          // Calculate the position in the sample, accounting for the start
+          // position
+          float samplePos = start + normalizedPos * sampleSize;
+
+          // Check if we've reached the end
+          if (samplePos >= end || samplePos >= sampleSize) {
+            samplePos = end;
+            isPlaying_ = false;
+          }
+
+          // Update position (normalized to full sample range)
+          playbackPosition_ = samplePos / sampleSize;
+          forceRedraw_ = true;
+        }
+      }
+    }
+  }
+
+  // Check if we need to update the waveform display
+  if (forceRedraw_) {
+
+    // TODO: enable after fixing crash on advance
+    // Update the waveform display
+    // updateWaveformDisplay();
+    forceRedraw_ = false;
+  }
+
+  GUITextProperties props;
+  drawBattery(props);
+  drawPowerButtonUI(props);
+}
+
+void SampleEditorView::Update(Observable &o, I_ObservableData *d) {
+  // When any of our observed variables change, force a redraw of the waveform
+  forceRedraw_ = true;
+}
+
+void SampleEditorView::updateWaveformCache() {
+  if (!currentInstrument_) {
+    waveformCacheValid_ = false;
+    return;
+  }
+
+  SamplePool *pool = SamplePool::GetInstance();
+  SoundSource *source = pool->GetSource(currentInstrument_->GetSampleIndex());
+
+  if (!source) {
+    waveformCacheValid_ = false;
+    return;
+  }
+
+  int sampleSize = source->GetSize(0);
+  short *sampleBuffer = (short *)source->GetSampleBuffer(0);
+
+  if (!sampleBuffer || sampleSize == 0) {
+    waveformCacheValid_ = false;
+    return;
+  }
+
+  float samplesPerPixel = (float)sampleSize / (WAVEFORM_CACHE_SIZE - 2);
+  int maxHeight = (BITMAPHEIGHT / 2) - 2;
+
+  // First, find the peak amplitude of the sample to determine scaling
+  short peakAmplitude = 0;
+  for (int i = 0; i < sampleSize; i++) {
+    short sampleValue = abs(sampleBuffer[i]);
+    if (sampleValue > peakAmplitude) {
+      peakAmplitude = sampleValue;
+    }
+  }
+
+  // Choose a scaling factor based on the peak amplitude
+  float scalingFactor = 1.0f;
+  if (peakAmplitude < 15000) {
+    scalingFactor = 3.0f;
+  } else if (peakAmplitude < 25000) {
+    scalingFactor = 1.5f;
+  }
+
+  // Now, calculate the RMS for each column and apply the chosen scaling
+  for (int x = 0; x < WAVEFORM_CACHE_SIZE; x++) {
+    int startSampleIndex = (int)(x * samplesPerPixel);
+    int endSampleIndex = (int)((x + 1) * samplesPerPixel);
+
+    if (endSampleIndex <= startSampleIndex) {
+      endSampleIndex = startSampleIndex + 1;
+    }
+
+    if (startSampleIndex < 0)
+      startSampleIndex = 0;
+    if (endSampleIndex >= sampleSize)
+      endSampleIndex = sampleSize - 1;
+
+    double sumSquares = 0.0;
+    int sampleCount = 0;
+
+    for (int i = startSampleIndex; i <= endSampleIndex; i++) {
+      float normalizedSample = sampleBuffer[i] / 32768.0f;
+      sumSquares += normalizedSample * normalizedSample;
+      sampleCount++;
+    }
+
+    float rmsValue = (sampleCount > 0) ? sqrt(sumSquares / sampleCount) : 0.0f;
+    float scaledRms = rmsValue * scalingFactor;
+
+    // Clamp the value to prevent overflow
+    if (scaledRms > 1.0f) {
+      scaledRms = 1.0f;
+    }
+
+    waveformCache_[x] = (uint8_t)(scaledRms * maxHeight);
+  }
+
+  waveformCacheValid_ = true;
+}
+
+void SampleEditorView::updateWaveformDisplay() {
+  // Clear the bitmap buffer
+  memset(bitmapBuffer_, 0, BITMAPWIDTH * BITMAPHEIGHT / 8);
+
+  // Draw a border around the waveform display
+  BitmapGraphics *gfx = BitmapGraphics::GetInstance();
+  gfx->drawRect(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, 0, 0, BITMAPWIDTH - 1,
+                BITMAPHEIGHT - 1, false, true);
+
+  // Check if we have a valid instrument
+  if (!currentInstrument_) {
+    // No instrument, just update the bitmap and return
+    waveformField_[0].SetBitmap(bitmapBuffer_);
+    return;
+  }
+
+  // Get sample size directly from the instrument
+  int sampleSize = currentInstrument_->GetSampleSize();
+  if (sampleSize <= 0) {
+    // No sample data, just update the bitmap and return
+    waveformField_[0].SetBitmap(bitmapBuffer_);
+    Trace::Debug("No sample data, just update the bitmap");
+    return;
+  }
+
+  // Get the sample data from the instrument
+  int sampleIndex = currentInstrument_->GetSampleIndex();
+  if (sampleIndex < 0) {
+    // No valid sample index, just update the bitmap and return
+    waveformField_[0].SetBitmap(bitmapBuffer_);
+    return;
+  }
+
+  // Get the sample source from the sample pool
+  SamplePool *pool = SamplePool::GetInstance();
+  SoundSource *source = pool->GetSource(sampleIndex);
+  if (!source) {
+    // No valid source, just update the bitmap and return
+    waveformField_[0].SetBitmap(bitmapBuffer_);
+    return;
+  }
+
+  // Get sample parameters
+  int start = 0;
+  int end = sampleSize - 1;
+  int loopStart = 0;
+  int loopMode = 0;
+
+  Variable *startVar =
+      currentInstrument_->FindVariable(FourCC::SampleInstrumentStart);
+  if (startVar)
+    start = startVar->GetInt();
+
+  Variable *endVar =
+      currentInstrument_->FindVariable(FourCC::SampleInstrumentEnd);
+  if (endVar)
+    end = endVar->GetInt();
+
+  Variable *loopStartVar =
+      currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopStart);
+  if (loopStartVar)
+    loopStart = loopStartVar->GetInt();
+
+  Variable *loopModeVar =
+      currentInstrument_->FindVariable(FourCC::SampleInstrumentLoopMode);
+  if (loopModeVar)
+    loopMode = loopModeVar->GetInt();
+
+  // Ensure parameters are within valid range
+  if (start >= sampleSize) {
+    start = sampleSize - 1;
+  }
+  if (end >= sampleSize) {
+    end = sampleSize - 1;
+  }
+  if (loopStart >= sampleSize) {
+    loopStart = sampleSize - 1;
+  }
+
+  // Draw the waveform from the cache
+  int centerY = BITMAPHEIGHT / 2;
+  for (int x = 0; x < WAVEFORM_CACHE_SIZE; x++) {
+    int pixelHeight = waveformCache_[x];
+
+    // Always draw at least a 1-pixel line for visibility, even for very quiet
+    // signals
+    if (pixelHeight < 1) {
+      // For very quiet signals, draw a single pixel line
+      gfx->drawLine(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, x, centerY, x,
+                    centerY, true);
+    } else {
+      // For non-zero signals, draw the full height
+      gfx->drawLine(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, x,
+                    centerY - pixelHeight, x, centerY + pixelHeight, true);
+    }
+  }
+
+  // Get the full sample range for proper scaling of markers
+  int fullSampleSize = currentInstrument_->GetSampleSize();
+
+  // Calculate positions for start and end markers based on their actual values
+  // Map the start position to the bitmap width - start as a fraction of
+  // fullSampleSize
+  int startX = 1 + (int)(((float)start / fullSampleSize) * (BITMAPWIDTH - 2));
+  if (startX < 1)
+    startX = 1;
+  if (startX >= BITMAPWIDTH - 1)
+    startX = BITMAPWIDTH - 2;
+
+  // Draw the start marker line
+  gfx->drawLine(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, startX, 1, startX,
+                BITMAPHEIGHT - 2, true);
+
+  // Map the end position to the bitmap width - end as a fraction of
+  // fullSampleSize
+  int endX = 1 + (int)(((float)end / fullSampleSize) * (BITMAPWIDTH - 2));
+  if (endX < 1)
+    endX = 1;
+  if (endX >= BITMAPWIDTH - 1)
+    endX = BITMAPWIDTH - 2;
+
+  // Draw the end marker line
+  gfx->drawLine(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, endX, 1, endX,
+                BITMAPHEIGHT - 2, true);
+
+  // First playhead drawing section - removed
+
+  // Draw markers for loop points if loop mode is enabled
+  // draw loop start marker as dashed line
+  if (loopMode > 0) {
+    // Calculate x position for loop start using the same scaling as start/end
+    // markers - loopStart as a fraction of fullSampleSize
+    int loopX =
+        1 + (int)(((float)loopStart / fullSampleSize) * (BITMAPWIDTH - 2));
+    if (loopX >= 1 && loopX < BITMAPWIDTH - 1) {
+      // Draw a dashed vertical line for loop start
+      for (int y = 1; y < BITMAPHEIGHT - 2; y += 3) {
+        // Draw 2-pixel dash, then 1-pixel gap
+        gfx->setPixel(bitmapBuffer_, BITMAPWIDTH, loopX, y, true);
+        gfx->setPixel(bitmapBuffer_, BITMAPWIDTH, loopX, y + 1, true);
+      }
+    }
+  }
+
+  // Draw the playhead indicator if the sample is playing
+  if (isPlaying_) {
+    // Calculate the x position for the playhead using the normalized position
+    // (0.0-1.0) Map the normalized position directly to bitmap width
+    int playheadX = 1 + (int)(playbackPosition_ * (BITMAPWIDTH - 2));
+
+    // Ensure the playhead stays within bounds
+    if (playheadX < 1)
+      playheadX = 1;
+    if (playheadX >= BITMAPWIDTH - 1)
+      playheadX = BITMAPWIDTH - 2;
+
+    // Draw a thick vertical line for better visibility
+    for (int offset = -1; offset <= 1; offset++) {
+      int x = playheadX + offset;
+      if (x >= 1 && x < BITMAPWIDTH - 1) {
+        gfx->drawLine(bitmapBuffer_, BITMAPWIDTH, BITMAPHEIGHT, x, 1, x,
+                      BITMAPHEIGHT - 2, true);
+      }
+    }
+
+    // Draw a triangle at the top of the playhead
+    for (int y = 0; y < 3; y++) {
+      for (int x = -y; x <= y; x++) {
+        int px = playheadX + x;
+        int py = y;
+        if (px >= 1 && px < BITMAPWIDTH - 1 && py < BITMAPHEIGHT - 2) {
+          gfx->setPixel(bitmapBuffer_, BITMAPWIDTH, px, py, true);
+        }
+      }
+    }
+  }
+
+  // Update the bitmap field and request redraw
+  if (waveformField_.size() > 0) {
+    waveformField_[0].SetBitmap(bitmapBuffer_);
+    SetDirty(true);
+    // Force immediate redraw of the view
+    if (isPlaying_) {
+      Redraw();
+    }
+  }
+}

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -66,6 +66,9 @@ void SampleEditorView::OnFocus() {
   // Invalidate cache on focus to ensure we always have the right waveform
   updateWaveformCache();
 
+  // make sure we do initial draw of the waveform into bitmap for display
+  updateWaveformDisplay();
+
   FieldView::OnFocus();
   addAllFields();
 }

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -45,6 +45,7 @@ private:
   void updateWaveformDisplay();
   void addAllFields();
   void addNameTextField(I_Instrument *instr, GUIPoint &position);
+  void updateSampleParameters();
 
   // UI fields
   etl::vector<UIIntVarField, 10> intVarField_;
@@ -60,9 +61,12 @@ private:
 #ifdef ADV
   // Statically allocated bitmap buffer for scaled waveform display
   uint8_t *scaledBitmapBuffer_;
-#endif
+  // Statically allocated bitmap buffer for waveform display
+  uint8_t bitmapBuffer_[BITMAPWIDTH * BITMAPHEIGHT];
+#else
   // Statically allocated bitmap buffer for waveform display
   uint8_t bitmapBuffer_[BITMAPWIDTH * BITMAPHEIGHT / 8];
+#endif
 
   // Sample data reference
   SampleInstrument *currentInstrument_;
@@ -74,6 +78,12 @@ private:
   bool isPlaying_;
   bool isSingleCycle_; // Whether the sample is a single cycle waveform
   bool playKeyHeld_;   // Flag to track when the play key is being held down
+
+  // Cached sample parameters
+  int start_;
+  int end_;
+  int loopStart_;
+  int loopMode_;
 
 private:
   // Waveform data cache

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -1,0 +1,87 @@
+
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2018 Discodirt
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _SAMPLE_EDITOR_VIEW_H_
+#define _SAMPLE_EDITOR_VIEW_H_
+
+#include "Application/Instruments/InstrumentNameVariable.h"
+#include "Application/Instruments/SampleInstrument.h"
+#include "BaseClasses/UIActionField.h"
+#include "BaseClasses/UIBigHexVarField.h"
+#include "BaseClasses/UIBitmapField.h"
+#include "BaseClasses/UIIntVarField.h"
+#include "BaseClasses/UIStaticField.h"
+#include "BaseClasses/UITextField.h"
+#include "FieldView.h"
+#include "Foundation/Observable.h"
+#include "ViewData.h"
+
+class SampleEditorView : public FieldView, public I_Observer {
+public:
+  SampleEditorView(GUIWindow &w, ViewData *data);
+  virtual ~SampleEditorView();
+
+  virtual void ProcessButtonMask(unsigned short mask, bool pressed);
+  virtual void DrawView();
+  virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
+  virtual void OnFocus();
+
+  // Observer for action callback
+  void Update(Observable &, I_ObservableData *);
+
+  void AnimationUpdate() override;
+
+protected:
+private:
+  // Helper methods
+  SampleInstrument *getCurrentSampleInstrument();
+  void updateWaveformDisplay();
+  void addAllFields();
+  void addNameTextField(I_Instrument *instr, GUIPoint &position);
+
+  // UI fields
+  etl::vector<UIIntVarField, 10> intVarField_;
+  etl::vector<UIBigHexVarField, 4> bigHexVarField_;
+  etl::vector<UIActionField, 2> actionField_;
+  etl::vector<UIStaticField, 4> staticField_;
+  etl::vector<UIBitmapField, 1> waveformField_;
+  etl::vector<UITextField<MAX_INSTRUMENT_NAME_LENGTH>, 1> nameTextField_;
+  etl::vector<InstrumentNameVariable, 1> nameVariables_;
+
+#define BITMAPWIDTH 320
+#define BITMAPHEIGHT 80
+  // Statically allocated bitmap buffer for waveform display
+  uint8_t bitmapBuffer_[BITMAPWIDTH * BITMAPHEIGHT / 8];
+
+  // Sample data reference
+  SampleInstrument *currentInstrument_;
+
+  // Flag to force redraw of waveform
+  bool forceRedraw_;
+
+  // Playback state
+  bool isPlaying_;
+  bool isSingleCycle_; // Whether the sample is a single cycle waveform
+  bool playKeyHeld_;   // Flag to track when the play key is being held down
+
+private:
+  // Waveform data cache
+  static const int WAVEFORM_CACHE_SIZE = 320; // Match BITMAPWIDTH
+  uint8_t
+      waveformCache_[WAVEFORM_CACHE_SIZE]; // Store pre-calculated pixel heights
+  bool waveformCacheValid_;
+
+  void updateWaveformCache();
+
+  float playbackPosition_; // Current playback position as normalized value (0.0
+                           // - 1.0)
+  uint32_t playbackStartFrame_; // Animation frame when playback started
+};
+#endif

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -83,5 +83,7 @@ private:
   float playbackPosition_; // Current playback position as normalized value (0.0
                            // - 1.0)
   uint32_t playbackStartFrame_; // Animation frame when playback started
+  uint32_t lastAnimationTime_;  // Timestamp of the last animation frame
+  System *sys_;
 };
 #endif

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -57,6 +57,10 @@ private:
 
 #define BITMAPWIDTH 320
 #define BITMAPHEIGHT 80
+#ifdef ADV
+  // Statically allocated bitmap buffer for scaled waveform display
+  uint8_t *scaledBitmapBuffer_;
+#endif
   // Statically allocated bitmap buffer for waveform display
   uint8_t bitmapBuffer_[BITMAPWIDTH * BITMAPHEIGHT / 8];
 

--- a/sources/Foundation/Types/Types.h
+++ b/sources/Foundation/Types/Types.h
@@ -204,6 +204,7 @@ struct FourCC {
     // 172 is taken for ActionThemeName
     // 173 is taken for VarThemeName
     // 174 is taken for VarBacklightLevel
+    // 175 is taken for ActionShowSampleEditor
 
     VarChannel1Volume = 163,
     VarChannel2Volume = 164,
@@ -237,6 +238,7 @@ struct FourCC {
     ActionThemeName = 172,
     SampleInstrumentSlices = 171,
     VarBacklightLevel = 174,
+    ActionShowSampleEditor = 175,
 
     Default = 255, // "    "
   };

--- a/sources/System/Display/BitmapGraphics.h
+++ b/sources/System/Display/BitmapGraphics.h
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 xiphonics, inc.
+ *
+ * This file is part of the picoTracker firmware
+ */
+
+#ifndef _BITMAPGRAPHICS_H
+#define _BITMAPGRAPHICS_H
+
+#include "Foundation/T_Factory.h"
+#include <cstdint>
+
+class BitmapGraphics : public T_Factory<BitmapGraphics> {
+public:
+  BitmapGraphics() = default;
+  virtual ~BitmapGraphics() = default;
+
+  /**
+   * Draw a monochrome bitmap on the display
+   * @param x X position in character cells
+   * @param y Y position in character cells
+   * @param width Width in pixels (must be multiple of 8)
+   * @param height Height in pixels
+   * @param bitmap_data Pointer to bitmap data (1 bit per pixel, row-major
+   * order)
+   * @param fg_color Foreground color (for 1 bits)
+   * @param bg_color Background color (for 0 bits)
+   */
+  virtual void drawBitmap(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
+                  const uint8_t *bitmap_data, uint16_t fg_color,
+                  uint16_t bg_color) = 0;
+
+  /**
+   * Clear a bitmap buffer (set all pixels to 0)
+   * @param buffer Pointer to the bitmap buffer
+   * @param width Width in pixels (must be multiple of 8)
+   * @param height Height in pixels
+   */
+  virtual void clearBuffer(uint8_t *buffer, uint16_t width, uint16_t height) = 0;
+
+  /**
+   * Set a pixel in a bitmap buffer
+   * @param buffer Pointer to the bitmap buffer
+   * @param width Width of the bitmap in pixels (must be multiple of 8)
+   * @param x X coordinate of the pixel
+   * @param y Y coordinate of the pixel
+   * @param value Pixel value (true = set, false = clear)
+   */
+  virtual void setPixel(uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y,
+                bool value) = 0;
+
+  /**
+   * Get a pixel from a bitmap buffer
+   * @param buffer Pointer to the bitmap buffer
+   * @param width Width of the bitmap in pixels (must be multiple of 8)
+   * @param x X coordinate of the pixel
+   * @param y Y coordinate of the pixel
+   * @return Pixel value (true = set, false = clear)
+   */
+  virtual bool getPixel(const uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y) = 0;
+
+  /**
+   * Draw a line in a bitmap buffer using Bresenham's algorithm
+   * @param buffer Pointer to the bitmap buffer
+   * @param width Width of the bitmap in pixels (must be multiple of 8)
+   * @param height Height of the bitmap in pixels
+   * @param x0 Starting X coordinate
+   * @param y0 Starting Y coordinate
+   * @param x1 Ending X coordinate
+   * @param y1 Ending Y coordinate
+   * @param value Pixel value (true = set, false = clear)
+   */
+  virtual void drawLine(uint8_t *buffer, uint16_t width, uint16_t height, uint16_t x0,
+                uint16_t y0, uint16_t x1, uint16_t y1, bool value) = 0;
+
+  /**
+   * Draw a rectangle in a bitmap buffer
+   * @param buffer Pointer to the bitmap buffer
+   * @param width Width of the bitmap in pixels (must be multiple of 8)
+   * @param height Height of the bitmap in pixels
+   * @param x X coordinate of the top-left corner
+   * @param y Y coordinate of the top-left corner
+   * @param rect_width Width of the rectangle
+   * @param rect_height Height of the rectangle
+   * @param filled Whether to fill the rectangle
+   * @param value Pixel value (true = set, false = clear)
+   */
+  virtual void drawRect(uint8_t *buffer, uint16_t width, uint16_t height, uint16_t x,
+                uint16_t y, uint16_t rect_width, uint16_t rect_height,
+                bool filled, bool value) = 0;
+};
+
+#endif // _BITMAPGRAPHICS_H

--- a/sources/System/Display/BitmapGraphics.h
+++ b/sources/System/Display/BitmapGraphics.h
@@ -28,9 +28,9 @@ public:
    * @param fg_color Foreground color (for 1 bits)
    * @param bg_color Background color (for 0 bits)
    */
-  virtual void drawBitmap(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
-                  const uint8_t *bitmap_data, uint16_t fg_color,
-                  uint16_t bg_color) = 0;
+  virtual void drawBitmap(uint16_t x, uint16_t y, uint16_t width,
+                          uint16_t height, const uint8_t *bitmap_data,
+                          uint16_t fg_color, uint16_t bg_color) = 0;
 
   /**
    * Clear a bitmap buffer (set all pixels to 0)
@@ -38,7 +38,8 @@ public:
    * @param width Width in pixels (must be multiple of 8)
    * @param height Height in pixels
    */
-  virtual void clearBuffer(uint8_t *buffer, uint16_t width, uint16_t height) = 0;
+  virtual void clearBuffer(uint8_t *buffer, uint16_t width,
+                           uint16_t height) = 0;
 
   /**
    * Set a pixel in a bitmap buffer
@@ -49,7 +50,7 @@ public:
    * @param value Pixel value (true = set, false = clear)
    */
   virtual void setPixel(uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y,
-                bool value) = 0;
+                        bool value) = 0;
 
   /**
    * Get a pixel from a bitmap buffer
@@ -59,7 +60,8 @@ public:
    * @param y Y coordinate of the pixel
    * @return Pixel value (true = set, false = clear)
    */
-  virtual bool getPixel(const uint8_t *buffer, uint16_t width, uint16_t x, uint16_t y) = 0;
+  virtual bool getPixel(const uint8_t *buffer, uint16_t width, uint16_t x,
+                        uint16_t y) = 0;
 
   /**
    * Draw a line in a bitmap buffer using Bresenham's algorithm
@@ -72,8 +74,9 @@ public:
    * @param y1 Ending Y coordinate
    * @param value Pixel value (true = set, false = clear)
    */
-  virtual void drawLine(uint8_t *buffer, uint16_t width, uint16_t height, uint16_t x0,
-                uint16_t y0, uint16_t x1, uint16_t y1, bool value) = 0;
+  virtual void drawLine(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
+                        bool value) = 0;
 
   /**
    * Draw a rectangle in a bitmap buffer
@@ -87,9 +90,9 @@ public:
    * @param filled Whether to fill the rectangle
    * @param value Pixel value (true = set, false = clear)
    */
-  virtual void drawRect(uint8_t *buffer, uint16_t width, uint16_t height, uint16_t x,
-                uint16_t y, uint16_t rect_width, uint16_t rect_height,
-                bool filled, bool value) = 0;
+  virtual void drawRect(uint8_t *buffer, uint16_t width, uint16_t height,
+                        uint16_t x, uint16_t y, uint16_t rect_width,
+                        uint16_t rect_height, bool filled, bool value) = 0;
 };
 
 #endif // _BITMAPGRAPHICS_H

--- a/sources/System/Profiler/Profiler.cpp
+++ b/sources/System/Profiler/Profiler.cpp
@@ -62,7 +62,7 @@ Profiler::Profiler(const etl::string<32> &name, bool use_moving_avg)
     : name_(name.c_str()), start_time_(0), use_moving_avg_(use_moving_avg),
       total_time_(0), call_count_(0), last_log_time_(0) {
 #if ENABLE_PROFILING
-  start_time_ = micros();
+  start_time_ = System::GetInstance()->Micros();
   if (use_moving_avg_) {
     // Automatically create the profiler if it doesn't exist
     auto it = moving_avg_profilers_.find(name);
@@ -80,7 +80,8 @@ Profiler Profiler::MovingAverage(const char *name) {
 
 Profiler::~Profiler() {
 #if ENABLE_PROFILING
-  uint32_t end_time = micros();
+
+  uint32_t end_time = System::GetInstance()->Micros();
   uint32_t duration = time_diff(end_time, start_time_);
 
   if (use_moving_avg_) {

--- a/sources/System/Profiler/Profiler.h
+++ b/sources/System/Profiler/Profiler.h
@@ -14,7 +14,7 @@ uint32_t time_diff(uint32_t newer, uint32_t older);
 // Enable/disable profiling with a preprocessor flag
 // defaults to disabled
 #ifndef ENABLE_PROFILING
-#define ENABLE_PROFILING 0
+#define ENABLE_PROFILING 1
 #endif
 
 // Moving average window size (1 second at 60fps)

--- a/sources/System/System/System.h
+++ b/sources/System/System/System.h
@@ -40,6 +40,7 @@ public:                                 // Override in implementation
   virtual void SystemReboot() = 0;
   virtual int32_t GetRandomNumber() = 0;
   virtual uint32_t Micros() = 0;
+  virtual uint32_t Millis() = 0;
 };
 
 #define SYS_MEMSET(a, b, c)                                                    \


### PR DESCRIPTION
This adds a new Field class for displaying monochrome bitmaps. Memory restrictions mean we need to limit these bitmaps in side to just a portion of the screen.

The new bitmap field type is then used in a new Sample Editor screen to display a waveform for the current sample instrument. For now the Sample editor screen is not yet functional except for:
* some initial field place holders 
* dotted line markers to show the `start` and `loop end` positions on the waveform
* the ability to playback the sample (`PLAY`) with a "playhead" marker being displayed on the waveform during playback

Note: the bitmap on the advance is not yet properly scaled to take up whole screen width. Also there are some performance issues drawing the play head on the advance which will need to be addressed later on.

Note: the bitmap field is not yet supported for the remote UI protocol.

Fixes: #477 