### PR TITLE
Prevent using samples before sample start point

### DIFF
--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -654,15 +654,21 @@ bool SampleInstrument::Render(int channel, fixed *buffer, int size,
         // get input sample to interpolate from
         // s= left channel
         // t= right channel
-
         short *i1 = input;
         if (dsMask != 0xFFFFFFFF) {
           if (useDirtyDownsampling_) {
             i1 = (short *)(((uintptr_t)input) & dsMask);
           } else {
-            unsigned int distance =
-                (unsigned int)(input - dsBasePtr) / channelCount;
-            i1 = dsBasePtr + (distance & dsMask) * channelCount;
+            // prevent input ever being lower mem address then dsBasePtr (sample
+            // start point) this can occur eg. if doing reverse playback and
+            // using RTG cmds
+            if (input < dsBasePtr) {
+              i1 = dsBasePtr;
+            } else {
+              unsigned int distance =
+                  (unsigned int)(input - dsBasePtr) / channelCount;
+              i1 = dsBasePtr + (distance & dsMask) * channelCount;
+            }
           }
         }
 


### PR DESCRIPTION
I must admit I don't really understand how this wasn't an issue prior to 409096179be347c0ba5360cc7bf2026a2452a148 which is the first commit where this starts to cause a hardfault when playing the "oneCycAc"  project. Initially I thought the cause of this from that commit was:
```
writeOffset1_ = (writeOffset1_ + 3) & ~3;
```

yet removing that doesn't prevent the hardfault but adding the check to prevent `input` being lower than `daBasePtr` does 🤷‍♂️

Fixes:  #744