### PR TITLE
Dont try to take mixer lock when stop is called

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -202,9 +202,12 @@ void Player::Start(PlayMode mode, bool forceSongMode, MixerServiceMode msmMode,
   mixer_.Unlock();
 }
 
-void Player::Stop() {
+// set nolock to true when calling from code that ALREADY hold the mixer lock
+void Player::Stop(bool nolock) {
 
-  mixer_.Lock();
+  if (!nolock) {
+    mixer_.Lock();
+  }
 
   for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
     mixer_.StopChannel(i);
@@ -218,7 +221,9 @@ void Player::Stop() {
   PlayerEvent pe(PET_STOP);
   NotifyObservers(&pe);
 
-  mixer_.Unlock();
+  if (!nolock) {
+    mixer_.Unlock();
+  }
 }
 
 const char *Player::GetPlayedNote(int channel) {
@@ -589,7 +594,6 @@ void Player::Update(Observable &o, I_ObservableData *d) {
     now_ = system->GetClock();
 
     // Notify refresh
-
     PlayerEvent pe(PET_UPDATE, 0);
     SetChanged();
     NotifyObservers(&pe);
@@ -699,7 +703,7 @@ bool Player::ProcessChannelCommand(int channel, FourCC cmd, ushort param) {
   case FourCC::InstrumentCommandStop: {
     switch (GetSequencerMode()) {
     case SM_SONG:
-      Stop();
+      Stop(true);
       break;
     case SM_LIVE:
       //            QueueChannel(channel,QM_CHAINSTOP,0) ;

--- a/sources/Application/Player/Player.h
+++ b/sources/Application/Player/Player.h
@@ -61,7 +61,7 @@ public:
 
   void Start(PlayMode mode, bool forceSongMode, MixerServiceMode msmMode,
              bool stopAtEnd = false);
-  void Stop();
+  void Stop(bool nolock = false);
 
   void SetSequencerMode(SequencerMode mode);
   SequencerMode GetSequencerMode();


### PR DESCRIPTION
Allows code that already holds mixer lock to call stop without it trying
to take the lock.

Fixes: #778