### PR TITLE
Add missed fn call to properly close render files

### DIFF
--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -1119,6 +1119,7 @@ void Player::moveToNextChain(int channel, int hop) {
         for (int i = 0; i < SONG_CHANNEL_COUNT; i++) {
           mixer_.StopChannel(i);
         }
+        mixer_.OnPlayerStop();
 
         isRunning_ = false;
         SetChanged();


### PR DESCRIPTION
OnPlayerStop() needs to be called to have rendered wav files be closed.

This was working "by accident" with larger renders as they would get the file buffer mostly flushed out even without the file being properly closed.