### PR TITLE
remove 'sample edit' field making fields going out of bounds

### DIFF
--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -275,12 +275,6 @@ void InstrumentView::fillSampleParameters() {
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));
 
   position._y += 1;
-  actionField_.emplace_back("Sample Editor", FourCC::ActionShowSampleEditor,
-                            position);
-  fieldList_.insert(fieldList_.end(), &(*actionField_.rbegin()));
-  (*actionField_.rbegin()).AddObserver(*this);
-
-  position._y += 1;
   v = instrument->FindVariable(FourCC::SampleInstrumentPan);
   intVarField_.emplace_back(position, *v, "pan: %2.2X", 0, 0xFE, 1, 0x10);
   fieldList_.insert(fieldList_.end(), &(*intVarField_.rbegin()));


### PR DESCRIPTION
Problem with colors on screen changing was due to the last field of the sample instrument being written out of screen bounds and there is nothing safeguarding this (we should do something about it, generally)

Removed the sample edit field since we are going to relocate it anyway