### PR TITLE
Dont start playback when nav'ing to rec screen

### DIFF
--- a/sources/Application/Views/SongView.cpp
+++ b/sources/Application/Views/SongView.cpp
@@ -660,6 +660,7 @@ void SongView::processNormalButtonMask(unsigned int mask) {
           ViewEvent ve(VET_SWITCH_VIEW, &vt);
           SetChanged();
           NotifyObservers(&ve);
+          return;
         }
 
       } else {


### PR DESCRIPTION
Note: the key combo is still considered a temp placeholder for nav'ing to the record screen.