### PR TITLE
Advance filesystem optimisation

### DIFF
--- a/sources/Adapters/adv/Core/Inc/main.h
+++ b/sources/Adapters/adv/Core/Inc/main.h
@@ -36,6 +36,8 @@ typedef struct {
   uint32_t crc32;   // CRC of the firmware (excluding this struct)
   uint32_t type;    // type of firmware
 } firmware_info_t;
+
+static uint8_t is_booting_ = 1;
 /* USER CODE END ET */
 
 /* Exported constants --------------------------------------------------------*/

--- a/sources/Adapters/adv/Core/Src/main.c
+++ b/sources/Adapters/adv/Core/Src/main.c
@@ -162,6 +162,8 @@ int main(void) {
 
   Application::GetInstance()->Init(params);
 
+  is_booting_ = 0;
+
   advSystem::MainLoop();
   // WE NEVER GET HERE
 

--- a/sources/Adapters/adv/audio/tlv320aic3204.h
+++ b/sources/Adapters/adv/audio/tlv320aic3204.h
@@ -14,8 +14,6 @@
 // #define CODEC_RESET_PIN GPIO_PIN_13
 #define I2C_MEMADD_SIZE_8BIT (0x00000001U)
 
-#define BIT(n) 1 << n
-
 #define REFERENCE_PWR_UP_SLOW BIT(2)
 #define COMMON_MODE_09V BIT(6)
 
@@ -25,6 +23,9 @@ extern "C" {
 
 void tlv320_init();
 
+void tlv320_select_output(void);
+void tlv320_unmute(void);
+void tlv320_mute(void);
 void tlv320_enable_linein(void);
 void tlv320_enable_mic(void);
 void tlv320_disable_linein(void);

--- a/sources/Adapters/adv/filesystem/advFileSystem.cpp
+++ b/sources/Adapters/adv/filesystem/advFileSystem.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "advFileSystem.h"
+#include "FreeRTOS.h"
+#include "main.h"
+#include "task.h"
 
 FATFS SDFatFS;
 char SDPath[4];
@@ -15,7 +18,6 @@ char SDPath[4];
 #define PARENT_DIR_MARKER_INDEX (std::numeric_limits<int>::max())
 
 advFileSystem::advFileSystem() {
-
   // Link FatFs driver
   FATFS_LinkDriver(&SD_DMA_Driver, SDPath);
 
@@ -23,7 +25,6 @@ advFileSystem::advFileSystem() {
   Trace::Log("FILESYSTEM", "Try to mount SD Card");
   if (f_mount(&SDFatFS, (TCHAR const *)SDPath, 0) == FR_OK) {
     Trace::Log("FILESYSTEM", "Mounted SD Card FAT Filesystem first partition");
-    updateCache();
     return;
   }
   // Do we have any kind of card?
@@ -170,6 +171,7 @@ void advFileSystem::updateCache() {
   DIR dir;
   res = f_opendir(&dir, path);
   if (res == FR_OK) {
+    int file_count = 0;
     for (;;) {
       FILINFO fno;
       res = f_readdir(&dir, &fno);
@@ -180,6 +182,10 @@ void advFileSystem::updateCache() {
       } else {
         Trace::Error("file cache is full");
         break;
+      }
+      // make sure not to block audio task for too long
+      if ((file_count++ % 4) == 0 && is_booting_ != 1) {
+        vTaskDelay(1);
       }
     }
     f_closedir(&dir);

--- a/sources/Adapters/adv/filesystem/advFileSystem.h
+++ b/sources/Adapters/adv/filesystem/advFileSystem.h
@@ -62,13 +62,15 @@ public:
   virtual bool CopyFile(const char *src, const char *dest) override;   // OK
 
 private:
-  //  SdFs sd;
-  void tolowercase(char *temp);
   FILINFO fileFromIndex(int index);
-  // buffer needs to be allocated here as too big for allocation as local
-  // variable on the stack
-  uint8_t fileBuffer_[512];
-  TCHAR filepath[256];
+  void tolowercase(char *temp);
+  void updateCache();
+  char filepath[PFILENAME_SIZE];
+  BYTE fileBuffer_[4096];
+
+  // TODO: this is quit big, need move it out to external RAM
+  // cache for fileFromIndex
+  etl::vector<FILINFO, 256> file_cache_;
 };
 
 #endif

--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -19,6 +19,7 @@
 #include "platform.h"
 #include "tim.h"
 #include "timers.h"
+#include "tlv320aic3204.h"
 #include "tusb.h"
 #include <UIFramework/SimpleBaseClasses/EventManager.h>
 

--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -24,6 +24,7 @@
 #include "input.h"
 #include "platform.h"
 #include "tim.h"
+#include "tlv320aic3204.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <malloc.h>
@@ -170,6 +171,8 @@ unsigned int advSystem::GetMemoryUsage() {
 }
 
 void advSystem::PowerDown() {
+  tlv320_mute();
+
   // Ship mode
   uint8_t value = 0x64;
   HAL_StatusTypeDef status = HAL_I2C_Mem_Write(

--- a/sources/Adapters/adv/system/input.h
+++ b/sources/Adapters/adv/system/input.h
@@ -8,9 +8,8 @@
 #ifndef _PICOTRACKERINPUT_H_
 #define _PICOTRACKERINPUT_H_
 
+#include "utils.h"
 #include <cstdint>
-
-#define BIT(n) (1 << (n))
 
 typedef enum KEYPAD_BITS {
   KEY_LEFT = BIT(0),   //!< Keypad LEFT button.

--- a/sources/Adapters/adv/utils/utils.h
+++ b/sources/Adapters/adv/utils/utils.h
@@ -18,6 +18,7 @@
 typedef enum { PICO_ERROR = -1, FALSE, TRUE } LOGICAL;
 
 #define BOOL(x) (!(!(x)))
+#define BIT(n) 1 << n
 
 #define BitSet(arg, posn) ((arg) | (1L << (posn)))
 #define BitClr(arg, posn) ((arg) & ~(1L << (posn)))

--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -816,24 +816,52 @@ void AppWindow::onQuitApp() {
   System::GetInstance()->PostQuitMessage();
 }
 
-void AppWindow::Print(char *line) {
+void AppWindow::Print(char *line) { PrintMultiLine(line); }
 
-  //	GUIWindow::Clear(View::backgroundColor_,true) ;
+void AppWindow::PrintMultiLine(char *line) {
   Clear();
-  strcpy(_statusLine, line);
-  // unwrapped for gcc
-  int position = 32;
-  position -= strlen(_statusLine);
-  position /= 2;
-  GUIPoint pos(position, 12);
-  //
   GUITextProperties props;
   SetColor(CD_NORMAL);
-  DrawString(_statusLine, pos, props);
+
+  int current_y = 11; // Start near the middle of the screen
+
+  // Handle single line case for Print function
+  bool isSingleLine = (line != nullptr && strchr(line, '\n') == nullptr);
+
+  // Use strtok to split the string by newline characters
+  char *token = strtok(line, "\n");
+  int lineCount = 0;
+
+  while (token != NULL) {
+    // Stop if we are about to overwrite the build string line
+    if (current_y >= 22) {
+      break;
+    }
+
+    // For single line, center it at position 12 instead of starting at 11
+    if (isSingleLine && lineCount == 0) {
+      current_y = 12;
+    }
+
+    // Horizontally center the current line of text
+    int position = 32; // Assumes a screen width of 32 characters
+    position -= strlen(token);
+    position /= 2;
+
+    GUIPoint pos(position, current_y);
+    DrawString(token, pos, props);
+
+    // Get the next line
+    token = strtok(NULL, "\n");
+    current_y++;
+    lineCount++;
+  }
+
+  // Preserve the build string at the bottom of the screen
   char buildString[SCREEN_WIDTH + 1];
   npf_snprintf(buildString, sizeof(buildString), "picoTracker build %s%s_%s",
                PROJECT_NUMBER, PROJECT_RELEASE, BUILD_COUNT);
-  pos._y = 22;
+  GUIPoint pos(0, 22);
   pos._x = (32 - strlen(buildString)) / 2;
   DrawString(buildString, pos, props);
   Flush();

--- a/sources/Application/AppWindow.h
+++ b/sources/Application/AppWindow.h
@@ -97,6 +97,7 @@ protected: // GUIWindow implementation
   // Status implementation
 
   virtual void Print(char *);
+  virtual void PrintMultiLine(char *);
 
   void defineColor(FourCC colorCode, GUIColor &color, int paletteIndex);
 

--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -60,7 +60,7 @@ void SamplePool::Load(const char *projectName) {
 
       // Show progress as percentage
       int progress = (int)((i * 100) / totalSamples);
-      Status::Set("Copying:%s (%d%%)", name, progress);
+      Status::SetMultiLine("Copying:\n%s (%d%%)", name, progress);
       loadSample(name);
     }
     if (i == MAX_SAMPLES) {
@@ -96,7 +96,7 @@ int SamplePool::GetNameListSize() { return count_; };
 
 #define IMPORT_CHUNK_SIZE 1000
 
-int SamplePool::ImportSample(char *name, const char *projectName) {
+int SamplePool::ImportSample(const char *name, const char *projectName) {
 
   if (count_ == MAX_SAMPLES) {
     return -1;
@@ -114,11 +114,21 @@ int SamplePool::ImportSample(char *name, const char *projectName) {
   long size = fin->Tell();
   fin->Seek(0, SEEK_SET);
 
+  // will truncate too long filenames to make sure the filename imported into
+  // the project is with filename length limit
+  etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> projSampleFilename(name);
+  if (projSampleFilename.is_truncated()) {
+    // Truncate the string in-place and then append the extension
+    projSampleFilename =
+        projSampleFilename.substr(0, MAX_INSTRUMENT_FILENAME_LENGTH - 4);
+    projSampleFilename.append(".wav");
+  }
+
   etl::string<MAX_PROJECT_SAMPLE_PATH_LENGTH> projectSamplePath("/projects/");
   projectSamplePath.append(projectName);
   projectSamplePath.append("/samples/");
-  projectSamplePath.append(name);
-  Status::Set("Loading %s->", name);
+  projectSamplePath.append(projSampleFilename);
+  Status::SetMultiLine("Loading %s->\n%s", name, projSampleFilename);
 
   I_File *fout =
       FileSystem::GetInstance()->Open(projectSamplePath.c_str(), "w");
@@ -141,10 +151,13 @@ int SamplePool::ImportSample(char *name, const char *projectName) {
 
     // Update progress indicator
     int progress = (int)(((totalSize - size) * 100) / totalSize);
-    Status::Set("Loading %s: %d%%", name, progress);
+    Status::SetMultiLine("Loading:\n%s\n%d%%", projSampleFilename.c_str(),
+                         progress);
   };
 
   // now load the sample into memory/flash
+  // make sure to use orig name because we are loading the og file, not the
+  // potentially truncated filename now in the projectes sampels subdir
   bool status = loadSample(name);
 
   fin->Close();

--- a/sources/Application/Instruments/SamplePool.h
+++ b/sources/Application/Instruments/SamplePool.h
@@ -34,7 +34,7 @@ public:
   SoundSource *GetSource(int i);
   char **GetNameList();
   int GetNameListSize();
-  int ImportSample(char *name, const char *projectName);
+  int ImportSample(const char *name, const char *projectName);
   void PurgeSample(int i, const char *projectName);
   virtual bool CheckSampleFits(int sampleSize) = 0;
   virtual uint32_t GetAvailableSampleStorageSpace() = 0;

--- a/sources/Application/Model/Table.h
+++ b/sources/Application/Model/Table.h
@@ -16,6 +16,7 @@
 
 #define TABLE_COUNT 0x20
 #define TABLE_STEPS 16
+#define TABLE_COUMNS 3
 
 #define NO_MORE_TABLE TABLE_COUNT + 10
 

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -898,8 +898,24 @@ void Player::playCursorPosition(int channel) {
         if (instrument->GetTableAutomation()) {
           TablePlayerChange tpc;
           tpc.timeToLive_ = timeToLive_[channel];
+          tpc.instrRetrigger_ = -1;
           tpb.ProcessStep(tpc);
           timeToLive_[channel] = tpc.timeToLive_;
+          if (tpc.instrRetrigger_ >= 0) {
+            int note = mixer_.GetChannelNote(channel);
+            I_Instrument *instr = mixer_.GetInstrument(channel);
+            if ((note != 0xFF) && (instr != 0)) {
+              // TODO: should we instead allow for transposing notes *down* with
+              // values over 64?
+              note += (tpc.instrRetrigger_ > 80) ? 80 : tpc.instrRetrigger_;
+              while (note > 127) {
+                note -= 12;
+              };
+              mixer_.StopInstrument(channel);
+              // NOTE: 'newIntrument' bool flag is really the "retrigger" flag
+              mixer_.StartInstrument(channel, instr, note, false);
+            };
+          };
         }
       }
     }

--- a/sources/Application/Player/TablePlayback.cpp
+++ b/sources/Application/Player/TablePlayback.cpp
@@ -174,8 +174,9 @@ void TablePlayback::ProcessStep(TablePlayerChange &tpc) {
         if (automated_) {
           TableSaveState state;
           instrument_->GetTableState(state);
-          memcpy(hopCount_, state.hopCount_, sizeof(uchar) * TABLE_STEPS * 2);
-          memcpy(position_, state.position_, sizeof(int) * 2);
+          memcpy(hopCount_, state.hopCount_,
+                 sizeof(uchar) * TABLE_STEPS * TABLE_COUMNS);
+          memcpy(position_, state.position_, sizeof(int) * TABLE_COUMNS);
         }
 
         // try local processing for if it changes current table or position
@@ -222,8 +223,9 @@ void TablePlayback::ProcessStep(TablePlayerChange &tpc) {
 
         if (automated_) {
           TableSaveState state;
-          memcpy(state.hopCount_, hopCount_, sizeof(uchar) * TABLE_STEPS * 3);
-          memcpy(state.position_, position_, sizeof(int) * 3);
+          memcpy(state.hopCount_, hopCount_,
+                 sizeof(uchar) * TABLE_STEPS * TABLE_COUMNS);
+          memcpy(state.position_, position_, sizeof(int) * TABLE_COUMNS);
           instrument_->SetTableState(state);
         }
       }

--- a/sources/Application/Player/TablePlayback.h
+++ b/sources/Application/Player/TablePlayback.h
@@ -39,13 +39,13 @@ public:
 
 private:
   Table *table_;
-  int position_[3];
-  int previous_[3];
-  bool hopped_[3];
+  int position_[TABLE_COUMNS];
+  int previous_[TABLE_COUMNS];
+  bool hopped_[TABLE_COUMNS];
   I_Instrument *instrument_;
   int channel_;
   bool automated_;
-  uchar hopCount_[TABLE_STEPS][3];
+  uchar hopCount_[TABLE_STEPS][TABLE_COUMNS];
   ChannelGroove groove_;
 
   static TablePlayback playback_[SONG_CHANNEL_COUNT];
@@ -54,8 +54,8 @@ private:
 class TableSaveState {
 public:
   void Reset();
-  uchar hopCount_[TABLE_STEPS][3];
-  int position_[3];
+  uchar hopCount_[TABLE_STEPS][TABLE_COUMNS];
+  int position_[TABLE_COUMNS];
 };
 
 #endif

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -404,21 +404,6 @@ void ImportView::import() {
   unsigned fileIndex = fileIndexList_[currentIndex_];
   fs->getFileName(fileIndex, name, PFILENAME_SIZE);
 
-  // Check if the filename is too long
-  size_t nameLength = strlen(name);
-
-  if (nameLength > MAX_INSTRUMENT_FILENAME_LENGTH) {
-    Trace::Log("PICOIMPORT", "Filename too long: %s (%zu chars, max is %d)",
-               name, nameLength, MAX_INSTRUMENT_FILENAME_LENGTH);
-    char sizeMesg[20];
-    npf_snprintf(sizeMesg, sizeof(sizeMesg), "Max is %02d chars",
-                 MAX_INSTRUMENT_FILENAME_LENGTH);
-    MessageBox *mb =
-        new MessageBox(*this, "Filename too long", sizeMesg, MBBF_OK);
-    DoModal(mb);
-    return;
-  }
-
   // Get current project name
   char projName[MAX_PROJECT_NAME_LENGTH];
   viewData_->project_->GetProjectName(projName);
@@ -477,6 +462,16 @@ void ImportView::import() {
       SampleInstrument *sinstr = (SampleInstrument *)instr;
       sinstr->AssignSample(sampleID);
     };
+
+    // check if we had to truncate filename
+    size_t nameLength = strlen(name);
+    if (nameLength > MAX_INSTRUMENT_FILENAME_LENGTH) {
+      Trace::Log("PICOIMPORT", "Filename too long: %s (%zu chars, max is %d)",
+                 name, nameLength, MAX_INSTRUMENT_FILENAME_LENGTH);
+      MessageBox *mb = new MessageBox(*this, "Sample name Truncated!",
+                                      "Max filename length:24", MBBF_OK);
+      DoModal(mb);
+    }
   } else {
     Trace::Error("failed to import sample");
     // Show a generic error message if import failed for other reasons

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -688,6 +688,8 @@ void InstrumentView::ProcessButtonMask(unsigned short mask, bool pressed) {
             DoModal(mb);
           } else {
             ImportView::SetSourceViewType(VT_INSTRUMENT);
+            // set the browser to defautlt into sample import mode
+            viewData_->sampleEditorProjectList = false;
 
             // Go to import sample
             ViewType vt = VT_IMPORT;

--- a/sources/System/io/Status.cpp
+++ b/sources/System/io/Status.cpp
@@ -27,3 +27,18 @@ void Status::Set(const char *fmt, ...) {
 
   va_end(args);
 }
+
+void Status::SetMultiLine(const char *fmt, ...) {
+  Status *status = Status::GetInstance();
+  if (!status)
+    return;
+
+  char buffer[128];
+  va_list args;
+  va_start(args, fmt);
+
+  npf_vsnprintf(buffer, sizeof(buffer), fmt, args);
+  status->PrintMultiLine(buffer);
+
+  va_end(args);
+}

--- a/sources/System/io/Status.h
+++ b/sources/System/io/Status.h
@@ -15,7 +15,9 @@
 class Status : public T_Factory<Status> {
 public:
   virtual void Print(char *) = 0;
+  virtual void PrintMultiLine(char *) = 0;
   static void Set(const char *fmt, ...);
+  static void SetMultiLine(const char *fmt, ...);
 };
 
 #endif


### PR DESCRIPTION
Use a cache for file indexes in the current working dir on the Advance to greatly improve performance for the file browser screen. Also ensure for large directories that we don't block the audio task for too long.

Fixes: #815 