### PR TITLE
Apply brightness onboot in xplatform way

### DIFF
--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.cpp
@@ -107,9 +107,6 @@ void picoTrackerSystem::Boot(int argc, char **argv) {
 
   Trace::Log("PICOTRACKERSYSTEM", "ADC INIT DONE");
 #endif
-
-  // Initialize display brightness from config
-  UpdateBrightnessFromConfig();
 };
 
 void picoTrackerSystem::Shutdown() { delete Audio::GetInstance(); };
@@ -152,20 +149,6 @@ void picoTrackerSystem::GetBatteryState(BatteryState &state) {
 
 void picoTrackerSystem::SetDisplayBrightness(unsigned char value) {
   platform_brightness(value);
-}
-
-void picoTrackerSystem::UpdateBrightnessFromConfig() {
-  // Get the brightness value from config and apply it
-  Config *config = Config::GetInstance();
-  if (config) {
-    Variable *v = config->FindVariable(FourCC::VarBacklightLevel);
-    if (v) {
-      unsigned char brightness = (unsigned char)v->GetInt();
-      platform_brightness(brightness);
-      Trace::Log("PICOTRACKERSYSTEM", "Set display brightness to %d",
-                 brightness);
-    }
-  }
 }
 
 void picoTrackerSystem::Sleep(int millisec) {

--- a/sources/Adapters/picoTracker/system/picoTrackerSystem.h
+++ b/sources/Adapters/picoTracker/system/picoTrackerSystem.h
@@ -46,9 +46,6 @@ private:
   static bool invert_;
   static unsigned int lastBeatCount_;
 
-  // Update brightness from config
-  static void UpdateBrightnessFromConfig();
-
   static EventManager *eventManager_;
   std::map<void *, unsigned> mmap_;
 };

--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -37,6 +37,19 @@ bool Application::Init(GUICreateWindowParams &params) {
   Audio *audio = Audio::GetInstance();
   audio->Init();
 
+  // Initialize display brightness from config
+  // Get the brightness value from config and apply it
+  Config *config = Config::GetInstance();
+  if (config) {
+    Variable *v = config->FindVariable(FourCC::VarBacklightLevel);
+    if (v) {
+      unsigned char brightness = (unsigned char)v->GetInt();
+      System::GetInstance()->SetDisplayBrightness(brightness);
+      Trace::Log("PICOTRACKERSYSTEM", "Set display brightness to %d",
+                 brightness);
+    }
+  }
+
   return true;
 };
 


### PR DESCRIPTION
Fixes advance not applying brightness from config on boot.

Fixes: #835