### PR TITLE
use of expected semantics for wavfile return values

### DIFF
--- a/sources/Adapters/adv/system/advSamplePool.cpp
+++ b/sources/Adapters/adv/system/advSamplePool.cpp
@@ -48,20 +48,21 @@ bool advSamplePool::loadSample(const char *name) {
   if (count_ == MAX_SAMPLES)
     return false;
 
-  WavFile *wave = WavFile::Open(name);
-  if (wave) {
-    wav_[count_] = wave;
-    names_[count_] = (char *)SYS_MALLOC(strlen(name) + 1);
-    strcpy(names_[count_], name);
-    count_++;
-    Load(wave);
-    wave->Close();
-
-    return true;
-  } else {
+  //  WavFile *wave = WavFile::Open(name);
+  auto wave = WavFile::Open(name);
+  if (!wave) {
     Trace::Error("Failed to load sample:%s", name);
     return false;
   }
+
+  wav_[count_] = wave.value();
+  names_[count_] = (char *)SYS_MALLOC(strlen(name) + 1);
+  strcpy(names_[count_], name);
+  count_++;
+  Load(wave.value());
+  wave.value()->Close();
+
+  return true;
 };
 
 bool advSamplePool::Load(WavFile *wave) {

--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -45,12 +45,13 @@ bool AudioFileStreamer::Start(const char *name, int startSample, bool looping) {
     SAFE_DELETE(wav_);
   }
   Trace::Log("", "wave open:%s", name_);
-  wav_ = WavFile::Open(name_);
-  if (!wav_) {
+  auto res = WavFile::Open(name_);
+  if (!res) {
     Trace::Error("Failed to open streaming of file:%s", name_);
     mode_ = AFSM_STOPPED;
     return false;
   }
+  wav_ = res.value();
 
   // Get sample rate information and calculate speed factor
   fileSampleRate_ = wav_->GetSampleRate(-1);

--- a/sources/Application/Instruments/WavFile.h
+++ b/sources/Application/Instruments/WavFile.h
@@ -10,11 +10,23 @@
 #ifndef _WAV_FILE_H_
 #define _WAV_FILE_H_
 
+#include <expected>
+
 #include "SoundSource.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/System/System.h"
 
 #define BUFFER_SIZE 512
+
+enum WAVEFILE_ERROR {
+  INVALID_FILE,
+  UNSUPPORTED_FILE_FORMAT,
+  INVALID_HEADER,
+  UNSUPPORTED_WAV_FORMAT,
+  UNSUPPORTED_COMPRESSION,
+  UNSUPPORTED_BITDEPTH,
+  UNSUPPORTED_SAMPLERATE,
+};
 
 class WavFile : public SoundSource {
 
@@ -23,7 +35,7 @@ protected: // Factory - see Load method
 
 public:
   virtual ~WavFile();
-  static WavFile *Open(const char *);
+  static std::expected<WavFile *, WAVEFILE_ERROR> Open(const char *);
   virtual void *GetSampleBuffer(int note);
   void SetSampleBuffer(short *ptr);
   virtual int GetSize(int note);

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Export compile_commands.json")
 


### PR DESCRIPTION
For use in #841 

If we want to switch on errors as we do in that PR, we just need to use the returned expected variable as:
```
auto res = WavFile::Open(name);
if (!res) {
    switch(res.error())
...
```