### PR TITLE
fixes bit masking type for the character rendering

### DIFF
--- a/sources/Adapters/picoTracker/display/chargfx.c
+++ b/sources/Adapters/picoTracker/display/chargfx.c
@@ -197,7 +197,7 @@ inline void chargfx_draw_sub_region(uint8_t x, uint8_t y, uint8_t width,
     uint16_t *buffer_idx = buffer;
 
     for (int bit = CHAR_WIDTH - 1; bit >= 0; bit--) {
-      uint8_t mask = 1 << (CHAR_WIDTH - 1 - bit);
+      uint16_t mask = 1 << (CHAR_WIDTH - 1 - bit);
       for (int col = y + height - 1; col >= y; col--) {
         int16_t idx = col * TEXT_WIDTH + page;
         uint8_t character = screen[idx];


### PR DESCRIPTION
Fixes xiphonics/picoTracker#869

For the 10 pixel wide font `uint8_t mask = 1 << (CHAR_WIDTH - 1 - bit);`. would fail after the first 8 pixels leaving the rest empty. Using a uint16_t as the mask allows all pixel to be written.

Tested on picoTracker v2.1 hardware.