### PR TITLE
Improve responsiveness of SID ADSR

### DIFF
--- a/sources/Application/Instruments/SIDInstrument.cpp
+++ b/sources/Application/Instruments/SIDInstrument.cpp
@@ -101,7 +101,7 @@ bool SIDInstrument::Init() {
 void SIDInstrument::OnStart() {
   tableState_.Reset();
   int osc = GetOsc();
-  sid_->cRSID_resetADSR(osc);
+  sid_->cRSID_resetChannel(osc);
 };
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"

--- a/sources/Externals/cRSID/SID.cpp
+++ b/sources/Externals/cRSID/SID.cpp
@@ -176,7 +176,7 @@ cRSID::cRSID_emulateADSRs(char cycles) {
   }
 }
 
-void cRSID::cRSID_resetADSR(unsigned char channel) {
+void cRSID::cRSID_resetChannel(unsigned char channel) {
   ADSRstate[channel] = 0;
   RateCounter[channel] = 0;
   EnvelopeCounter[channel] = 0;

--- a/sources/Externals/cRSID/SID.h
+++ b/sources/Externals/cRSID/SID.h
@@ -16,7 +16,7 @@ public:
   // SID model fixed at 8580
   cRSID(unsigned short samplerate);
   void cRSID_emulateADSRs(char cycles);
-  void cRSID_resetADSR(unsigned char channel);
+  void cRSID_resetChannel(unsigned char channel);
   int cRSID_emulateWaves();
   cRSID_SIDwavOutput cRSID_emulateHQwaves(char cycles);
 


### PR DESCRIPTION
fixes #427
fixes #445:

- add reset for ADSR values onStart
- set gate bit to 0 on stop
- prevent sustain value from dropping to zero during playback if editing ADSR

This creates a more reliable experience when stopping and starting playback. SID no longer gets stuck in sustain state and the envelope will be properly modeled starting from the rising edge on playback start.

Tested with all three oscillators in use in three separate channels. Starting and stopping from the song screen then moving to a phrase causes the other oscillators to go silent. Previously the other oscillators would be stuck playing.

From the instrument view if SID is playing increasing Sustain value would cause the next trigger of a note to decay to envelope zero. GOF commands or reloading the instrument would be the only way to get sound back. Now the Sustain value changes will adjust the current playback envelope to the new sustain value. Stopping and starting again rests ADSR so there is also no longer a risk of the instrument getting stuck with envelope zero.

