### PR TITLE
New onFocusLost callback, use it to save themedata

### DIFF
--- a/sources/Application/Views/BaseClasses/View.h
+++ b/sources/Application/Views/BaseClasses/View.h
@@ -106,7 +106,13 @@ public:
     OnFocus();
   };
 
-  void LooseFocus() { hasFocus_ = false; };
+  virtual void LooseFocus() {
+    if (!hasFocus_) {
+      return;
+    }
+    hasFocus_ = false;
+    OnFocusLost();
+  };
 
   void Clear();
 
@@ -121,6 +127,7 @@ public:
   virtual void DrawView() = 0;
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int currentTick) = 0;
   virtual void OnFocus() = 0;
+  virtual void OnFocusLost(){};
   virtual void AnimationUpdate() = 0;
 
   void SetDirty(bool dirty);

--- a/sources/Application/Views/ThemeView.h
+++ b/sources/Application/Views/ThemeView.h
@@ -33,7 +33,8 @@ public:
   virtual void ProcessButtonMask(unsigned short mask, bool pressed);
   virtual void DrawView();
   virtual void OnPlayerUpdate(PlayerEventType, unsigned int){};
-  virtual void OnFocus();
+  void OnFocus() override;
+  void OnFocusLost() override;
 
   // Observer for action callback
   void Update(Observable &, I_ObservableData *);
@@ -68,5 +69,7 @@ private:
   // need separate flag for force because isDirty_ won't work for this because
   // it gets reset before AnimationUpdate is called in ThemeViews case
   bool _forceRedraw = false;
+  // use to flag pending theme data changes to be persisted to file
+  bool configDirty_ = false;
 };
 #endif


### PR DESCRIPTION
Save theme data changes only on leaving the theme subscreen instead on every value change.

Fixes: #963