### PR TITLE
Resolve #991 and resolve TODO for -Wno-int-to-pointer-cast

### DIFF
--- a/sources/Application/Views/BaseClasses/UIBigHexVarField.cpp
+++ b/sources/Application/Views/BaseClasses/UIBigHexVarField.cpp
@@ -93,5 +93,6 @@ void UIBigHexVarField::ProcessArrow(unsigned short mask) {
   src_.SetInt(value);
 
   SetChanged();
-  NotifyObservers((I_ObservableData *)(char)src_.GetID());
+  NotifyObservers(reinterpret_cast<I_ObservableData *>(
+      static_cast<uintptr_t>(src_.GetID())));
 };

--- a/sources/Application/Views/BaseClasses/UIBitmaskVarField.cpp
+++ b/sources/Application/Views/BaseClasses/UIBitmaskVarField.cpp
@@ -81,5 +81,6 @@ void UIBitmaskVarField::ProcessArrow(unsigned short mask) {
   src_.SetInt(value);
 
   SetChanged();
-  NotifyObservers((I_ObservableData *)(char)src_.GetID());
+  NotifyObservers(reinterpret_cast<I_ObservableData *>(
+      static_cast<uintptr_t>(src_.GetID())));
 };

--- a/sources/Application/Views/BaseClasses/UIIntVarField.cpp
+++ b/sources/Application/Views/BaseClasses/UIIntVarField.cpp
@@ -98,7 +98,8 @@ void UIIntVarField::ProcessArrow(unsigned short mask) {
   src_.SetInt(value);
 
   SetChanged();
-  NotifyObservers((I_ObservableData *)(char)src_.GetID());
+  NotifyObservers(reinterpret_cast<I_ObservableData *>(
+      static_cast<uintptr_t>(src_.GetID())));
 };
 
 FourCC UIIntVarField::GetVariableID() { return src_.GetID(); };

--- a/sources/Application/Views/BaseClasses/UITempoField.cpp
+++ b/sources/Application/Views/BaseClasses/UITempoField.cpp
@@ -36,7 +36,8 @@ void UITempoField::OnEditClick() {
 
 void UITempoField::Update(Observable &, I_ObservableData *data) {
   SetChanged();
-  NotifyObservers((I_ObservableData *)(char)action_);
+  NotifyObservers(
+      reinterpret_cast<I_ObservableData *>(static_cast<uintptr_t>(action_)));
 }
 
 void UITempoField::ProcessArrow(unsigned short mask) {

--- a/sources/Application/Views/BaseClasses/UITextField.ipp
+++ b/sources/Application/Views/BaseClasses/UITextField.ipp
@@ -64,7 +64,8 @@ void UITextField<MaxLength>::Draw(GUIWindow &w, int offset) {
 
 template <uint8_t MaxLength> void UITextField<MaxLength>::OnClick() {
   SetChanged();
-  NotifyObservers((I_ObservableData *)fourcc_);
+  NotifyObservers(
+      reinterpret_cast<I_ObservableData *>(static_cast<uintptr_t>(fourcc_)));
 };
 
 template <uint8_t MaxLength> void UITextField<MaxLength>::OnEditClick() {
@@ -75,7 +76,8 @@ template <uint8_t MaxLength> void UITextField<MaxLength>::OnEditClick() {
   }
   src_->SetString(buffer.c_str(), true);
   SetChanged();
-  NotifyObservers((I_ObservableData *)fourcc_);
+  NotifyObservers(
+      reinterpret_cast<I_ObservableData *>(static_cast<uintptr_t>(fourcc_)));
 };
 
 template <uint8_t MaxLength>
@@ -99,7 +101,8 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
       src_->SetString(buffer.c_str(), true);
     }
     SetChanged();
-    NotifyObservers((I_ObservableData *)fourcc_);
+    NotifyObservers(
+        reinterpret_cast<I_ObservableData *>(static_cast<uintptr_t>(fourcc_)));
     break;
   case EPBM_DOWN:
     // If buffer is empty or matches default, initialize with 'A'
@@ -113,7 +116,8 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
       src_->SetString(buffer.c_str(), true);
     }
     SetChanged();
-    NotifyObservers((I_ObservableData *)fourcc_);
+    NotifyObservers(
+        reinterpret_cast<I_ObservableData *>(static_cast<uintptr_t>(fourcc_)));
     break;
   case EPBM_LEFT:
     // If we're showing the default value and user presses left, initialize with
@@ -122,7 +126,8 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
       buffer = defaultValue_;
       src_->SetString(buffer.c_str(), true);
       SetChanged();
-      NotifyObservers((I_ObservableData *)fourcc_);
+      NotifyObservers(reinterpret_cast<I_ObservableData *>(
+          static_cast<uintptr_t>(fourcc_)));
     }
     if (currentChar_ > 0) {
       currentChar_--;
@@ -135,7 +140,8 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
       buffer = defaultValue_;
       src_->SetString(buffer.c_str(), true);
       SetChanged();
-      NotifyObservers((I_ObservableData *)fourcc_);
+      NotifyObservers(reinterpret_cast<I_ObservableData *>(
+          static_cast<uintptr_t>(fourcc_)));
     }
     if (currentChar_ < (buffer.length() - 1)) {
       currentChar_++;
@@ -145,7 +151,8 @@ void UITextField<MaxLength>::ProcessArrow(unsigned short mask) {
       buffer.append("A");
       src_->SetString(buffer.c_str(), true);
       SetChanged();
-      NotifyObservers((I_ObservableData *)fourcc_);
+      NotifyObservers(reinterpret_cast<I_ObservableData *>(
+          static_cast<uintptr_t>(fourcc_)));
     }
     break;
   };

--- a/sources/Application/Views/CMakeLists.txt
+++ b/sources/Application/Views/CMakeLists.txt
@@ -1,8 +1,3 @@
-add_compile_options(
-  # TODO: SHOULD FIX
-  -Wno-int-to-pointer-cast
-)
-
 add_library(application_views
   FieldView.cpp
   ChainView.cpp


### PR DESCRIPTION
This PR ensures that the use of `NotifyObservers` which expects an `I_ObservableData *` pointer first explicitly casts the `Fourcc` ID value to a `uintptr_t` before performing the pointer cast, in order to resolve the errors suppressed by `-Wno-int-to-pointer-cast`.