### PR TITLE
Advance: Adjust level of HPL and HPR amplifiers

### DIFF
--- a/sources/Adapters/adv/audio/tlv320aic3204.c
+++ b/sources/Adapters/adv/audio/tlv320aic3204.c
@@ -227,10 +227,10 @@ void tlv320_enable_hp(void) {
   tlv320write(0x04, 0x00);
 
   // Adjust the output amp for full volume to 1.4Vpp (0.5Vrms) for line level
-  // Set the HPL gain to 9dB
-  tlv320write(0x10, 0x09);
-  // Set the HPR gain to 9dB
-  tlv320write(0x11, 0x09);
+  // Set the HPL gain to 2dB
+  tlv320write(0x10, 0x02);
+  // Set the HPR gain to 2dB
+  tlv320write(0x11, 0x02);
   // Power up HPL and HPR drivers
   tlv320write(0x09, 0x30);
   // Wait for 2.5 sec for soft stepping to take effect


### PR DESCRIPTION
Measured using a full range sine 440Hz sample at full volume into Hi-Z (oscilloscope). Adjusted output to 1.4Vpp which seems to be a reasonable value for line output level (we are limited to 1.8V as maximum)

This level seems to work well as line out, 32ohm headphones and 250ohm headphones.

In future. We'd replace master output level with actual DAC digital control as to not lose any resolution.