### PR TITLE
Create a rendering buffer not located in DTCMRAM

### DIFF
--- a/sources/Application/Instruments/WavFileWriter.cpp
+++ b/sources/Application/Instruments/WavFileWriter.cpp
@@ -16,8 +16,9 @@
 #include <cstring>
 #include <limits>
 
-WavFileWriter::WavFileWriter(const char *path)
-    : sampleCount_(0), buffer_(0), bufferSize_(0), file_(0) {
+short WavFileWriter::buffer_[MAX_SAMPLE_COUNT * 2];
+
+WavFileWriter::WavFileWriter(const char *path) : sampleCount_(0), file_(0) {
   file_ = FileSystem::GetInstance()->Open(path, "wb");
   if (file_) {
     // Use WavHeaderWriter to write the header
@@ -34,17 +35,6 @@ WavFileWriter::~WavFileWriter() { Close(); }
 void WavFileWriter::AddBuffer(fixed *bufferIn, int size) {
 
   if (!file_)
-    return;
-
-  // allocate a short buffer for transfer
-
-  if (size > bufferSize_) {
-    SAFE_FREE(buffer_);
-    buffer_ = (short *)malloc(size * 2 * sizeof(short));
-    bufferSize_ = size;
-  };
-
-  if (!buffer_)
     return;
 
   short *s = buffer_;
@@ -454,5 +444,4 @@ void WavFileWriter::Close() {
 
   file_->Close();
   SAFE_DELETE(file_);
-  SAFE_FREE(buffer_);
 };

--- a/sources/Application/Instruments/WavFileWriter.h
+++ b/sources/Application/Instruments/WavFileWriter.h
@@ -11,6 +11,7 @@
 #define _WAV_FILE_WRITER_H_
 
 #include "Application/Utils/fixed.h"
+#include "Services/Audio/AudioDriver.h"
 #include "System/FileSystem/FileSystem.h"
 #include <cstddef>
 #include <cstdint>
@@ -46,8 +47,8 @@ public:
 
 private:
   int sampleCount_;
-  short *buffer_;
-  int bufferSize_;
+  // Buffer in AXI RAM since it has to be reachable by DMA perif
+  __attribute__((aligned(32))) static short buffer_[MAX_SAMPLE_COUNT * 2];
   I_File *file_;
 };
 #endif


### PR DESCRIPTION
The original buffer was being created in the HEAP, which, by itself is not ideal. But besides, the heap is in DTCMRAM, which the DMA periph cannot access and thus the DMA operations were always failing.