### PR TITLE
Fix tempo tap on advance 

### DIFF
--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -142,7 +142,7 @@ void advSystem::Boot() {
 
 void advSystem::Shutdown() { delete Audio::GetInstance(); };
 
-unsigned long advSystem::GetClock() { return HAL_GetTick(); }
+unsigned long advSystem::GetClock() { return xTaskGetTickCount(); }
 
 void advSystem::GetBatteryState(BatteryState &state) {
   auto soc = getBatterySOC();


### PR DESCRIPTION
Fix tempo by making GetClock() actually work on the Advance instead of always returning 0, as tempo relied on it to tell interval time passing.

Fixes: #1045 