### PR TITLE
Let persistent classes to not register w/ service

### DIFF
--- a/sources/Application/Instruments/I_Instrument.h
+++ b/sources/Application/Instruments/I_Instrument.h
@@ -38,8 +38,10 @@ protected:
 
 public:
   I_Instrument(etl::ilist<Variable *> *list,
-               const char *nodeName = "INSTRUMENT")
-      : VariableContainer(list), Persistent(nodeName){};
+               const char *nodeName = "INSTRUMENT",
+               bool registerWithPersistence = false)
+      : VariableContainer(list),
+        Persistent(nodeName, registerWithPersistence){};
   virtual ~I_Instrument();
 
   // Initialisation routine

--- a/sources/Application/Persistency/Persistent.cpp
+++ b/sources/Application/Persistency/Persistent.cpp
@@ -10,10 +10,9 @@
 #include "Persistent.h"
 #include "Foundation/Types/Types.h"
 
-Persistent::Persistent(const char *nodeName)
-    : SubService(FourCC::ServicePersistency) {
-  nodeName_ = nodeName;
-};
+Persistent::Persistent(const char *nodeName, bool registerWithService)
+    : SubService(FourCC::ServicePersistency, registerWithService),
+      nodeName_(nodeName) {}
 
 void Persistent::Save(tinyxml2::XMLPrinter *printer) {
   printer->OpenElement(nodeName_);

--- a/sources/Application/Persistency/Persistent.h
+++ b/sources/Application/Persistency/Persistent.h
@@ -16,7 +16,7 @@
 
 class Persistent : SubService {
 public:
-  Persistent(const char *nodeName);
+  Persistent(const char *nodeName, bool registerWithService = true);
   void Save(tinyxml2::XMLPrinter *printer);
   bool Restore(PersistencyDocument *doc);
 

--- a/sources/Foundation/Services/SubService.cpp
+++ b/sources/Foundation/Services/SubService.cpp
@@ -10,9 +10,15 @@
 #include "SubService.h"
 #include "ServiceRegistry.h"
 
-SubService::SubService(int fourCC) {
-  fourCC_ = fourCC;
-  ServiceRegistry::GetInstance()->Register(this);
+SubService::SubService(int fourCC, bool registerWithService)
+    : fourCC_(fourCC), registerWithService_(registerWithService) {
+  if (registerWithService_) {
+    ServiceRegistry::GetInstance()->Register(this);
+  }
 };
 
-SubService::~SubService() { ServiceRegistry::GetInstance()->Unregister(this); };
+SubService::~SubService() {
+  if (registerWithService_) {
+    ServiceRegistry::GetInstance()->Unregister(this);
+  }
+};

--- a/sources/Foundation/Services/SubService.h
+++ b/sources/Foundation/Services/SubService.h
@@ -12,11 +12,12 @@
 
 class SubService {
 public:
-  SubService(int fourCC);
+  SubService(int fourCC, bool registerWithService = true);
   virtual ~SubService();
   int GetFourCC() { return fourCC_; };
 
 private:
   int fourCC_;
+  bool registerWithService_;
 };
 #endif


### PR DESCRIPTION
This allows classes like Instrument, which will get persisted by the "container" class (InstrumentBank) to not get persisted separately a second time.

Fixes: #1072