### PR TITLE
Theme export UIFont value saved in same format as config.xml

### DIFF
--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -494,12 +494,7 @@ bool Config::SaveTheme(tinyxml2::XMLPrinter *printer, const char *themeName) {
   Variable *fontVar = FindVariable(FourCC::VarUIFont);
   if (fontVar) {
     printer->OpenElement("Font");
-
-    // Format font value in hex format with # prefix
-    char hexValue[16];
-    npf_snprintf(hexValue, sizeof(hexValue), "#%X", fontVar->GetInt());
-
-    printer->PushAttribute("value", hexValue);
+    printer->PushAttribute("value", std::to_string(fontVar->GetInt()).c_str());
     printer->CloseElement(); // Font
   }
 


### PR DESCRIPTION
fixes #1075 

Exported fonts now save the `UIFont` in decimal instead of hex. So now importing themes will use the `UIFont` value saved in the theme file.

Tested and verified importing different font values does not result in the font always being 'Regular'