### PR TITLE
cherrypick: Xml bounds checking (#1067)

### DIFF
--- a/sources/Application/Instruments/I_Instrument.cpp
+++ b/sources/Application/Instruments/I_Instrument.cpp
@@ -59,9 +59,8 @@ void I_Instrument::RestoreContent(PersistencyDocument *doc) {
   while (subelem) {
     // Process the PARAM element attributes
     bool hasAttr = doc->NextAttribute();
-    char name[24] = "";
-    char value[24] = "";
-
+    char name[MAX_VARIABLE_STRING_LENGTH + 1] = "";
+    char value[MAX_VARIABLE_STRING_LENGTH + 1] = "";
     while (hasAttr) {
       if (!strcasecmp(doc->attrname_, "NAME")) {
         strcpy(name, doc->attrval_);

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -356,8 +356,8 @@ void Project::RestoreContent(PersistencyDocument *doc) {
   bool elem = doc->FirstChild();
   while (elem) {
     bool attr = doc->NextAttribute();
-    char name[24];
-    char value[24];
+    char name[MAX_VARIABLE_STRING_LENGTH + 1];
+    char value[MAX_VARIABLE_STRING_LENGTH + 1];
     while (attr) {
       if (!strcmp(doc->attrname_, "NAME")) {
         strcpy(name, doc->attrval_);


### PR DESCRIPTION
* match xml variables to system variables

* safeguard against invalid XML file being loaded (with too long attributes)

* Ignore whitespace between attributes