### PR TITLE
Fix to correctly read black values, ie 0 color val

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -92,8 +92,9 @@ void AppWindow::defineColor(FourCC colorCode, GUIColor &color,
                             int paletteIndex) {
 
   Config *config = Config::GetInstance();
-  const int rgbValue = config->FindVariable(colorCode)->GetInt();
-  if (rgbValue) {
+  auto rgbVar = config->FindVariable(colorCode);
+  if (rgbVar) {
+    const int32_t rgbValue = rgbVar->GetInt();
     unsigned short r, g, b;
     r = (rgbValue >> 16) & 0xFF;
     g = (rgbValue >> 8) & 0xFF;


### PR DESCRIPTION
We were incorrectly checking the value of the color which of course can be 0 (black) instead of the config variable itself.

Fixes: #1047