### PR TITLE
Fix remoteui showing wrong colors

### DIFF
--- a/sources/Adapters/adv/gui/advGUIWindowImp.cpp
+++ b/sources/Adapters/adv/gui/advGUIWindowImp.cpp
@@ -130,9 +130,7 @@ void advGUIWindowImp::SetColor(GUIColor &c) {
     char remoteUIBuffer[8];
     auto bufferIndex =
         remoteUISetColorCommand(c._r, c._g, c._b, remoteUIBuffer);
-    sendToUSBCDC(remoteUIBuffer, bufferIndex);
-    sendToUSBCDCBuffered(remoteUIBuffer,
-                         bufferIndex); // Use the buffered function
+    sendToUSBCDCBuffered(remoteUIBuffer, bufferIndex);
   }
 };
 


### PR DESCRIPTION
Remove double calling usb uart  send function that was incorrectly left over from prev code refactor. This was causing random chars on the remote UI to be drawn in wrong color.

Also small fix to slight improve delay when sending chars to remote ui.

Fixes: #1016