### PR TITLE
fix how the TinyUSB FreeRTOS task works

### DIFF
--- a/sources/Adapters/adv/gui/advEventManager.cpp
+++ b/sources/Adapters/adv/gui/advEventManager.cpp
@@ -30,8 +30,6 @@
 
 #include "advRemoteUI.h"
 
-#define USB_PROCESSING_INTERVAL_MS 10
-
 bool advEventManager::finished_ = false;
 bool advEventManager::redrawing_ = false;
 uint16_t advEventManager::buttonMask_ = 0;
@@ -241,8 +239,7 @@ void ProcessEvent(void *) {
 
 void USBDevice(void *) {
   for (;;) {
-    tud_task(); // Handle USB device events
-    vTaskDelay(pdMS_TO_TICKS(USB_PROCESSING_INTERVAL_MS));
+    tud_task(); // Blocks on TinyUSB event queue until there is work to do
   }
 }
 


### PR DESCRIPTION
I miss-understood how the TinyUSB FreeRTOS task was supposed to work. tinyUSB in FreeRTOS mode has a queue that is driven by interrupts, so the delay (and a large one at that) was just adding latency. Presumably also the cause of the remoteUI slowness.

This should be a pretty safe change, I already verified that without this delay the USB task is not consuming any cycles and waiting to be woken up. If the task worked before adding this artificial delay, it should work after.
Enumeration works and plugging/unplugging device causes the task to wake up and correctly do it's job.