### PR TITLE
Fix project parse error detection

### DIFF
--- a/sources/Application/Persistency/PersistencyDocument.cpp
+++ b/sources/Application/Persistency/PersistencyDocument.cpp
@@ -98,7 +98,7 @@ bool PersistencyDocument::FirstChild() {
 bool PersistencyDocument::NextSibling() {
   // Only to be called after finishing an element end (YXML_ELEMEND), so need to
   // accept both plus the idle OK state. Also accept coming straight from an
-  // element start  (YXML_ELEMSTART) as well as post-attribute/end states.
+  // element start  (YXML_ELEMSTART).
   if ((r_ != YXML_OK) && (r_ != YXML_ELEMEND) && (r_ != YXML_ELEMSTART)) {
     Trace::Error(
         "XML NextSibling called with invalid state: %d for element '%s'", r_,


### PR DESCRIPTION
For some reason NextSibling is now also called with YXML_ELEMSTART  while it was not doing so when PR #1077  was  merged.