### PR TITLE
Dont clear dirty flag on every event

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -581,8 +581,6 @@ bool AppWindow::onEvent(GUIEvent &event) {
 
   _shouldQuit = false;
 
-  _isDirty = false;
-
   unsigned short v = 1 << event.GetValue();
 
   MixerService *sm = MixerService::GetInstance();


### PR DESCRIPTION
This hopefully fixes the issue of intermittent failures to redraw a screen after screen navigation by not clearing the dirty flag on every event which could cause a race with AnimationUpdate, but given there is no reliable repro for the issue, unsure if it actually does fix the issue.

Fixes: #1110