### PR TITLE
purge unnamed project when forcing a load of untitled project

### DIFF
--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -60,6 +60,7 @@ bool Application::initProject(char *projectName) {
   if (forceLoadUntitledProject) {
     Trace::Log("APPLICATION", "Force loading untitled project");
     FileSystem::GetInstance()->DeleteFile("/.current");
+    PersistencyService::GetInstance()->PurgeUnnamedProject();
     forceLoadUntitledProject = false; // Reset the flag
   }
 


### PR DESCRIPTION
resolves #1108 by adding a call to `PersistencyService::GetInstance()->PurgeUnnamedProject();` during force loading untitled project.