### PR TITLE
correctly filter out . & .. virtual dir entries

### DIFF
--- a/sources/Application/Views/SelectProjectView.cpp
+++ b/sources/Application/Views/SelectProjectView.cpp
@@ -172,8 +172,7 @@ void SelectProjectView::setCurrentFolder() {
 
     if (isDotEntry || isUntitled) {
       if (isUntitled) {
-        Trace::Log("SELECTPROJECTVIEW",
-                   "skipping untitled project on Index:%d",
+        Trace::Log("SELECTPROJECTVIEW", "skipping untitled project on Index:%d",
                    static_cast<int>(it - fileIndexList_.begin()));
       }
       it = fileIndexList_.erase(it);


### PR DESCRIPTION
Removes the prior hack and correctly checks specifically for "." and ".."

Fixes: #1115