### PR TITLE
we were saving past bounds for commands as FourCC is a char sized typ…

### DIFF
--- a/sources/Application/Utils/HexBuffers.cpp
+++ b/sources/Application/Utils/HexBuffers.cpp
@@ -78,7 +78,8 @@ void saveHexBuffer(tinyxml2::XMLPrinter *printer, const char *nodeName,
 
 void saveHexBuffer(tinyxml2::XMLPrinter *printer, const char *nodeName,
                    FourCC *src, unsigned len) {
-  saveHexBuffer(printer, nodeName, (unsigned char *)src, len * sizeof(short));
+  saveHexBuffer(printer, nodeName, (unsigned char *)src,
+                len * sizeof(FourCC::enum_type));
 }
 
 void restoreHexBuffer(PersistencyDocument *doc, unsigned char *destination) {


### PR DESCRIPTION
…e rather than short

this was generating this line at the boundary:
              <DATA VALUE="45" LENGTH="64"/>
              <DATA VALUE="45" LENGTH="64"/>
              <DATA VALUE="45" LENGTH="64"/>
              <DATA>2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D00000000000000000000000000000000</DATA>
              <DATA VALUE="0" LENGTH="64"/>
              <DATA VALUE="0" LENGTH="64"/>
              <DATA VALUE="0" LENGTH="64"/>

This doesn't affect loading, so it's cosmetic, but it did affect us when loading a picoTracker project into picoTracker Advance, which can load pass that boundary, generating bad data in the Advance. While loading picoTracker projects in Advance is not supported, this shouldn't happen in the first place.