### PR TITLE
Dont close files being previewed directly in Stop

### DIFF
--- a/sources/Application/Audio/AudioFileStreamer.h
+++ b/sources/Application/Audio/AudioFileStreamer.h
@@ -47,7 +47,9 @@ protected:
 
   // For matching oscillator mode in SampleInstrument
   float referencePitch_; // Reference pitch in Hz (C3 = 130.81 Hz)
+#ifndef ADV
   volatile bool stopRequested_;
+#endif
 
 public:
   void SetProject(Project *project) { project_ = project; }


### PR DESCRIPTION
On the pico, because Stop() is called from Core0 while rendering is on Core1, can get a race if the wav file is closed in Stop() while rendering is still reading from the file to stream the audio data.

Fixes: #1003 