### PR TITLE
Detect no sdcard & show input tester

### DIFF
--- a/sources/Adapters/picoTracker/gui/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/gui/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(platform_gui
   GUIFactory.cpp
+  InputTester.cpp
   picoTrackerGUIWindowImp.cpp
   picoTrackerEventManager.cpp
   SerialDebugUI.cpp

--- a/sources/Adapters/picoTracker/gui/InputTester.cpp
+++ b/sources/Adapters/picoTracker/gui/InputTester.cpp
@@ -1,0 +1,52 @@
+#include "InputTester.h"
+#include "Adapters/picoTracker/display/chargfx.h"
+#include "Adapters/picoTracker/system/input.h"
+#include "Foundation/Constants/SpecialCharacters.h"
+#include <System/Console/nanoprintf.h>
+#include <string.h>
+
+// Helper function to draw a single button with optional inversion
+static void draw_string(int x, int y, const char *s, bool invert) {
+  while (*s) {
+    chargfx_set_cursor(x++, y);
+    chargfx_putc(*s++, invert);
+  }
+}
+
+static void draw_button(uint8_t x, uint8_t y, char label, bool invert) {
+  const char line[4] = {char_border_single_vertical, label,
+                        char_border_single_vertical, 0};
+  draw_string(x, y + 0,
+              char_border_single_topLeft_s char_border_single_horizontal_s
+                  char_border_single_topRight_s,
+              invert);
+  draw_string(x, y + 1, (const char *)line, invert);
+  draw_string(x, y + 2,
+              char_border_single_bottomLeft_s char_border_single_horizontal_s
+                  char_border_single_bottomRight_s,
+              invert);
+}
+
+void drawInputTester() {
+  // Read button state
+  uint16_t keys = scanKeys();
+
+  // Title
+  chargfx_set_cursor(10, 2);
+  chargfx_print("Button Tester", false);
+
+  // Row 1: Up, Play, Edit
+  draw_button(13, 14, char_button_up, keys & KEY_UP);
+  draw_button(16, 14, char_button_play, keys & KEY_START);
+  draw_button(19, 14, char_button_edit, keys & KEY_EDIT);
+
+  // Row 2: Left, Down, Right, Enter/Set
+  draw_button(10, 17, char_button_left, keys & KEY_LEFT);
+  draw_button(13, 17, char_button_down, keys & KEY_DOWN);
+  draw_button(16, 17, char_button_right, keys & KEY_RIGHT);
+  draw_button(19, 17, char_button_enter, keys & KEY_ENTER);
+
+  // Row 3: Alt, Nav
+  draw_button(13, 20, char_button_alt, keys & KEY_ALT);
+  draw_button(16, 20, char_button_nav, keys & KEY_NAV);
+}

--- a/sources/Adapters/picoTracker/gui/InputTester.h
+++ b/sources/Adapters/picoTracker/gui/InputTester.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void drawInputTester();

--- a/sources/Adapters/picoTracker/system/critical_error_message.c
+++ b/sources/Adapters/picoTracker/system/critical_error_message.c
@@ -8,64 +8,72 @@
 
 #include "critical_error_message.h"
 #include "Adapters/picoTracker/display/chargfx.h"
+#include "Foundation/Constants/SpecialCharacters.h"
 #include <System/Console/nanoprintf.h>
 #include <string.h>
 
 // show this message and basically crash, so only for critical errors where
 // we need to show user a message and cannot continue until a reboot
-void critical_error_message(const char *message, int guruId) {
+void critical_error_message(const char *message, int guruId,
+                            bool (*externalCallback)(void)) {
   chargfx_init();
 
   chargfx_set_font_index(0);
 
   chargfx_set_palette_color(15, 0x0000); // BLACK
   chargfx_set_palette_color(14, 0xF800); // RED
+
   chargfx_set_background(CHARGFX_GURU_BG);
-  chargfx_clear(CHARGFX_GURU_BG);
   chargfx_set_foreground(CHARGFX_GURU_TXT);
 
   int msglen = strlen(message) < 30 ? strlen(message) : 30;
   char msgbuffer[32];
-  char gurumsgbuffer[32];
-  npf_snprintf(gurumsgbuffer, sizeof(gurumsgbuffer),
-               "   Guru Meditation: 00000.%04d", guruId);
 
   int center = (32 - msglen) / 2;
   if (center > 0) {
     memset(&msgbuffer[1], ' ', center - 1);
     memcpy(&msgbuffer[center], message, msglen);
     memset(&msgbuffer[center + msglen], ' ', 32 - center - msglen - 1);
-    msgbuffer[0] = '#';
-    msgbuffer[31] = '#';
-    gurumsgbuffer[0] = '#';
-    gurumsgbuffer[31] = '#';
   }
+
+  chargfx_clear(CHARGFX_GURU_BG);
+
   // halt
-  for (;;) {
-    for (int y = 0; y < 4; y++) {
+  for (int i = 0;; i++) {
+    bool border = i % 10 < 5;
+    // prepare message lines with changing border
+    msgbuffer[0] = border ? char_border_double_vertical : ' ';
+    msgbuffer[31] = msgbuffer[0];
+
+    chargfx_set_cursor(10, 2);
+    chargfx_putc(' ', false);
+
+    // draw border
+    for (int y = 0; y < 3; y++) {
       for (int x = 0; x < 32; x++) {
         chargfx_set_cursor(x, y + 10);
-        if (y == 0 || y == 3) {
-          chargfx_putc('#', false);
-        } else if (y == 2) {
-          chargfx_putc(gurumsgbuffer[x], false);
+        if (y == 0 || y == 2) {
+          char c = char_border_double_horizontal;
+          if (x == 0 || x == 31) {
+            c = (x == 0) ? (y == 0 ? char_border_double_topLeft
+                                   : char_border_double_bottomLeft)
+                         : (y == 0 ? char_border_double_topRight
+                                   : char_border_double_bottomRight);
+          }
+          chargfx_putc(border ? c : ' ', false);
         } else {
           chargfx_putc(msgbuffer[x], false);
         }
       }
     }
-    chargfx_draw_changed();
-    sleep_ms(1000);
-    chargfx_clear(CHARGFX_GURU_BG);
 
-    // draw just the message
-    for (int x = 1; x < 31; x++) {
-      chargfx_set_cursor(x, 11);
-      chargfx_putc(msgbuffer[x], false);
-      chargfx_set_cursor(x, 12);
-      chargfx_putc(gurumsgbuffer[x], false);
-    }
     chargfx_draw_changed();
-    sleep_ms(1000);
+
+    // call the external callback if provided to check if the error was cleared.
+    if (externalCallback != NULL && externalCallback()) {
+      return;
+    }
+
+    sleep_ms(100);
   }
 }

--- a/sources/Adapters/picoTracker/system/critical_error_message.h
+++ b/sources/Adapters/picoTracker/system/critical_error_message.h
@@ -13,7 +13,10 @@
 extern "C" {
 #endif
 
-void critical_error_message(const char *message, int guruId);
+#include <stdbool.h>
+
+void critical_error_message(const char *message, int guruId,
+                            bool (*externalCallback)(void));
 
 #ifdef __cplusplus
 }

--- a/sources/Adapters/picoTracker/system/input.h
+++ b/sources/Adapters/picoTracker/system/input.h
@@ -10,6 +10,10 @@
 #define _PICOTRACKERINPUT_H_
 #include "pico/stdlib.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BIT(n) (1 << (n))
 
 typedef enum KEYPAD_BITS {
@@ -25,5 +29,9 @@ typedef enum KEYPAD_BITS {
 } KEYPAD_BITS;
 
 uint16_t scanKeys();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/sources/Foundation/Constants/SpecialCharacters.h
+++ b/sources/Foundation/Constants/SpecialCharacters.h
@@ -139,10 +139,29 @@
 #define char_block_bottomRightCorner_s "\346"
 #define char_block_bottomRightCorner char_block_bottomRightCorner_s[0]
 
-#define char_button_left_s "\216"
-#define char_button_left char_button_left_s[0]
-#define char_button_right_s "\217"
+#define char_button_border_left_s "\216"
+#define char_button_border_left char_button_border_left_s[0]
+#define char_button_border_right_s "\217"
+#define char_button_border_right char_button_border_right_s[0]
+
+#define char_button_right_s "\227"
 #define char_button_right char_button_right_s[0]
+#define char_button_up_s "\230"
+#define char_button_up char_button_up_s[0]
+#define char_button_down_s "\231"
+#define char_button_down char_button_down_s[0]
+#define char_button_left_s "\232"
+#define char_button_left char_button_left_s[0]
+#define char_button_play_s "\233"
+#define char_button_play char_button_play_s[0]
+#define char_button_enter_s "\234"
+#define char_button_enter char_button_enter_s[0]
+#define char_button_alt_s "\235"
+#define char_button_alt char_button_alt_s[0]
+#define char_button_nav_s "\236"
+#define char_button_nav char_button_nav_s[0]
+#define char_button_edit_s "\237"
+#define char_button_edit char_button_edit_s[0]
 
 #define char_filledBorder_bottom_s "\337"
 #define char_filledBorder_bottom char_filledBorder_bottom_s[0]
@@ -233,6 +252,7 @@
 #define char_border_double_verticalRight_s "\314"
 #define char_border_double_verticalRight char_border_double_verticalRight_s[0]
 #define char_border_double_cross_s "\316"
+#define char_border_double_cross char_border_double_cross_s[0]
 
 #define char_logo_x_s "\320"
 #define char_logo_x char_logo_x_s[0]
@@ -276,7 +296,7 @@
       char_battery_right_s
 
 // Array of bargraph characters for fast lookup
-static constexpr const char *const char_bargraph_lookup[] = {
+static const char *const char_bargraph_lookup[] = {
     char_bargraph_bar0_s, // 0
     char_bargraph_bar1_s, // 1
     char_bargraph_bar2_s, // 2


### PR DESCRIPTION
This feature was entirely contributed by @n1LS in #1090 , this PR only serves to extract that specific functionality out from other pieces of code included in that PR.

This PR adds detection on boot for a missing sdcard, shows an error screen if its missing which also contains a simple keypad tester. It detects if an sdcard is inserted while its being displayed and will then proceed to boot normal in that case.

Note: This is for the pico *only*.

Fixes: #156 