### PR TITLE
re-enables PC messages on change, when the player is running

### DIFF
--- a/sources/Application/Views/BaseClasses/UIIntVarOffField.cpp
+++ b/sources/Application/Views/BaseClasses/UIIntVarOffField.cpp
@@ -54,6 +54,10 @@ void UIIntVarOffField::ProcessArrow(unsigned short mask) {
     }
   }
   src_.SetInt(value);
+
+  SetChanged();
+  NotifyObservers(reinterpret_cast<I_ObservableData *>(
+      static_cast<uintptr_t>(src_.GetID())));
 };
 
 void UIIntVarOffField::Draw(GUIWindow &w, int offset) {


### PR DESCRIPTION
Implements #762:

- enables observers for UIIntVarOffField
- send program change (w/o note) on change, when the player is running