### PR TITLE
Usermanual typo fixes (#1192)

### DIFF
--- a/sources/Adapters/adv/Core/Src/main.c
+++ b/sources/Adapters/adv/Core/Src/main.c
@@ -152,7 +152,7 @@ int main(void) {
   MX_RTC_Init();
   /* USER CODE BEGIN 2 */
 
-  // Check for ENTER key hold on boot to force load untitled project
+  // Check for EDIT key hold on boot to force load untitled project
   {
     if (HAL_GPIO_ReadPin(INPUT_ENTER_GPIO_Port, INPUT_EDIT_Pin) ==
         GPIO_PIN_SET) {

--- a/usermanual/advance-edition/content/pages/chains.md
+++ b/usermanual/advance-edition/content/pages/chains.md
@@ -11,7 +11,7 @@ template: page
 - The rightmost column is transpose. If you use very high numbers like FF the phrase on that row will transpose down. Low numbers like 04 will cause the phrase on that row to transpose up.
 - you can jump to previous / next chain on the row with with ``EDIT`+`LEFT`/`RIGHT`
 - You can make a new phrase by hitting `EDIT EDIT` on a blank space in the Chain screen.
-- You can clone a phrase by highlighting it with the cursor and pressing `NAV`+`EDIT ENTER`.
+- You can clone a phrase by highlighting it with the cursor and pressing `ALT`+`(EDIT, ENTER)`.
 - You can copy a phrase/transposition/selection by highlighting and pressing `EDIT`.
 - You can cut or delete a phrase/transposition/selection by highlighting and pressing `EDIT`+`ENTER`.
 - Make a big selection by pressing `NAV`+`EDIT`, then Arrows around to highlight.

--- a/usermanual/advance-edition/content/pages/getting-started.md
+++ b/usermanual/advance-edition/content/pages/getting-started.md
@@ -12,11 +12,11 @@ The picoTracker user interface is made up of a series of screens, which are laye
 
 ![image of screen map](image/screenmap.png)
 
-The picoTracker boots into the Song screen of your most recently opened project. Press and hold ENTER while restarting to instead launch a new, untitled project instead.
+The picoTracker boots into the Song screen of your most recently opened project. Press and hold `EDIT` while restarting to instead launch a new, untitled project instead.
 
 The picoTrackers keypad layout resembles a typical old console game controller.
 
-You can navigate (aka move) between screens using <span class="minikeys">ENTER+DOWN/UP/LEFT/RIGHT ![nav+up/down/left/righ](image/pt-buttons-small-nav_arrows.jpg)</span>.
+You can navigate (aka move) between screens using <span class="minikeys">NAV+DOWN/UP/LEFT/RIGHT ![nav+up/down/left/righ](image/pt-buttons-small-nav_arrows.jpg)</span>.
 
 To get to the chain screen, you need to have your cursor on a chain in the song. To get to the phrase screen, you need to have your cursor on a pattern in the chain screen.
 
@@ -28,7 +28,7 @@ The names of the keys are shown below.
 
 When you are on the Song screen, there are two modes for playback, Song Mode and Live Mode. The controls in each mode differ slightly.
 
-You can switch between the modes by hitting <span class="minikeys">ENTER+LEFT/RIGHT ![enter+left/right](image/pt-buttons-small-enter_leftright.jpg)</span> in the Song screen.
+You can switch between the modes by hitting <span class="minikeys">EDIT+LEFT/RIGHT</span> in the Song screen.
 
 For a list of all the controls, see the [Controls & Moves reference](keypadcombos.html).
 
@@ -36,9 +36,9 @@ For a list of all the controls, see the [Controls & Moves reference](keypadcombo
 
 When selecting a sample wav file or project file you enter the file browser view.
 
-When in the Project File Browser view, use the arrow keys <span class="minikeys">UP/Down ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of project available and press <span class="minikeys">EDIT ![edit](image/pt-buttons-small-edit.jpg)</span> to open the currently selected (highlighted) a project. 
+When in the Project File Browser view, use the arrow keys <span class="minikeys">UP/Down ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of project available and press <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span> to open the currently selected (highlighted) a project. 
 
-When in the wave sample File Browser, use the arrow keys <span class="minikeys">UP/DOWN ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press <span class="minikeys">EDIT ![edit](image/pt-buttons-small-edit.jpg)</span> to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entery and pressing <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span>. Press <span class="minikeys">PLAY ![play](image/pt-buttons-small-play.jpg)</span> to audition the currently selected sample wave file. To import the currently selected wave file press <span class="minikeys">ALT+PLAY ![alt+play](image/pt-buttons-small-alt_play.jpg)</span>. At any time, you can return to the instrument screen from the sample file browser by pressing <span class="minikeys">NAV+LEFT ![nav+left](image/pt-buttons-small-nav_left.jpg)</span>.
+When in the wave sample File Browser, use the arrow keys <span class="minikeys">UP/DOWN ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press <span class="minikeys">ENTER ![Enter](image/pt-buttons-small-enter.jpg)</span> to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entry and pressing <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span>. Press <span class="minikeys">PLAY ![play](image/pt-buttons-small-play.jpg)</span> to audition the currently selected sample wave file. To import the currently selected wave file press <span class="minikeys">ALT+PLAY ![alt+play](image/pt-buttons-small-alt_play.jpg)</span>. At any time, you can return to the instrument screen from the sample file browser by pressing <span class="minikeys">NAV+LEFT ![nav+left](image/pt-buttons-small-nav_left.jpg)</span>.
 
 
 ## Shutdown

--- a/usermanual/advance-edition/content/pages/grooves.md
+++ b/usermanual/advance-edition/content/pages/grooves.md
@@ -48,8 +48,8 @@ To understand how grooves affect playback:
 The following controls are available in the groove screen:
 
 - `EDIT`: Add a new step to the groove pattern if one doesn't exist
-- `EDIT`+`Left/Right`: Modify the current step value
-- `ENTER`+`Arrows`: Navigate between different groove patterns
+- `ENTER`+`Left/Right`: Modify the current step value
+- `EDIT`+`Arrows`: Navigate between different groove patterns
 - `EDIT`+`ENTER`: Clear the current step
 
 ## Tips for Using Grooves

--- a/usermanual/advance-edition/content/pages/instruments.md
+++ b/usermanual/advance-edition/content/pages/instruments.md
@@ -54,7 +54,7 @@ Once you've created an instrument, you can save it for use in other projects:
 - **loop Start:** start point of the sample when loop is enabled (note value is in hex)
 - **loop End:** end point of the sample (note value is in hex). You can play samples backwards by setting the end value lower than the start
 - **automation:** If On, the table play arrows will advance one row every time the instrument is triggered, and execute only the commands on the new rows. If this is Off, table behavior is normal (play arrows will move at the speed of 1 row per tick)
-- **table:** Select a table the instrument will always run. To clone a table here: `NAV`+(`EDIT`, `ENTER`). Make a new table by selecting a higher number not yet in use.
+- **table:** Select a table the instrument will always run. To clone a table here: `ALT`+(`EDIT`, `ENTER`). Make a new table by selecting a higher number not yet in use.
 
 
 ## Sample Import Screen
@@ -137,7 +137,7 @@ A MIDI instrument has the following settings:
 - **Program** - MIDI program change value to send (0x00-0x7F). Program changes for *each* MIDI instrument are sent only once at sequencer start. Setting this to `--` will disable sending program change messages entirely.
 - **Length** - Sets note gate length in number of ticks
 - **Automation** - When on, the table play arrows will advance one row every time the instrument is triggered, and execute only the commands on the new rows. If this is `Off`, table behavior is normal (play arrows will move at the speed of 1 row per tick)
-- **Table**- As above, select a table the instrument will always run. Clone a table here: `NAV`+`EDIT`,`ENTER`. Make a new table by selecting a higher number not yet in use.
+- **Table**- As above, select a table the instrument will always run. Clone a table here: `ALT`+`EDIT`,`ENTER`. Make a new table by selecting a higher number not yet in use.
 
 
 ## Synths

--- a/usermanual/advance-edition/content/pages/keypadcombos.md
+++ b/usermanual/advance-edition/content/pages/keypadcombos.md
@@ -62,7 +62,7 @@ To reset all muted and soloed tracks, press `NAV + ALT`.
 | query current row for playback                                                                        |        `ALT + PLAY`        |       ![nav + alt + play](image/pt-buttons-alt_play.jpg)        |
 | reset all muted & soloed tracks                                                                       |        `ALT + NAV`         |       ![nav + alt + enter](image/pt-buttons-nav_alt.jpg)        |
 | cut the current cursor position if filled, paste otherwise                                            |       `ALT + ENTER`        |          ![arrow keys](image/pt-buttons-alt_enter.jpg)          |
-| Clone: Overwrite current highlighted Item with a copy of itself using the next unused Item available. |    `ALT + EDIT + ENTER`    | ![alt + edit + enter keys](image/pt-buttons-alt_edit_enter.jpg) |
+| Clone: Overwrite current highlighted Item with a copy of itself using the next unused Item available. |    `ALT + (EDIT, ENTER)`    | ![alt + edit + enter keys](image/pt-buttons-alt_edit_enter.jpg) |
 | start selection                                                                                       |       `ALT + EDIT `        |        ![edit + alt keys](image/pt-buttons-alt_edit.jpg)        |
 | start selection with row selected                                                                     |    `ALT + EDIT + EDIT`     |       ![edit + alt keys](image/pt-buttons-alt_edit2.jpg)        |
 | start selection with current screen selected                                                          | `ALT + EDIT + EDIT + EDIT` |       ![edit + alt keys](image/pt-buttons-alt_edit3.jpg)        |
@@ -126,7 +126,7 @@ Once a selection is started you can do a few more things:
 | Function               |    Key Combination    |                             Image                              |
 |:-----------------------|:---------------------:|:--------------------------------------------------------------:|
 | unmute all             |      `ALT + NAV`      |         ![alt + nav key](image/pt-buttons-nav_alt.jpg)         |
-| clone current position | ` ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current position | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
 | paste clipboard        |     `ALT + ENTER`     |       ![alt + enter key](image/pt-buttons-alt_enter.jpg)       |
 | start selection        |     `ALT + EDIT`      |        ![alt + edit key](image/pt-buttons-alt_edit.jpg)        |
 
@@ -205,8 +205,8 @@ Once a selection is started you can do a few more things:
 | unmute all                                                                      |     `ALT + NAV`      |         ![alt + nav key](image/pt-buttons-nav_alt.jpg)         |
 | paste clipboard                                                                 |    `ALT + ENTER`     |       ![alt + enter key](image/pt-buttons-alt_enter.jpg)       |
 | start selection                                                                 |     `ALT + EDIT`     |        ![alt + edit key](image/pt-buttons-alt_edit.jpg)        |
-| clone current instrument (cursor in note / instrument column)                   | `ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
-| clone current table (cursor in note / instrument column) (TODO: see issue #753) | `ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current instrument (cursor in note / instrument column)                   | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current table (cursor in note / instrument column) (TODO: see issue #753) | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
 
 ### EDIT Modifier
 
@@ -274,7 +274,7 @@ Once a selection is started you can do a few more things:
 | Previous/Next instrument (-1/+1)                                             | `EDIT + (LEFT / RIGHT)` | ![edit + (left / right) key](image/pt-buttons-edit_leftright.jpg) |
 | Previous/Next instrument (-16/+16)                                           |  `EDIT + (DOWN / UP)`   |       ![edit + down key](image/pt-buttons-edit_updown.jpg)        |
 | Cut/purge instrument (sample) or clear table                                 |     `EDIT + ENTER`      |       ![edit + enter key](image/pt-buttons-edit_enter.jpg)        |
-| clone current table                                                          |  `EDIT + ALT + ENTER`   |      ![edit + alt key](image/pt-buttons-alt_edit_enter.jpg)       |
+| clone current table                                                          |  `ALT + (EDIT, ENTER)`   |      ![edit + alt key](image/pt-buttons-alt_edit_enter.jpg)       |
 | \[advance only\] Sample recording, only accessible when sequencer is stopped |      `EDIT + PLAY`      |        ![edit + play keys](image/pt-buttons-edit_play.jpg)        |
 
 ## Import View

--- a/usermanual/advance-edition/content/pages/phrases.md
+++ b/usermanual/advance-edition/content/pages/phrases.md
@@ -16,7 +16,7 @@ template: page
   * parameters for FX2
 - You can use the all the [standard picoTrackerkey editing combos](keypadcombos.html) for editing on the phrase screen.
 - If you copy/cut anything in the phrase screen, pasting will always put the data back in the same column (regardless if you've moved the cursor to another column). This means effects in column one are always pasted back there, and you can't accidentally paste a note into the effect column, etc.
-- You can clone an instrument in the phrase screen by pressing `NAV`+`ENTER`,`EDIT` on instrument number in phrase screen. 
+- You can clone an instrument in the phrase screen by pressing `ALT + (EDIT, ENTER)` on instrument number in phrase screen. 
 - If no instrument is set when triggering a new note, tables are not stopped, running commands are not stopped and phase of oscillator instrument is not reset (allowing for clickless transitions)
 - In Song mode `Play` starts and stops playback from Step 00, soloing the current phrase
 - In Live mode `Play` queues the Edited Chain Step from 00

--- a/usermanual/pico-edition/content/pages/chains.md
+++ b/usermanual/pico-edition/content/pages/chains.md
@@ -11,7 +11,7 @@ template: page
 - The rightmost column is transpose. If you use very high numbers like FF the phrase on that row will transpose down. Low numbers like 04 will cause the phrase on that row to transpose up.
 - you can jump to previous / next chain on the row with with ``EDIT`+`LEFT`/`RIGHT`
 - You can make a new phrase by hitting `EDIT EDIT` on a blank space in the Chain screen.
-- You can clone a phrase by highlighting it with the cursor and pressing `NAV`+`EDIT ENTER`.
+- You can clone a phrase by highlighting it with the cursor and pressing `ALT + (EDIT, ENTER)`.
 - You can copy a phrase/transposition/selection by highlighting and pressing `EDIT`.
 - You can cut or delete a phrase/transposition/selection by highlighting and pressing `EDIT`+`ENTER`.
 - Make a big selection by pressing `NAV`+`EDIT`, then Arrows around to highlight.

--- a/usermanual/pico-edition/content/pages/getting-started.md
+++ b/usermanual/pico-edition/content/pages/getting-started.md
@@ -12,11 +12,11 @@ The picoTracker user interface is made up of a series of screens, which are laye
 
 ![image of screen map](image/screenmap.png)
 
-The picoTracker boots into the Song screen of your most recently opened project. Press and hold ENTER while restarting to instead launch a new, untitled project instead.
+The picoTracker boots into the Song screen of your most recently opened project. Press and hold `EDIT` while restarting to instead launch a new, untitled project instead.
 
 The picoTrackers keypad layout resembles a typical old console game controller.
 
-You can navigate (aka move) between screens using <span class="minikeys">ENTER+DOWN/UP/LEFT/RIGHT ![nav+up/down/left/righ](image/pt-buttons-small-nav_arrows.jpg)</span>.
+You can navigate (aka move) between screens using <span class="minikeys">NAV+DOWN/UP/LEFT/RIGHT ![nav+up/down/left/righ](image/pt-buttons-small-nav_arrows.jpg)</span>.
 
 To get to the chain screen, you need to have your cursor on a chain in the song. To get to the phrase screen, you need to have your cursor on a pattern in the chain screen.
 
@@ -28,7 +28,7 @@ The names of the keys are shown below.
 
 When you are on the Song screen, there are two modes for playback, Song Mode and Live Mode. The controls in each mode differ slightly.
 
-You can switch between the modes by hitting <span class="minikeys">ENTER+LEFT/RIGHT ![enter+left/right](image/pt-buttons-small-enter_leftright.jpg)</span> in the Song screen.
+You can switch between the modes by hitting <span class="minikeys">EDIT+LEFT/RIGHT</span> in the Song screen.
 
 For a list of all the controls, see the [Controls & Moves reference](keypadcombos.html).
 
@@ -36,9 +36,9 @@ For a list of all the controls, see the [Controls & Moves reference](keypadcombo
 
 When selecting a sample wav file or project file you enter the file browser view.
 
-When in the Project File Browser view, use the arrow keys <span class="minikeys">UP/Down ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of project available and press <span class="minikeys">EDIT ![edit](image/pt-buttons-small-edit.jpg)</span> to open the currently selected (highlighted) a project. 
+When in the Project File Browser view, use the arrow keys <span class="minikeys">UP/Down ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of project available and press <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span> to open the currently selected (highlighted) a project. 
 
-When in the wave sample File Browser, use the arrow keys <span class="minikeys">UP/DOWN ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press <span class="minikeys">EDIT ![edit](image/pt-buttons-small-edit.jpg)</span> to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entery and pressing <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span>. Press <span class="minikeys">PLAY ![play](image/pt-buttons-small-play.jpg)</span> to audition the currently selected sample wave file. To import the currently selected wave file press <span class="minikeys">ALT+PLAY ![alt+play](image/pt-buttons-small-alt_play.jpg)</span>. At any time, you can return to the instrument screen from the sample file browser by pressing <span class="minikeys">NAV+LEFT ![nav+left](image/pt-buttons-small-nav_left.jpg)</span>.
+When in the wave sample File Browser, use the arrow keys <span class="minikeys">UP/DOWN ![up/down](image/pt-buttons-small-arrows-updown.jpg)</span> to navigate through the list of available sample files and subdirectories, subdirectories are indciated with a `/` prefix. Press <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span> to enter a subdirectory, you can go back to the parent directory by navigating to the `/..` entry and pressing <span class="minikeys">ENTER ![enter](image/pt-buttons-small-enter.jpg)</span>. Press <span class="minikeys">PLAY ![play](image/pt-buttons-small-play.jpg)</span> to audition the currently selected sample wave file. To import the currently selected wave file press <span class="minikeys">ALT+PLAY ![alt+play](image/pt-buttons-small-alt_play.jpg)</span>. At any time, you can return to the instrument screen from the sample file browser by pressing <span class="minikeys">NAV+LEFT ![nav+left](image/pt-buttons-small-nav_left.jpg)</span>.
 
 
 ## Shutdown

--- a/usermanual/pico-edition/content/pages/grooves.md
+++ b/usermanual/pico-edition/content/pages/grooves.md
@@ -48,8 +48,8 @@ To understand how grooves affect playback:
 The following controls are available in the groove screen:
 
 - `EDIT`: Add a new step to the groove pattern if one doesn't exist
-- `EDIT`+`Left/Right`: Modify the current step value
-- `ENTER`+`Arrows`: Navigate between different groove patterns
+- `ENTER`+`Left/Right`: Modify the current step value
+- `EDIT`+`Arrows`: Navigate between different groove patterns
 - `EDIT`+`ENTER`: Clear the current step
 
 ## Tips for Using Grooves

--- a/usermanual/pico-edition/content/pages/instruments.md
+++ b/usermanual/pico-edition/content/pages/instruments.md
@@ -54,7 +54,7 @@ Once you've created an instrument, you can save it for use in other projects:
 - **loop Start:** start point of the sample when loop is enabled (note value is in hex)
 - **loop End:** end point of the sample (note value is in hex). You can play samples backwards by setting the end value lower than the start
 - **automation:** If On, the table play arrows will advance one row every time the instrument is triggered, and execute only the commands on the new rows. If this is Off, table behavior is normal (play arrows will move at the speed of 1 row per tick)
-- **table:** Select a table the instrument will always run. To clone a table here: `NAV`+(`EDIT`, `ENTER`). Make a new table by selecting a higher number not yet in use.
+- **table:** Select a table the instrument will always run. To clone a table here: `ALT + (EDIT, ENTER)`. Make a new table by selecting a higher number not yet in use.
 
 
 ## Sample Import Screen
@@ -137,7 +137,7 @@ A MIDI instrument has the following settings:
 - **Program** - MIDI program change value to send (0x00-0x7F). Program changes for *each* MIDI instrument are sent only once at sequencer start. Setting this to `--` will disable sending program change messages entirely.
 - **Length** - Sets note gate length in number of ticks
 - **Automation** - When on, the table play arrows will advance one row every time the instrument is triggered, and execute only the commands on the new rows. If this is `Off`, table behavior is normal (play arrows will move at the speed of 1 row per tick)
-- **Table**- As above, select a table the instrument will always run. Clone a table here: `NAV`+`EDIT`,`ENTER`. Make a new table by selecting a higher number not yet in use.
+- **Table**- As above, select a table the instrument will always run. Clone a table here: `ALT + (EDIT, ENTER)`. Make a new table by selecting a higher number not yet in use.
 
 
 ## Synths

--- a/usermanual/pico-edition/content/pages/keypadcombos.md
+++ b/usermanual/pico-edition/content/pages/keypadcombos.md
@@ -62,7 +62,7 @@ To reset all muted and soloed tracks, press `NAV + ALT`.
 | query current row for playback                                                                        |        `ALT + PLAY`        |       ![nav + alt + play](image/pt-buttons-alt_play.jpg)        |
 | reset all muted & soloed tracks                                                                       |        `ALT + NAV`         |       ![nav + alt + enter](image/pt-buttons-nav_alt.jpg)        |
 | cut the current cursor position if filled, paste otherwise                                            |       `ALT + ENTER`        |          ![arrow keys](image/pt-buttons-alt_enter.jpg)          |
-| Clone: Overwrite current highlighted Item with a copy of itself using the next unused Item available. |    `ALT + EDIT + ENTER`    | ![alt + edit + enter keys](image/pt-buttons-alt_edit_enter.jpg) |
+| Clone: Overwrite current highlighted Item with a copy of itself using the next unused Item available. |    `ALT + (EDIT, ENTER)`    | ![alt + edit + enter keys](image/pt-buttons-alt_edit_enter.jpg) |
 | start selection                                                                                       |       `ALT + EDIT `        |        ![edit + alt keys](image/pt-buttons-alt_edit.jpg)        |
 | start selection with row selected                                                                     |    `ALT + EDIT + EDIT`     |       ![edit + alt keys](image/pt-buttons-alt_edit2.jpg)        |
 | start selection with current screen selected                                                          | `ALT + EDIT + EDIT + EDIT` |       ![edit + alt keys](image/pt-buttons-alt_edit3.jpg)        |
@@ -126,7 +126,7 @@ Once a selection is started you can do a few more things:
 | Function               |    Key Combination    |                             Image                              |
 |:-----------------------|:---------------------:|:--------------------------------------------------------------:|
 | unmute all             |      `ALT + NAV`      |         ![alt + nav key](image/pt-buttons-nav_alt.jpg)         |
-| clone current position | ` ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current position | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
 | paste clipboard        |     `ALT + ENTER`     |       ![alt + enter key](image/pt-buttons-alt_enter.jpg)       |
 | start selection        |     `ALT + EDIT`      |        ![alt + edit key](image/pt-buttons-alt_edit.jpg)        |
 
@@ -137,7 +137,7 @@ Once a selection is started you can do a few more things:
 | warp to (previous / next) channel                                            |  `EDIT + (LEFT / RIGHT)`   | ![edit + horizontal arrow keys](image/pt-buttons-edit_leftright.jpg) |
 | warp to (previous / next) chain of current channel                           |    `EDIT + (UP / DOWN)`    |   ![edit + vertical arrow keys](image/pt-buttons-edit_updown.jpg)    |
 | cut current position into clipboard                                          |       `EDIT + ENTER`       |         ![edit + enter key](image/pt-buttons-edit_enter.jpg)         |
-| clone current position                                                       |    `EDIT + ALT + ENTER`    |    ![edit + alt + enter key](image/pt-buttons-alt_edit_enter.jpg)    |
+| clone current position                                                       |    `ALT + (EDIT, ENTER`    |    ![edit + alt + enter key](image/pt-buttons-alt_edit_enter.jpg)    |
 | toggle mute                                                                  |        `EDIT + NAV`        |           ![edit + nav key](image/pt-buttons-nav_edit.jpg)           |
 | start selection                                                              |        `ALT + EDIT`        |           ![alt + edit key](image/pt-buttons-alt_edit.jpg)           |
 | start selection with row selected                                            |    `ALT + EDIT + EDIT`     |       ![alt + edit twice keys](image/pt-buttons-alt_edit2.jpg)       |
@@ -205,8 +205,8 @@ Once a selection is started you can do a few more things:
 | unmute all                                                                      |     `ALT + NAV`      |         ![alt + nav key](image/pt-buttons-nav_alt.jpg)         |
 | paste clipboard                                                                 |    `ALT + ENTER`     |       ![alt + enter key](image/pt-buttons-alt_enter.jpg)       |
 | start selection                                                                 |     `ALT + EDIT`     |        ![alt + edit key](image/pt-buttons-alt_edit.jpg)        |
-| clone current instrument (cursor in note / instrument column)                   | `ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
-| clone current table (cursor in note / instrument column) (TODO: see issue #753) | `ALT + EDIT + ENTER` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current instrument (cursor in note / instrument column)                   | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
+| clone current table (cursor in note / instrument column) (TODO: see issue #753) | `ALT + (EDIT, ENTER)` | ![alt + edit + enter key](image/pt-buttons-alt_edit_enter.jpg) |
 
 ### EDIT Modifier
 
@@ -274,7 +274,7 @@ Once a selection is started you can do a few more things:
 | Previous/Next instrument (-1/+1)                                             | `EDIT + (LEFT / RIGHT)` | ![edit + (left / right) key](image/pt-buttons-edit_leftright.jpg) |
 | Previous/Next instrument (-16/+16)                                           |  `EDIT + (DOWN / UP)`   |       ![edit + down key](image/pt-buttons-edit_updown.jpg)        |
 | Cut/purge instrument (sample) or clear table                                 |     `EDIT + ENTER`      |       ![edit + enter key](image/pt-buttons-edit_enter.jpg)        |
-| clone current table                                                          |  `EDIT + ALT + ENTER`   |      ![edit + alt key](image/pt-buttons-alt_edit_enter.jpg)       |
+| clone current table                                                          |  `ALT + (EDIT, ENTER)`   |      ![edit + alt key](image/pt-buttons-alt_edit_enter.jpg)       |
 | \[advance only\] Sample recording, only accessible when sequencer is stopped |      `EDIT + PLAY`      |        ![edit + play keys](image/pt-buttons-edit_play.jpg)        |
 
 ## Import View

--- a/usermanual/pico-edition/content/pages/phrases.md
+++ b/usermanual/pico-edition/content/pages/phrases.md
@@ -16,7 +16,7 @@ template: page
   * parameters for FX2
 - You can use the all the [standard picoTrackerkey editing combos](keypadcombos.html) for editing on the phrase screen.
 - If you copy/cut anything in the phrase screen, pasting will always put the data back in the same column (regardless if you've moved the cursor to another column). This means effects in column one are always pasted back there, and you can't accidentally paste a note into the effect column, etc.
-- You can clone an instrument in the phrase screen by pressing `NAV`+`ENTER`,`EDIT` on instrument number in phrase screen. 
+- You can clone an instrument in the phrase screen by pressing `ALT + (EDIT, ENTER)` on instrument number in phrase screen. 
 - If no instrument is set when triggering a new note, tables are not stopped, running commands are not stopped and phase of oscillator instrument is not reset (allowing for clickless transitions)
 - In Song mode `Play` starts and stops playback from Step 00, soloing the current phrase
 - In Live mode `Play` queues the Edited Chain Step from 00


### PR DESCRIPTION
* fix key combo typos in getting-started & code comment
* fix typo in groove screen
* use consistent bracket notation for clone keycombo