### PR TITLE
Revert "Adds binary filename to sources/Adapter/picoTracker/main/CMakeLists.txt (#1018)"

### DIFF
--- a/sources/Adapters/picoTracker/main/CMakeLists.txt
+++ b/sources/Adapters/picoTracker/main/CMakeLists.txt
@@ -2,8 +2,6 @@ add_executable(picoTracker
   picoTrackerMain.cpp
 )
 
-set_target_properties(picoTracker PROPERTIES OUTPUT_NAME "picoTracker.elf")
-
 target_link_libraries(picoTracker PUBLIC
 
     # --- Platform-specific Adapter Libraries (Highest Level) ---


### PR DESCRIPTION
This reverts commit ffd7a96391a55a1962d8042711bba089d198ea15.

That commit broke CI by causing the file name of built files to end in elf.elf instead of .uf2
