### PR TITLE
Fix select, copy, paste etc ops on phrase screen

### DIFF
--- a/sources/Application/Views/PhraseView.cpp
+++ b/sources/Application/Views/PhraseView.cpp
@@ -878,8 +878,7 @@ void PhraseView::ProcessButtonMask(unsigned short mask, bool pressed) {
     }
   }
 
-  if ((viewMode_ == VM_CLONE) &&
-      !((mask & EPBM_ENTER) && (mask & EPBM_ALT))) {
+  if ((viewMode_ == VM_CLONE) && !((mask & EPBM_ENTER) && (mask & EPBM_ALT))) {
     viewMode_ = VM_SELECTION;
   }
 


### PR DESCRIPTION
Not sure how this happened, I suspect maybe got lost in a recent branch merge.

Fixes #1246