### PR TITLE
fix mic recordings to be mono wave files

### DIFF
--- a/sources/Adapters/adv/audio/record.cpp
+++ b/sources/Adapters/adv/audio/record.cpp
@@ -15,8 +15,8 @@ static FileHandle RecordFile;
 uint8_t *activeBuffer;
 uint8_t *writeBuffer;
 
-__attribute__((section(".FRAMEBUFFER")))
-__attribute__((aligned(32))) uint16_t recordBuffer[RECORD_BUFFER_SIZE];
+__attribute__((section(".FRAMEBUFFER"))) __attribute__((aligned(32)))
+uint16_t recordBuffer[RECORD_BUFFER_SIZE];
 // TODO (democloid): this is less than ideal, but works for now. we need to swap
 // the samples in the input buffer and since we also do the monitoring from it,
 // we cannot invert it in place (and we would have to also invert the monitoring


### PR DESCRIPTION
The reason for the lack of waveform from mic recordings was actually due to the mic recording being stereo with the right channel set to silence and the sample editor only uses the left channel for waveform display.

So the immediate fix here is to record mic to a mono wave file which the sampler already knows how to display correctly.

Tested as working and also line in recordings tested as still working in stereo.

Fixes: #1150 