### PR TITLE
whitelist views safe to be current view when autosave runs

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -1009,10 +1009,11 @@ bool AppWindow::AutoSave() {
   bool autosaveSafeView =
       _currentView == &views_->songView || _currentView == &views_->chainView ||
       _currentView == &views_->phraseView ||
-      _currentView == &views_->tableView || _currentView == &views_->grooveView ||
+      _currentView == &views_->tableView ||
+      _currentView == &views_->grooveView ||
       _currentView == &views_->instrumentView ||
-      _currentView == &views_->deviceView || _currentView == &views_->themeView || 
-      _currentView == &views_->mixerView;
+      _currentView == &views_->deviceView ||
+      _currentView == &views_->themeView || _currentView == &views_->mixerView;
   bool recording = IsRecordingActive();
   if (!player->IsRunning() && !recording && autosaveSafeView) {
     Trace::Log("APPWINDOW", "AutoSaving Project Data");


### PR DESCRIPTION
This creates a white list of screens that can be the current screen for autosave to run safely, if any other screen is the current screen autosave will not run and autosave will be deferred until the user navigates to one of the screens on the whitelist.


Fixes: #1250