### PR TITLE
Use etl string for preview playback filenames

### DIFF
--- a/sources/Application/Audio/AudioFileStreamer.cpp
+++ b/sources/Application/Audio/AudioFileStreamer.cpp
@@ -40,17 +40,23 @@ AudioFileStreamer::~AudioFileStreamer() { wav_.Close(); };
 
 bool AudioFileStreamer::Start(const char *name, int startSample, bool looping) {
   Trace::Debug("Starting to stream:%s from sample %d", name, startSample);
-  strcpy(name_, name);
+  if (!name) {
+    Trace::Error("AudioFileStreamer: null filename");
+    mode_ = AFSM_STOPPED;
+    return false;
+  }
+
+  name_ = name;
   position_ = (startSample > 0) ? float(startSample) : 0.0f;
 #ifndef ADV
   stopRequested_ = false;
 #endif
 
   wav_.Close();
-  Trace::Log("", "wave open:%s", name_);
-  auto res = wav_.Open(name_);
+  Trace::Log("", "wave open:%s", name_.c_str());
+  auto res = wav_.Open(name_.c_str());
   if (!res) {
-    Trace::Error("Failed to open streaming of file:%s", name_);
+    Trace::Error("Failed to open streaming of file:%s", name_.c_str());
     mode_ = AFSM_STOPPED;
     return false;
   }
@@ -89,7 +95,7 @@ bool AudioFileStreamer::Start(const char *name, int startSample, bool looping) {
   fpSpeed_ = fl2fp(ratio);
   Trace::Debug("AudioFileStreamer: File '%s' - Sample Rate: %d Hz, Channels: "
                "%d",
-               name_, fileSampleRate_, channels);
+               name_.c_str(), fileSampleRate_, channels);
   Trace::Debug("Size: %ld samples, Speed: %d", size, fp2i(fpSpeed_));
 
   // Load the entire buffer for single cycle waveforms
@@ -197,7 +203,7 @@ bool AudioFileStreamer::Render(fixed *buffer, int samplecount) {
   }
   // look if we have the file loaded
   if (!wav_.IsOpen()) {
-    Trace::Error("Failed to open streaming of file:%s", name_);
+    Trace::Error("Failed to open streaming of file:%s", name_.c_str());
     mode_ = AFSM_STOPPED;
     return false;
   }

--- a/sources/Application/Audio/AudioFileStreamer.h
+++ b/sources/Application/Audio/AudioFileStreamer.h
@@ -12,7 +12,9 @@
 
 #include "Application/Instruments/WavFile.h"
 #include "Application/Model/Project.h"
+#include "Externals/etl/include/etl/string.h"
 #include "Services/Audio/AudioModule.h"
+#include "System/FileSystem/FileSystem.h"
 
 #define SINGLE_CYCLE_MAX_SAMPLE_SIZE 600
 
@@ -30,7 +32,7 @@ public:
 
 protected:
   AudioFileStreamerMode mode_;
-  char name_[256];
+  etl::string<PFILENAME_SIZE - 1> name_;
   WavFile wav_;
   float position_;
   Project *project_;


### PR DESCRIPTION
Actually turns out we no longer need to do any warning per #598 because we now are able to handle preview playback of filenames upto the 255 FAT filename limit so this PR just does some cleanup to use etl string instead of c char buffers.

Fixes: #598