### PR TITLE
Dont clear dirty flag in process button

### DIFF
--- a/sources/Application/Views/BaseClasses/View.cpp
+++ b/sources/Application/Views/BaseClasses/View.cpp
@@ -44,8 +44,9 @@ bool View::batteryDisplayInitialized_ = false;
 
 View::View(GUIWindow &w, ViewData *viewData)
     : w_(w), viewData_(viewData), needsRedraw_(false), isVisible_(true),
-      vuMeterCount_(0), viewMode_(VM_NORMAL), isDirty_(true), viewType_(VT_SONG),
-      hasFocus_(false), powerButtonPressed_(false), powerButtonHoldCount_(0) {
+      vuMeterCount_(0), viewMode_(VM_NORMAL), isDirty_(true),
+      viewType_(VT_SONG), hasFocus_(false), powerButtonPressed_(false),
+      powerButtonHoldCount_(0) {
   if (!initPrivate_) {
     View::margin_ = 0;
     songRowCount_ = 16;


### PR DESCRIPTION
Clearing the dirty flag in ProcessButton could cause a race condition for redraw in AnimationUpdate() while still drawing the battery widget per:

```
1. A view switch sets the new view dirty and clears the screen in AppWindow::Update(...) (sources/Application/AppWindow.cpp:888, sources/Application/AppWindow.cpp:889, sources/Application/
     AppWindow.cpp:890, sources/Application/AppWindow.cpp:891).
  2. Before the next AnimationUpdate() tick, a key release event can arrive (ET_PADBUTTONUP) and is routed to the new current view (sources/Application/AppWindow.cpp:623, sources/Application/
     AppWindow.cpp:627).
  3. View::ProcessButton() unconditionally clears isDirty_ at the start (sources/Application/Views/BaseClasses/View.cpp:356, sources/Application/Views/BaseClasses/View.cpp:357), even on button-up events
     that often do no work.
  4. AppWindow::AnimationUpdate() then skips _currentView->Redraw() because dirty is now false (sources/Application/AppWindow.cpp:768, sources/Application/AppWindow.cpp:769), but still calls
     _currentView->AnimationUpdate() (sources/Application/AppWindow.cpp:774, sources/Application/AppWindow.cpp:777).
  5. ScreenView::AnimationUpdate() always draws battery/power overlay (sources/Application/Views/ScreenView.cpp:20), so you see “battery indicator only” on an otherwise blank screen.
```

Also make sure all view fields are correctly initialised.

Fixes: #1257