### PR TITLE
Advance fix low bat workflow

### DIFF
--- a/sources/Adapters/adv/system/advSystem.cpp
+++ b/sources/Adapters/adv/system/advSystem.cpp
@@ -32,9 +32,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#define ONBOOT_MINIMUM_ALLOWED_BATTERY_PERCENTAGE 3
-#define DISPLAY_LOWBATT_DELAY_IN_SEC 5
-
 EventManager *advSystem::eventManager_ = NULL;
 bool advSystem::invert_ = false;
 int advSystem::lastBattLevel_ = 100;
@@ -132,18 +129,7 @@ void advSystem::Boot() {
 
   // Configure the battery fuel gauge - will only update if ITPOR bit is set
   configureBatteryGauge();
-
-  // check for low batt
-  BatteryState batteryState;
-  System::GetInstance()->GetBatteryState(batteryState);
-  if (batteryState.percentage < ONBOOT_MINIMUM_ALLOWED_BATTERY_PERCENTAGE &&
-      !batteryState.charging) {
-    // show low battery message on screen
-    Trace::Log("PICOTRACKERSYSTEM", "Low Batt: %d%%\n",
-               batteryState.percentage);
-    critical_error_message("!! LOW BATTERY !!", 0x01,
-                           DISPLAY_LOWBATT_DELAY_IN_SEC, false);
-  }
+  configureCharger();
 
   eventManager_ = I_GUIWindowFactory::GetInstance()->GetEventManager();
   eventManager_->Init();

--- a/sources/Adapters/adv/system/charger.cpp
+++ b/sources/Adapters/adv/system/charger.cpp
@@ -251,3 +251,26 @@ bool stopCharging(void) {
   }
   return true;
 }
+
+void configureCharger(void) {
+  uint8_t reg_value = 0;
+  HAL_StatusTypeDef status =
+      HAL_I2C_Mem_Read(&hi2c4, BQ25601_I2C_ADDR << 1, BQ25601_STATUS_REG,
+                       I2C_MEMADD_SIZE_8BIT, &reg_value, 1, HAL_MAX_DELAY);
+  if (status != HAL_OK) {
+    Trace::Error("Power status read failed: %i", status);
+    return;
+  }
+
+  bool powerPresent = (reg_value & BQ25601_PG_STAT) != 0;
+
+  if (powerPresent) {
+    if (!startCharging()) {
+      Trace::Error("Failed to enable charging during init");
+    }
+  } else {
+    if (!stopCharging()) {
+      Trace::Error("Failed to disable charging during init");
+    }
+  }
+}

--- a/sources/Adapters/adv/system/charger.h
+++ b/sources/Adapters/adv/system/charger.h
@@ -15,6 +15,7 @@ extern "C" {
 bool startCharging(void);
 bool stopCharging(void);
 void powerOff();
+void configureCharger(void);
 
 typedef enum {
   NOT_CHARGING,


### PR DESCRIPTION
When device was shutdown due to low batt, it then booted into a state where the state wasn't restored correctly for the charger to be enabled before shutdown, which would lead to a device that wouldn't charge (could always recover going to the bootloader)

This does a couple of things:
1. Configure the charger on first load by checking if power is connected
2. Removed the "critcal error message" usage on boot. This wasn't the right dialog to use because it didn't offer a restoration option (if VBUS was replugged for example)
3. Current workflow uses the system low battery message to go back to sleep if necessary. Only issue with this is that the project has to fully load before this check kicking in. It shouldn't be a big issue generally, we can improve this later.