### PR TITLE
Instrument ram cleanup

### DIFF
--- a/sources/Application/Instruments/I_Instrument.cpp
+++ b/sources/Application/Instruments/I_Instrument.cpp
@@ -31,7 +31,7 @@ void I_Instrument::SaveContent(tinyxml2::XMLPrinter *printer) {
   }
 
   // Save all the instrument's parameters
-  for (auto it = Variables()->begin(); it != Variables()->end(); it++) {
+  for (auto it = VarBegin(); it != VarEnd(); it++) {
     printer->OpenElement("PARAM");
     printer->PushAttribute("NAME", (*it)->GetName());
     printer->PushAttribute("VALUE", (*it)->GetString().c_str());
@@ -83,7 +83,7 @@ void I_Instrument::RestoreContent(PersistencyDocument *doc) {
         bool found = false;
 
         // Find the variable with this name and set its value
-        for (auto it = Variables()->begin(); it != Variables()->end(); it++) {
+        for (auto it = VarBegin(); it != VarEnd(); it++) {
           if (!strcasecmp((*it)->GetName(), name)) {
             (*it)->SetString(value);
             // Trace::Log("I_INSTRUMENT", "Set parameter: %s = %s", name,
@@ -114,7 +114,7 @@ void I_Instrument::RestoreContent(PersistencyDocument *doc) {
 }
 
 void I_Instrument::Purge() {
-  for (auto it = Variables()->begin(); it != Variables()->end(); it++) {
+  for (auto it = VarBegin(); it != VarEnd(); it++) {
     (*it)->Reset();
   }
 };

--- a/sources/Application/Instruments/I_Instrument.h
+++ b/sources/Application/Instruments/I_Instrument.h
@@ -37,10 +37,10 @@ protected:
   etl::string<MAX_INSTRUMENT_NAME_LENGTH> name_;
 
 public:
-  I_Instrument(etl::ilist<Variable *> *list,
+  I_Instrument(Variable **begin, Variable **end,
                const char *nodeName = "INSTRUMENT",
                bool registerWithPersistence = false)
-      : VariableContainer(list),
+      : VariableContainer(begin, end),
         Persistent(nodeName, registerWithPersistence){};
   virtual ~I_Instrument();
 
@@ -113,7 +113,6 @@ public:
 
   virtual void GetTableState(TableSaveState &state) = 0;
   virtual void SetTableState(TableSaveState &state) = 0;
-  virtual etl::ilist<Variable *> *Variables() = 0;
 
   // Persistent implementation
   virtual void SaveContent(tinyxml2::XMLPrinter *printer) override;

--- a/sources/Application/Instruments/InstrumentBank.cpp
+++ b/sources/Application/Instruments/InstrumentBank.cpp
@@ -252,8 +252,7 @@ unsigned short InstrumentBank::Clone(unsigned short i) {
     return NO_MORE_INSTRUMENT;
   }
 
-  for (auto it = src->Variables()->begin(); it != src->Variables()->end();
-       it++) {
+  for (auto it = src->VarBegin(); it != src->VarEnd(); it++) {
     Variable *dstV = dst->FindVariable((*it)->GetID());
     if (dstV) {
       dstV->CopyFrom(**it);

--- a/sources/Application/Instruments/MacroInstrument.cpp
+++ b/sources/Application/Instruments/MacroInstrument.cpp
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 MacroInstrument::MacroInstrument()
-    : I_Instrument(&variables_),
+    : I_Instrument(variables_.begin(), variables_.end()),
       shape_(FourCC::MacroInstrumentShape, braids::algo_values,
              braids::MACRO_OSC_SHAPE_LAST - 2, 0),
       timbre_(FourCC::MacroInstrmentTimbre, 0x7f),
@@ -32,12 +32,12 @@ MacroInstrument::MacroInstrument()
 
   running_ = false;
 
-  variables_.insert(variables_.end(), &shape_);
-  variables_.insert(variables_.end(), &timbre_);
-  variables_.insert(variables_.end(), &color_);
-  variables_.insert(variables_.end(), &attack_);
-  variables_.insert(variables_.end(), &decay_);
-  variables_.insert(variables_.end(), &signature_);
+  variables_[0] = &shape_;
+  variables_[1] = &timbre_;
+  variables_[2] = &color_;
+  variables_[3] = &attack_;
+  variables_[4] = &decay_;
+  variables_[5] = &signature_;
 }
 
 MacroInstrument::~MacroInstrument() {}

--- a/sources/Application/Instruments/MacroInstrument.h
+++ b/sources/Application/Instruments/MacroInstrument.h
@@ -17,6 +17,7 @@
 #include "Externals/braids/quantizer.h"
 #include "Externals/braids/signature_waveshaper.h"
 #include "Externals/braids/vco_jitter_source.h"
+#include "Externals/etl/include/etl/array.h"
 #include "Foundation/Observable.h"
 #include "Foundation/Types/Types.h"
 #include "Foundation/Variables/WatchedVariable.h"
@@ -42,7 +43,6 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
 
   // Engine playback  start callback
   virtual void OnStart();
@@ -52,7 +52,7 @@ public:
 
 protected:
 private:
-  etl::list<Variable *, 7> variables_;
+  etl::array<Variable *, 6> variables_;
 
   bool running_;
 

--- a/sources/Application/Instruments/MidiInstrument.cpp
+++ b/sources/Application/Instruments/MidiInstrument.cpp
@@ -22,7 +22,8 @@ TimerService *MidiInstrument::timerSvc_ = 0;
 MidiInstrument::NoteOffInfo MidiInstrument::NoteOffInfo::current = {0, 0};
 
 MidiInstrument::MidiInstrument()
-    : I_Instrument(&variables_), channel_(FourCC::MidiInstrumentChannel, 0),
+    : I_Instrument(variables_.begin(), variables_.end()),
+      channel_(FourCC::MidiInstrumentChannel, 0),
       noteLen_(FourCC::MidiInstrumentNoteLength, 0),
       volume_(FourCC::MidiInstrumentVolume, 255),
       table_(FourCC::MidiInstrumentTable, VAR_OFF),
@@ -38,12 +39,12 @@ MidiInstrument::MidiInstrument()
   };
 
   // name_ is now an etl::string in the base class, not a Variable
-  variables_.insert(variables_.end(), &channel_);
-  variables_.insert(variables_.end(), &noteLen_);
-  variables_.insert(variables_.end(), &volume_);
-  variables_.insert(variables_.end(), &table_);
-  variables_.insert(variables_.end(), &tableAuto_);
-  variables_.insert(variables_.end(), &program_);
+  variables_[0] = &channel_;
+  variables_[1] = &noteLen_;
+  variables_[2] = &volume_;
+  variables_[3] = &table_;
+  variables_[4] = &tableAuto_;
+  variables_[5] = &program_;
 }
 
 MidiInstrument::~MidiInstrument(){};

--- a/sources/Application/Instruments/MidiInstrument.h
+++ b/sources/Application/Instruments/MidiInstrument.h
@@ -12,6 +12,7 @@
 
 #include "Application/Model/Song.h"
 #include "Application/Persistency/PersistenceConstants.h"
+#include "Externals/etl/include/etl/array.h"
 #include "Externals/etl/include/etl/string.h"
 #include "I_Instrument.h"
 #include "Services/Midi/MidiMessage.h"
@@ -61,7 +62,6 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
 
   void SetChannel(int i);
   void SendProgramChange(int channel, int program);
@@ -78,7 +78,7 @@ public:
   };
 
 private:
-  etl::list<Variable *, 7> variables_;
+  etl::array<Variable *, 6> variables_;
 
   etl::array<uint8_t, MAX_MIDI_CHORD_NOTES + 1> lastNotes_[SONG_CHANNEL_COUNT];
   int remainingTicks_;

--- a/sources/Application/Instruments/NoneInstrument.cpp
+++ b/sources/Application/Instruments/NoneInstrument.cpp
@@ -11,7 +11,7 @@
 #include "Application/Persistency/PersistenceConstants.h"
 #include "Externals/etl/include/etl/string.h"
 
-NoneInstrument::NoneInstrument() : I_Instrument(&variables_) {}
+NoneInstrument::NoneInstrument() : I_Instrument(nullptr, nullptr) {}
 
 NoneInstrument::~NoneInstrument(){};
 

--- a/sources/Application/Instruments/NoneInstrument.h
+++ b/sources/Application/Instruments/NoneInstrument.h
@@ -45,9 +45,7 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
 
 private:
-  etl::list<Variable *, 2> variables_;
 };
 #endif

--- a/sources/Application/Instruments/OpalInstrument.cpp
+++ b/sources/Application/Instruments/OpalInstrument.cpp
@@ -32,7 +32,7 @@ static const unsigned int noteFNumbers[] = {342, 363, 385, 408, 432, 458,
                                             485, 514, 544, 577, 611, 647};
 
 OpalInstrument::OpalInstrument()
-    : I_Instrument(&variables_),
+    : I_Instrument(variables_.begin(), variables_.end()),
       algorithm_(FourCC::OPALInstrumentAlgorithm, algorithms, 6, 0),
       feedback_(FourCC::OPALInstrumentFeedback, 0),
       deepTremeloVibrato_(FourCC::OPALInstrumentDeepTremeloVibrato, 0),
@@ -52,21 +52,21 @@ OpalInstrument::OpalInstrument()
                         0) {
 
   // name_ is now an etl::string in the base class, not a Variable
-  variables_.insert(variables_.end(), &algorithm_);
-  variables_.insert(variables_.end(), &feedback_);
-  variables_.insert(variables_.end(), &deepTremeloVibrato_);
-  variables_.insert(variables_.end(), &op1Level_);
-  variables_.insert(variables_.end(), &op1Multiplier_);
-  variables_.insert(variables_.end(), &op1ADSR_);
-  variables_.insert(variables_.end(), &op1WaveShape_);
-  variables_.insert(variables_.end(), &op1KeyScaleLevel_);
-  variables_.insert(variables_.end(), &op1TremVibSusKSR_);
-  variables_.insert(variables_.end(), &op2Level_);
-  variables_.insert(variables_.end(), &op2Multiplier_);
-  variables_.insert(variables_.end(), &op2ADSR_);
-  variables_.insert(variables_.end(), &op2WaveShape_);
-  variables_.insert(variables_.end(), &op2KeyScaleLevel_);
-  variables_.insert(variables_.end(), &op2TremVibSusKSR_);
+  variables_[0] = &algorithm_;
+  variables_[1] = &feedback_;
+  variables_[2] = &deepTremeloVibrato_;
+  variables_[3] = &op1Level_;
+  variables_[4] = &op1Multiplier_;
+  variables_[5] = &op1ADSR_;
+  variables_[6] = &op1WaveShape_;
+  variables_[7] = &op1KeyScaleLevel_;
+  variables_[8] = &op1TremVibSusKSR_;
+  variables_[9] = &op2Level_;
+  variables_[10] = &op2Multiplier_;
+  variables_[11] = &op2ADSR_;
+  variables_[12] = &op2WaveShape_;
+  variables_[13] = &op2KeyScaleLevel_;
+  variables_[14] = &op2TremVibSusKSR_;
 }
 
 OpalInstrument::~OpalInstrument(){};

--- a/sources/Application/Instruments/OpalInstrument.h
+++ b/sources/Application/Instruments/OpalInstrument.h
@@ -12,6 +12,7 @@
 
 #include "Application/Model/Song.h"
 #include "Application/Persistency/PersistenceConstants.h"
+#include "Externals/etl/include/etl/array.h"
 #include "Externals/opal/opal.h"
 #include "I_Instrument.h"
 #include <cstdint>
@@ -47,7 +48,6 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
 
   void setChannel(uint8_t channel);
 
@@ -56,7 +56,7 @@ private:
 
   uint8_t breg;
 
-  etl::list<Variable *, 16> variables_;
+  etl::array<Variable *, 15> variables_;
 
   Variable algorithm_;
   Variable feedback_;

--- a/sources/Application/Instruments/SIDInstrument.cpp
+++ b/sources/Application/Instruments/SIDInstrument.cpp
@@ -47,7 +47,7 @@ Variable SIDInstrument::fltmode2_(FourCC::SIDInstrument2FilterMode,
 Variable SIDInstrument::vol2_(FourCC::SIDInstrument2Volume, 0xF);
 
 SIDInstrument::SIDInstrument(SIDInstrumentInstance chip)
-    : I_Instrument(&variables_), chip_(chip),
+    : I_Instrument(variables_.begin(), variables_.end()), chip_(chip),
       vpw_(FourCC::SIDInstrumentPulseWidth, 0x800),
       vwf_(FourCC::SIDInstrumentWaveform, sidWaveformText, DWF_LAST, 0x1),
       vsync_(FourCC::SIDInstrumentVSync, false),
@@ -59,24 +59,24 @@ SIDInstrument::SIDInstrument(SIDInstrumentInstance chip)
       osc_(FourCC::SIDInstrumentOSCNumber, 0) {
 
   // name_ is now an etl::string in the base class, not a Variable
-  variables_.insert(variables_.end(), &vpw_);
-  variables_.insert(variables_.end(), &vwf_);
-  variables_.insert(variables_.end(), &vsync_);
-  variables_.insert(variables_.end(), &vring_);
-  variables_.insert(variables_.end(), &vadsr_);
-  variables_.insert(variables_.end(), &vfon_);
-  variables_.insert(variables_.end(), &table_);
-  variables_.insert(variables_.end(), &tableAuto_);
-  variables_.insert(variables_.end(), &osc_);
-  variables_.insert(variables_.end(), &fltcut1_);
-  variables_.insert(variables_.end(), &fltres1_);
-  variables_.insert(variables_.end(), &fltmode1_);
-  variables_.insert(variables_.end(), &vol1_);
+  variables_[0] = &vpw_;
+  variables_[1] = &vwf_;
+  variables_[2] = &vsync_;
+  variables_[3] = &vring_;
+  variables_[4] = &vadsr_;
+  variables_[5] = &vfon_;
+  variables_[6] = &table_;
+  variables_[7] = &tableAuto_;
+  variables_[8] = &osc_;
+  variables_[9] = &fltcut1_;
+  variables_[10] = &fltres1_;
+  variables_[11] = &fltmode1_;
+  variables_[12] = &vol1_;
 
-  variables_.insert(variables_.end(), &fltcut2_);
-  variables_.insert(variables_.end(), &fltres2_);
-  variables_.insert(variables_.end(), &fltmode2_);
-  variables_.insert(variables_.end(), &vol2_);
+  variables_[13] = &fltcut2_;
+  variables_[14] = &fltres2_;
+  variables_[15] = &fltmode2_;
+  variables_[16] = &vol2_;
 }
 
 SIDInstrument::~SIDInstrument(){};

--- a/sources/Application/Instruments/SIDInstrument.h
+++ b/sources/Application/Instruments/SIDInstrument.h
@@ -12,6 +12,7 @@
 
 #include "Application/Persistency/PersistenceConstants.h"
 #include "Externals/cRSID/SID.h"
+#include "Externals/etl/include/etl/array.h"
 #include "I_Instrument.h"
 
 enum SIDInstrumentInstance { SID1 = 1, SID2 };
@@ -82,7 +83,6 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
 
   SIDInstrumentInstance GetChip() { return chip_; };
   unsigned short GetOsc() { return osc_.GetInt(); };
@@ -92,7 +92,7 @@ public:
   const char *GetChipName() { return (chip_ == SID1) ? "SID #1" : "SID #2"; };
 
 private:
-  etl::list<Variable *, 19> variables_;
+  etl::array<Variable *, 17> variables_;
 
   SIDInstrumentInstance chip_; // SID1 or SID2
   bool render_ = false;

--- a/sources/Application/Instruments/SampleInstrument.cpp
+++ b/sources/Application/Instruments/SampleInstrument.cpp
@@ -42,7 +42,8 @@ signed char SampleInstrument::lastMidiNote_[SONG_CHANNEL_COUNT];
 #define KRATE_SAMPLE_COUNT 100
 
 SampleInstrument::SampleInstrument()
-    : I_Instrument(&variables_), sample_(FourCC::SampleInstrumentSample),
+    : I_Instrument(variables_.begin(), variables_.end()),
+      sample_(FourCC::SampleInstrumentSample),
       volume_(FourCC::SampleInstrumentVolume, 0x80),
       interpolation_(FourCC::SampleInstrumentInterpolation, interpolationTypes,
                      2, 0),
@@ -75,31 +76,31 @@ SampleInstrument::SampleInstrument()
 
   // Initialize exported variables
   // name_ is now an etl::string in the base class, not a Variable
-  variables_.insert(variables_.end(), &sample_);
+  variables_[0] = &sample_;
   sample_.AddObserver(*this);
 
-  variables_.insert(variables_.end(), &volume_);
-  variables_.insert(variables_.end(), &interpolation_);
-  variables_.insert(variables_.end(), &crush_);
-  variables_.insert(variables_.end(), &drive_);
-  variables_.insert(variables_.end(), &downsample_);
-  variables_.insert(variables_.end(), &rootNote_);
-  variables_.insert(variables_.end(), &fineTune_);
-  variables_.insert(variables_.end(), &pan_);
-  variables_.insert(variables_.end(), &cutoff_);
-  variables_.insert(variables_.end(), &reso_);
-  variables_.insert(variables_.end(), &filterMix_);
-  variables_.insert(variables_.end(), &filterMode_);
-  variables_.insert(variables_.end(), &start_);
+  variables_[1] = &volume_;
+  variables_[2] = &interpolation_;
+  variables_[3] = &crush_;
+  variables_[4] = &drive_;
+  variables_[5] = &downsample_;
+  variables_[6] = &rootNote_;
+  variables_[7] = &fineTune_;
+  variables_[8] = &pan_;
+  variables_[9] = &cutoff_;
+  variables_[10] = &reso_;
+  variables_[11] = &filterMix_;
+  variables_[12] = &filterMode_;
+  variables_[13] = &start_;
   start_.AddObserver(*this);
-  variables_.insert(variables_.end(), &loopMode_);
+  variables_[14] = &loopMode_;
   loopMode_.SetInt(0);
-  variables_.insert(variables_.end(), &loopStart_);
+  variables_[15] = &loopStart_;
   loopStart_.AddObserver(*this);
-  variables_.insert(variables_.end(), &loopEnd_);
+  variables_[16] = &loopEnd_;
   loopEnd_.AddObserver(*this);
-  variables_.insert(variables_.end(), &table_);
-  variables_.insert(variables_.end(), &tableAuto_);
+  variables_[17] = &table_;
+  variables_[18] = &tableAuto_;
 
   tableState_.Reset();
   slicePoints_.fill(0);
@@ -1540,7 +1541,7 @@ void SampleInstrument::RestoreContent(PersistencyDocument *doc) {
         setSliceFromString(name.c_str() + 2, value.c_str());
       } else {
         bool found = false;
-        for (auto it = Variables()->begin(); it != Variables()->end(); it++) {
+        for (auto it = VarBegin(); it != VarEnd(); it++) {
           if (!strcasecmp((*it)->GetName(), name.c_str())) {
             (*it)->SetString(value.c_str());
             found = true;

--- a/sources/Application/Instruments/SampleInstrument.h
+++ b/sources/Application/Instruments/SampleInstrument.h
@@ -53,7 +53,7 @@ public:
   virtual bool GetTableAutomation();
   virtual void GetTableState(TableSaveState &state);
   virtual void SetTableState(TableSaveState &state);
-  etl::ilist<Variable *> *Variables() { return &variables_; };
+  etl::array<Variable *, 19> *Variables() = delete;
 
   bool IsMulti();
 
@@ -101,7 +101,7 @@ protected:
   void doKRateUpdate(int channel);
 
 private:
-  etl::list<Variable *, 21> variables_;
+  etl::array<Variable *, 19> variables_;
 
   SoundSource *source_;
   __attribute__((section(".DTCMRAM"))) static struct renderParams

--- a/sources/Application/Instruments/SampleVariable.cpp
+++ b/sources/Application/Instruments/SampleVariable.cpp
@@ -12,7 +12,7 @@
 
 SampleVariable::SampleVariable(FourCC id) : WatchedVariable(id, 0, 0, -1) {
   SamplePool *pool = SamplePool::GetInstance();
-  list_.char_ = pool->GetNameList();
+  list_ = pool->GetNameList();
   listSize_ = pool->GetNameListSize();
   pool->AddObserver(*this);
 };
@@ -43,6 +43,6 @@ void SampleVariable::Update(Observable &o, I_ObservableData *d) {
   // For inserts, just refresh list pointers below
   // indices remain valid since imports append at the end
   SamplePool *pool = (SamplePool *)&o;
-  list_.char_ = pool->GetNameList();
+  list_ = pool->GetNameList();
   listSize_ = pool->GetNameListSize();
 };

--- a/sources/Application/Model/Config.cpp
+++ b/sources/Application/Model/Config.cpp
@@ -247,7 +247,7 @@ static const ConfigParam configParams[] = {
 };
 
 Config::Config()
-    : VariableContainer(&variables_),
+    : VariableContainer(variables_.begin(), variables_.end()),
       background_(FourCC::VarBGColor,
                   static_cast<int>(ThemeConstants::DEFAULT_BACKGROUND)),
       foreground_(FourCC::VarFGColor,
@@ -287,30 +287,30 @@ Config::Config()
       recordLineGain_(FourCC::VarRecordLineGain, DEFAULT_RECORD_LINE_GAIN_DB),
       recordMicGain_(FourCC::VarRecordMicGain, DEFAULT_RECORD_MIC_GAIN_DB) {
 
-  variables_.push_back(&background_);
-  variables_.push_back(&foreground_);
-  variables_.push_back(&hiColor1_);
-  variables_.push_back(&hiColor2_);
-  variables_.push_back(&consoleColor_);
-  variables_.push_back(&cursorColor_);
-  variables_.push_back(&infoColor_);
-  variables_.push_back(&warnColor_);
-  variables_.push_back(&errorColor_);
-  variables_.push_back(&accentColor_);
-  variables_.push_back(&accentAltColor_);
-  variables_.push_back(&emphasisColor_);
-  variables_.push_back(&lineOut_);
-  variables_.push_back(&midiDevice_);
-  variables_.push_back(&midiSync_);
-  variables_.push_back(&remoteUI_);
-  variables_.push_back(&importResampler_);
-  variables_.push_back(&uiFont_);
-  variables_.push_back(&themeName_);
-  variables_.push_back(&backlightLevel_);
-  variables_.push_back(&outputVolume_);
-  variables_.push_back(&recordSource_);
-  variables_.push_back(&recordLineGain_);
-  variables_.push_back(&recordMicGain_);
+  variables_[0] = &background_;
+  variables_[1] = &foreground_;
+  variables_[2] = &hiColor1_;
+  variables_[3] = &hiColor2_;
+  variables_[4] = &consoleColor_;
+  variables_[5] = &cursorColor_;
+  variables_[6] = &infoColor_;
+  variables_[7] = &warnColor_;
+  variables_[8] = &errorColor_;
+  variables_[9] = &accentColor_;
+  variables_[10] = &accentAltColor_;
+  variables_[11] = &emphasisColor_;
+  variables_[12] = &lineOut_;
+  variables_[13] = &midiDevice_;
+  variables_[14] = &midiSync_;
+  variables_[15] = &remoteUI_;
+  variables_[16] = &importResampler_;
+  variables_[17] = &uiFont_;
+  variables_[18] = &themeName_;
+  variables_[19] = &backlightLevel_;
+  variables_[20] = &outputVolume_;
+  variables_[21] = &recordSource_;
+  variables_[22] = &recordLineGain_;
+  variables_[23] = &recordMicGain_;
 
   PersistencyDocument doc;
 

--- a/sources/Application/Model/Config.h
+++ b/sources/Application/Model/Config.h
@@ -11,6 +11,7 @@
 #define _CONFIG_H_
 
 #include "Application/Persistency/Persistent.h"
+#include "Externals/etl/include/etl/array.h"
 #include "Foundation/T_Singleton.h"
 #include "Foundation/Variables/StringVariable.h"
 #include "Foundation/Variables/VariableContainer.h"
@@ -36,7 +37,7 @@ public:
   bool ImportTheme(const char *themeName);
 
 private:
-  etl::list<Variable *, 26> variables_;
+  etl::array<Variable *, 24> variables_;
   // Config variables (kept as members to avoid heap allocation)
   WatchedVariable background_;
   WatchedVariable foreground_;

--- a/sources/Application/Model/Project.cpp
+++ b/sources/Application/Model/Project.cpp
@@ -35,7 +35,7 @@
 #define DATA_UNUSED_VALUE 0xFF
 
 Project::Project(const char *name)
-    : Persistent("PROJECT"), VariableContainer(&variables_), song_(),
+    : Persistent("PROJECT"), VariableContainer(variables_.begin(), variables_.end()), song_(),
       tempoNudge_(0), tempo_(FourCC::VarTempo, DEFAULT_TEMPO),
       masterVolume_(FourCC::VarMasterVolume, DEFAULT_MASTER_VOLUME),
       channelVolume1_(FourCC::VarChannel1Volume, DEFAULT_CHANNEL_VOLUME),
@@ -52,27 +52,27 @@ Project::Project(const char *name)
       projectName_(FourCC::VarProjectName, name),
       previewVolume_(FourCC::VarPreviewVolume, DEFAULT_PREVIEW_VOLUME) {
 
-  this->variables_.insert(variables_.end(), &tempo_);
-  this->variables_.insert(variables_.end(), &masterVolume_);
+  variables_[0] = &tempo_;
+  variables_[1] = &masterVolume_;
 
   // Add individual channel volume variables to the container
-  this->variables_.insert(variables_.end(), &channelVolume1_);
-  this->variables_.insert(variables_.end(), &channelVolume2_);
-  this->variables_.insert(variables_.end(), &channelVolume3_);
-  this->variables_.insert(variables_.end(), &channelVolume4_);
-  this->variables_.insert(variables_.end(), &channelVolume5_);
-  this->variables_.insert(variables_.end(), &channelVolume6_);
-  this->variables_.insert(variables_.end(), &channelVolume7_);
-  this->variables_.insert(variables_.end(), &channelVolume8_);
+  variables_[2] = &channelVolume1_;
+  variables_[3] = &channelVolume2_;
+  variables_[4] = &channelVolume3_;
+  variables_[5] = &channelVolume4_;
+  variables_[6] = &channelVolume5_;
+  variables_[7] = &channelVolume6_;
+  variables_[8] = &channelVolume7_;
+  variables_[9] = &channelVolume8_;
 
-  this->variables_.insert(variables_.end(), &wrap_);
-  this->variables_.insert(variables_.end(), &transpose_);
-  this->variables_.insert(variables_.end(), &scale_);
+  variables_[10] = &wrap_;
+  variables_[11] = &transpose_;
+  variables_[12] = &scale_;
   scale_.SetInt(0);
-  this->variables_.insert(variables_.end(), &scaleRoot_);
+  variables_[13] = &scaleRoot_;
   scaleRoot_.SetInt(0); // Default to C (0)
-  this->variables_.insert(variables_.end(), &projectName_);
-  this->variables_.insert(variables_.end(), &previewVolume_);
+  variables_[14] = &projectName_;
+  variables_[15] = &previewVolume_;
 
   // Project name is now managed through the WatchedVariable
 

--- a/sources/Application/Model/Project.h
+++ b/sources/Application/Model/Project.h
@@ -14,6 +14,7 @@
 #include "Application/Persistency/PersistencyService.h"
 #include "Application/Persistency/Persistent.h"
 #include "BuildNumber.h"
+#include "Externals/etl/include/etl/array.h"
 #include "Foundation/Observable.h"
 #include "Foundation/Types/Types.h"
 #include "Foundation/Variables/StringVariable.h"
@@ -67,7 +68,7 @@ public:
   virtual void RestoreContent(PersistencyDocument *doc);
 
 private:
-  etl::list<Variable *, 16> variables_;
+  etl::array<Variable *, 16> variables_;
 
   InstrumentBank instrumentBank_;
   int tempoNudge_;

--- a/sources/Application/Views/FieldView.h
+++ b/sources/Application/Views/FieldView.h
@@ -11,6 +11,7 @@
 #define _FIELD_VIEW_H_
 
 #include "BaseClasses/UIField.h"
+#include "Externals/etl/include/etl/list.h"
 #include "ScreenView.h"
 
 class FieldView : public ScreenView {

--- a/sources/Application/Views/InstrumentView.cpp
+++ b/sources/Application/Views/InstrumentView.cpp
@@ -1174,13 +1174,11 @@ bool InstrumentView::checkInstrumentModified() {
   }
 
   // Get the list of variables for this instrument
-  etl::ilist<Variable *> *variables = instrument->Variables();
-  if (!variables) {
-    return false;
-  }
+  Variable **begin = instrument->VarBegin();
+  Variable **end = instrument->VarEnd();
 
   // Check if any variable has been modified from its default value
-  for (auto it = variables->begin(); it != variables->end(); ++it) {
+  for (auto it = begin; it != end; ++it) {
     Variable *var = *it;
     if (var && var->IsModified()) {
       return true;
@@ -1198,14 +1196,8 @@ void InstrumentView::resetInstrumentToDefaults() {
     return;
   }
 
-  // Get the list of variables for this instrument
-  etl::ilist<Variable *> *variables = instrument->Variables();
-  if (!variables) {
-    return;
-  }
-
   // Reset all variables to their default values
-  for (auto it = variables->begin(); it != variables->end(); ++it) {
+  for (auto it = instrument->VarBegin(); it != instrument->VarEnd(); ++it) {
     Variable *var = *it;
     if (var) {
       var->Reset();

--- a/sources/Foundation/Variables/Variable.cpp
+++ b/sources/Foundation/Variables/Variable.cpp
@@ -36,7 +36,7 @@ Variable::Variable(FourCC id, bool value) : id_(id) {
 
 Variable::Variable(FourCC id, const char *const *list, int size, int index)
     : id_(id) {
-  list_.char_ = list;
+  list_ = list;
   listSize_ = size;
   value_.index_ = index;
   defaultValue_.index_ = index;
@@ -190,8 +190,8 @@ void Variable::SetString(const char *string, bool notify) {
   case CHAR_LIST:
     value_.index_ = -1;
     for (int i = 0; i < listSize_; i++) {
-      if (list_.char_[i]) {
-        if (strcasecmp(string, list_.char_[i]) == 0) {
+      if (list_[i]) {
+        if (strcasecmp(string, list_[i]) == 0) {
           value_.index_ = i;
           break;
         }
@@ -227,7 +227,7 @@ etl::string<MAX_VARIABLE_STRING_LENGTH> Variable::GetString() {
     if ((value_.index_ < 0) || (value_.index_ >= listSize_)) {
       return "";
     } else {
-      return list_.char_[value_.index_];
+      return list_[value_.index_];
     }
     break;
   };
@@ -245,7 +245,7 @@ void Variable::CopyFrom(Variable &other) {
 
 const char *const *Variable::GetListPointer() {
   NAssert(type_ == CHAR_LIST);
-  return list_.char_;
+  return list_;
 };
 
 uint8_t Variable::GetListSize() {

--- a/sources/Foundation/Variables/Variable.h
+++ b/sources/Foundation/Variables/Variable.h
@@ -58,6 +58,7 @@ protected:
 
   FourCC id_;
   Type type_;
+  uint8_t listSize_ = 0;
 
   union {
     int int_;
@@ -73,12 +74,12 @@ protected:
     int index_;
   } defaultValue_;
 
+  // list_ and stringValue_ are mutually exclusive:
+  // list_ is only used when type_ == CHAR_LIST
+  // stringValue_ is only used when type_ == STRING
   union {
-    const char *const *char_;
-  } list_;
-
-  etl::istring *stringValue_ = nullptr;
-
-  uint8_t listSize_;
+    const char *const *list_;
+    etl::istring *stringValue_;
+  };
 };
 #endif

--- a/sources/Foundation/Variables/VariableContainer.cpp
+++ b/sources/Foundation/Variables/VariableContainer.cpp
@@ -10,29 +10,25 @@
 #include "VariableContainer.h"
 #include <string.h>
 
-VariableContainer::VariableContainer(etl::ilist<Variable *> *list)
-    : list_(list){};
+VariableContainer::VariableContainer(Variable **begin, Variable **end)
+    : begin_(begin), end_(end){};
 
 VariableContainer::~VariableContainer(){};
 
 Variable *VariableContainer::FindVariable(FourCC id) {
-  auto it = list_->begin();
-  for (size_t i = 0; i < list_->size(); i++) {
+  for (Variable **it = begin_; it != end_; ++it) {
     if ((*it)->GetID() == id) {
       return *it;
     }
-    it++;
   }
   return NULL;
 };
 
 Variable *VariableContainer::FindVariable(const char *name) {
-  auto it = list_->begin();
-  for (size_t i = 0; i < list_->size(); i++) {
+  for (Variable **it = begin_; it != end_; ++it) {
     if (!strcmp((*it)->GetName(), name)) {
       return *it;
     }
-    it++;
   }
   return NULL;
 };

--- a/sources/Foundation/Variables/VariableContainer.h
+++ b/sources/Foundation/Variables/VariableContainer.h
@@ -10,17 +10,19 @@
 #ifndef _VARIABLE_CONTAINER_H_
 #define _VARIABLE_CONTAINER_H_
 
-#include "Externals/etl/include/etl/list.h"
 #include "Variable.h"
 
 class VariableContainer {
 public:
-  VariableContainer(etl::ilist<Variable *> *list);
+  VariableContainer(Variable **begin, Variable **end);
   virtual ~VariableContainer();
   Variable *FindVariable(FourCC id);
   Variable *FindVariable(const char *name);
+  Variable **VarBegin() const { return begin_; }
+  Variable **VarEnd() const { return end_; }
 
 private:
-  etl::ilist<Variable *> *list_;
+  Variable **begin_;
+  Variable **end_;
 };
 #endif


### PR DESCRIPTION
- Optimizes padding in Variable and moves the two string pointers into a union
- Migrates from etl::list to etl::array for the Instrument's Variables() listing.

Figures below are for the pico-build.

```MASTER branch, unchanged

Memory region         Used Size  Region Size  %age Used
           FLASH:      716308 B         2 MB     34.16%
             RAM:      233688 B       256 KB     89.14%

Changed Variable containers from etl::list to etl::array

Memory region         Used Size  Region Size  %age Used
           FLASH:      707224 B         2 MB     33.72%
             RAM:      227028 B       256 KB     86.60%

--> 6.660 Bytes (2.54%)

Changes in Variable (padding, union)

Memory region         Used Size  Region Size  %age Used
           FLASH:      707080 B         2 MB     33.72%
             RAM:      222484 B       256 KB     84.87%

--> 4.544 Bytes (1.73%)

==> 11.204 Bytes (4.27%)
```