### PR TITLE
Show actual sample filename not temp filename

### DIFF
--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1098,8 +1098,7 @@ bool SampleEditorView::applyTrimOperation(uint32_t start_, uint32_t end_) {
   Trace::Log("SAMPLEEDITOR",
              "Trimmed sample '%s' to %u frames (start=%u, end=%u)",
              workingFilename.c_str(), trimResult.framesKept,
-             trimResult.clampedStart,
-             trimResult.clampedEnd);
+             trimResult.clampedStart, trimResult.clampedEnd);
   return true;
 }
 


### PR DESCRIPTION
Show actual sample filename not temp filename when applying op in sampleeditor.

Fixes: #1318 