### PR TITLE
fixes theme switching display issues + some

### DIFF
--- a/sources/Application/AppWindow.cpp
+++ b/sources/Application/AppWindow.cpp
@@ -274,7 +274,7 @@ void AppWindow::Clear(bool all) {
   memset(_charScreen, ' ', SCREEN_CHARS);
   memset(_charScreenProp, 0, SCREEN_CHARS);
   if (all) {
-    memset(_preScreen, ' ', SCREEN_CHARS);
+    memset(_preScreen, 0, SCREEN_CHARS);
     memset(_preScreenProp, 0, SCREEN_CHARS);
   };
 };

--- a/sources/Application/Views/ThemeImportView.cpp
+++ b/sources/Application/Views/ThemeImportView.cpp
@@ -192,6 +192,9 @@ void ThemeImportView::onImportTheme(const char *filename) {
     AppWindow &app = (AppWindow &)w_;
     app.UpdateColorsFromConfig();
 
+    // make sure we redraw everything with the new colors
+    ForceClear();
+
     // Show success message
     MessageBox *mb =
         MessageBox::Create(*this, "Theme imported successfully", MBBF_OK);

--- a/sources/Application/Views/ThemeView.cpp
+++ b/sources/Application/Views/ThemeView.cpp
@@ -279,6 +279,12 @@ void ThemeView::syncColorComponentVars(Variable *colorVar) {
     uint32_t componentValue =
         (colorValue >> entry.shift) & static_cast<uint32_t>(0xFF);
     entry.componentVar->SetInt(static_cast<int>(componentValue), false);
+
+    if (entry.colorVar->GetID() == FourCC::VarBGColor) {
+      // If the background or foreground color changed, we need to force a
+      // redraw to update all the colors on the screen
+      _forceRedraw = true;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1308 

- fixes `AppWindow::Clear(bool all)` to clear on `' '` as well
- force redraw after background color change to update the entire screen
- force redraw after loading a theme
- fixes text running out of screen on the theme overwrite dialog