### PR TITLE
Support ext wav type

### DIFF
--- a/sources/Application/Instruments/WavHeader.cpp
+++ b/sources/Application/Instruments/WavHeader.cpp
@@ -238,9 +238,9 @@ WavHeaderWriter::ReadHeader(I_File *file) {
 
     uint16_t subtype = static_cast<uint16_t>(subFormat[0]) |
                        (static_cast<uint16_t>(subFormat[1]) << 8);
-    info.audioFormat =
-        (subtype == WAV_FORMAT_IEEE_FLOAT) ? WAV_FORMAT_IEEE_FLOAT
-                                           : WAV_FORMAT_PCM;
+    info.audioFormat = (subtype == WAV_FORMAT_IEEE_FLOAT)
+                           ? WAV_FORMAT_IEEE_FLOAT
+                           : WAV_FORMAT_PCM;
   }
 
   const bool isPcm = info.audioFormat == WAV_FORMAT_PCM;

--- a/tests/wavheader_tests.cpp
+++ b/tests/wavheader_tests.cpp
@@ -175,8 +175,8 @@ ByteWriter BuildExtensibleWav(uint16_t channels, uint32_t sampleRate,
   writer.AppendU32(byteRate);
   writer.AppendU16(blockAlign);
   writer.AppendU16(bitsPerSample);
-  writer.AppendU16(22); // cbSize
-  writer.AppendU16(bitsPerSample); // valid bits per sample
+  writer.AppendU16(22);                        // cbSize
+  writer.AppendU16(bitsPerSample);             // valid bits per sample
   writer.AppendU32(channels == 1 ? 0x4 : 0x3); // mono center / stereo L|R
   writer.AppendU16(subtype); // KSDATAFORMAT_SUBTYPE_* low 16 bits of Data1
   writer.AppendU16(0);


### PR DESCRIPTION
Allows preview playback and import of wav files with a RIFF header that marks them as type WAVE_FORMAT_EXTENSIBLE.
See related issue for more information.

Fixes: #1341