### PR TITLE
Ensure selected list item is always displayed

### DIFF
--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -297,7 +297,7 @@ void ImportView::DrawView() {
   if (fileIndexList_.empty()) {
     return;
   }
-   // ensure selected item is in visible range
+  // ensure selected item is in visible range
   const size_t pageSize = LIST_PAGE_SIZE;
   if (currentIndex_ < topIndex_) {
     topIndex_ = currentIndex_;


### PR DESCRIPTION
Ensure selected list item is always displayed when returning to list view from SampleEditor or going up to parent dir.