### PR TITLE
track the currentIndex of each subdir in fs tree

### DIFF
--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -785,7 +785,8 @@ void ImportView::adjustPreviewVolume(int offset) {
 
 bool ImportView::changeDirectory(FileSystem *fs, const char *name) {
   if (strcmp(name, "..") == 0 && fs->isParentRoot()) {
-    Trace::Log("PICOIMPORT", "Detected top-level directory, navigating to root");
+    Trace::Log("PICOIMPORT",
+               "Detected top-level directory, navigating to root");
     return fs->chdir("/");
   }
 

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -810,7 +810,14 @@ void ImportView::enterDirectory(FileSystem *fs, const char *name) {
   }
 
   if (dirIndexStack_.full()) {
-    Trace::Error("ImportView directory stack overflow");
+    Trace::Error("ImportView directory stack overflow at depth %d",
+                 kDirectoryIndexStackDepth);
+    char message[SCREEN_WIDTH];
+    npf_snprintf(message, sizeof(message), "Max depth is %d",
+                 kDirectoryIndexStackDepth);
+    MessageBox *mb =
+        MessageBox::Create(*this, "Can't enter folder", message, MBBF_OK);
+    DoModal(mb);
     return;
   }
 

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -811,10 +811,10 @@ void ImportView::enterDirectory(FileSystem *fs, const char *name) {
 
   if (dirIndexStack_.full()) {
     Trace::Error("ImportView directory stack overflow at depth %d",
-                 kDirectoryIndexStackDepth);
+                 DirectoryIndexStackDepth);
     char message[SCREEN_WIDTH];
     npf_snprintf(message, sizeof(message), "Max depth is %d",
-                 kDirectoryIndexStackDepth);
+                 DirectoryIndexStackDepth);
     MessageBox *mb =
         MessageBox::Create(*this, "Can't enter folder", message, MBBF_OK);
     DoModal(mb);
@@ -837,11 +837,9 @@ void ImportView::goToParentDirectory(FileSystem *fs) {
     return;
   }
 
+  currentIndex_ = dirIndexStack_.empty() ? 0 : dirIndexStack_.top();
   if (!dirIndexStack_.empty()) {
-    currentIndex_ = dirIndexStack_.top();
     dirIndexStack_.pop();
-  } else {
-    currentIndex_ = 0;
   }
 
   refreshFileIndexList(fs);

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -58,7 +58,7 @@ void ImportView::Reset() {
   previewPlayingIndex_ = 0;
   selectedButton_ = 0;
   toInstr_ = 0;
-  dirDepth_ = 0;
+  dirIndexStack_.clear();
   playKeyHeld_ = false;
   editKeyHeld_ = false;
   enterKeyHeld_ = false;
@@ -809,7 +809,7 @@ void ImportView::enterDirectory(FileSystem *fs, const char *name) {
     return;
   }
 
-  if (dirDepth_ >= kDirectoryIndexStackDepth) {
+  if (dirIndexStack_.full()) {
     Trace::Error("ImportView directory stack overflow");
     return;
   }
@@ -819,8 +819,7 @@ void ImportView::enterDirectory(FileSystem *fs, const char *name) {
     return;
   }
 
-  dirIndexStack_[dirDepth_] = savedIndex;
-  ++dirDepth_;
+  dirIndexStack_.push(savedIndex);
   topIndex_ = 0;
   currentIndex_ = 0;
   refreshFileIndexList(fs);
@@ -831,9 +830,9 @@ void ImportView::goToParentDirectory(FileSystem *fs) {
     return;
   }
 
-  if (dirDepth_ > 0) {
-    --dirDepth_;
-    currentIndex_ = dirIndexStack_[dirDepth_];
+  if (!dirIndexStack_.empty()) {
+    currentIndex_ = dirIndexStack_.top();
+    dirIndexStack_.pop();
   } else {
     currentIndex_ = 0;
   }
@@ -846,7 +845,7 @@ void ImportView::jumpToDirectory(FileSystem *fs, const char *name) {
     return;
   }
 
-  dirDepth_ = 0;
+  dirIndexStack_.clear();
   topIndex_ = 0;
   currentIndex_ = 0;
   refreshFileIndexList(fs);

--- a/sources/Application/Views/ImportView.cpp
+++ b/sources/Application/Views/ImportView.cpp
@@ -58,6 +58,7 @@ void ImportView::Reset() {
   previewPlayingIndex_ = 0;
   selectedButton_ = 0;
   toInstr_ = 0;
+  dirDepth_ = 0;
   playKeyHeld_ = false;
   editKeyHeld_ = false;
   enterKeyHeld_ = false;
@@ -82,9 +83,12 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
         if (fs->getFileType(fileIndex) == PFT_DIR) {
           char name[PFILENAME_SIZE];
           fs->getFileName(fileIndex, name, PFILENAME_SIZE);
-          setCurrentFolder(fs, name);
+          if (strcmp(name, "..") == 0) {
+            goToParentDirectory(fs);
+          } else {
+            enterDirectory(fs, name);
+          }
           isDirty_ = true;
-          topIndex_ = 0;
         }
       }
       pendingDirEnterOnRelease_ = false;
@@ -120,9 +124,8 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
     // NAV+LEFT remains reserved for leaving the ImportView entirely.
     if ((mask & EPBM_EDIT) && (mask & EPBM_LEFT) && !(mask & EPBM_NAV) &&
         !inProjectSampleDir_) {
-      setCurrentFolder(fs, "..");
+      goToParentDirectory(fs);
       isDirty_ = true;
-      topIndex_ = 0;
       return;
     }
 
@@ -156,10 +159,10 @@ void ImportView::ProcessButtonMask(unsigned short mask, bool pressed) {
       // toggle from sdcard "import sample" & project pool listing
       if (inProjectSampleDir_) {
         inProjectSampleDir_ = false;
-        setCurrentFolder(fs, SAMPLES_LIB_DIR);
+        jumpToDirectory(fs, SAMPLES_LIB_DIR);
       } else {
         inProjectSampleDir_ = true;
-        setCurrentFolder(fs, PROJECT_SAMPLES_DIR);
+        jumpToDirectory(fs, PROJECT_SAMPLES_DIR);
       }
       selectedButton_ = 0;
     }
@@ -535,9 +538,9 @@ void ImportView::OnFocus() {
 
   if (inProjectSampleDir_) {
     goProjectSamplesDir(viewData_);
-    setCurrentFolder(fs, ".");
+    jumpToDirectory(fs, ".");
   } else {
-    setCurrentFolder(fs, viewData_->importViewStartDir);
+    jumpToDirectory(fs, viewData_->importViewStartDir);
   }
 };
 
@@ -780,40 +783,72 @@ void ImportView::adjustPreviewVolume(int offset) {
   isDirty_ = true;
 }
 
-void ImportView::setCurrentFolder(FileSystem *fs, const char *name) {
-  // Special case: if we're trying to go up (..) from a top-level directory
-  if (strcmp(name, "..") == 0) {
-    // Check if we're in a top-level directory (parent is root)
-    if (fs->isParentRoot()) {
-      Trace::Log("PICOIMPORT",
-                 "Detected top-level directory, navigating to root");
-      // Navigate directly to root instead of using ".."
-      fs->chdir("/");
-    }
+bool ImportView::changeDirectory(FileSystem *fs, const char *name) {
+  if (strcmp(name, "..") == 0 && fs->isParentRoot()) {
+    Trace::Log("PICOIMPORT", "Detected top-level directory, navigating to root");
+    return fs->chdir("/");
   }
 
-  // Normal directory navigation
   if (!fs->chdir(name)) {
     Trace::Error("FAILED to chdir to %s", name);
+    return false;
   }
-  currentIndex_ = 0;
-  refreshFileIndexList(fs);
+  return true;
+}
 
-  // Check if we're in the projects directory
-  // and if trying to go into the same dir as current project and if so dont
-  // allow it
+void ImportView::enterDirectory(FileSystem *fs, const char *name) {
   char projName[MAX_PROJECT_NAME_LENGTH + 1];
   viewData_->project_->GetProjectName(projName);
 
   if (strcmp(projName, name) == 0) {
-    // We just navigated to a current project directory, not allowed!
-    etl::string<MAX_PROJECT_SAMPLE_PATH_LENGTH> expectedPath(PROJECTS_DIR);
-    // so instead go back out into the projects dir
-    setCurrentFolder(fs, PROJECTS_DIR);
+    jumpToDirectory(fs, PROJECTS_DIR);
 
     Trace::Log("PICOIMPORT",
                "NOT allowed to browse into current project sample directory");
+    return;
   }
+
+  if (dirDepth_ >= kDirectoryIndexStackDepth) {
+    Trace::Error("ImportView directory stack overflow");
+    return;
+  }
+
+  uint8_t savedIndex = static_cast<uint8_t>(currentIndex_);
+  if (!changeDirectory(fs, name)) {
+    return;
+  }
+
+  dirIndexStack_[dirDepth_] = savedIndex;
+  ++dirDepth_;
+  topIndex_ = 0;
+  currentIndex_ = 0;
+  refreshFileIndexList(fs);
+}
+
+void ImportView::goToParentDirectory(FileSystem *fs) {
+  if (!changeDirectory(fs, "..")) {
+    return;
+  }
+
+  if (dirDepth_ > 0) {
+    --dirDepth_;
+    currentIndex_ = dirIndexStack_[dirDepth_];
+  } else {
+    currentIndex_ = 0;
+  }
+
+  refreshFileIndexList(fs);
+}
+
+void ImportView::jumpToDirectory(FileSystem *fs, const char *name) {
+  if (!changeDirectory(fs, name)) {
+    return;
+  }
+
+  dirDepth_ = 0;
+  topIndex_ = 0;
+  currentIndex_ = 0;
+  refreshFileIndexList(fs);
 }
 
 void ImportView::showSampleEditor(
@@ -909,11 +944,10 @@ void ImportView::refreshFileIndexList(FileSystem *fs) {
     }
   }
 
-  if (currentIndex_ >= fileIndexList_.size()) {
-    currentIndex_ = fileIndexList_.size() - 1;
-  }
   if (fileIndexList_.empty()) {
     topIndex_ = 0;
     currentIndex_ = 0;
+  } else if (currentIndex_ >= fileIndexList_.size()) {
+    currentIndex_ = fileIndexList_.size() - 1;
   }
 }

--- a/sources/Application/Views/ImportView.h
+++ b/sources/Application/Views/ImportView.h
@@ -33,7 +33,9 @@ public:
   static ViewType sourceViewType_;
 
 protected:
-  void setCurrentFolder(FileSystem *fs, const char *name);
+  void enterDirectory(FileSystem *fs, const char *name);
+  void goToParentDirectory(FileSystem *fs);
+  void jumpToDirectory(FileSystem *fs, const char *name);
   void warpToNextSample(bool goUp);
   void import();
   void preview(char *name);
@@ -44,6 +46,9 @@ protected:
   void refreshFileIndexList(FileSystem *fs);
 
 private:
+  static constexpr uint8_t kDirectoryIndexStackDepth = 32;
+
+  bool changeDirectory(FileSystem *fs, const char *name);
   void onConfirmRemoveProjectSample(View &view, ModalView &dialog);
 
   size_t topIndex_ = 0;
@@ -59,6 +64,8 @@ private:
   bool pendingDirEnterOnRelease_ = false; // Open dir on ENTER release
   bool inProjectSampleDir_ =
       false; // Flag to track if we're in the project's sample directory
+  uint8_t dirDepth_ = 0;
+  uint8_t dirIndexStack_[kDirectoryIndexStackDepth] = {};
   FileSystem *pendingDeleteFs_ = nullptr;
   char pendingDeleteFilename_[PFILENAME_SIZE] = {};
   etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexList_;

--- a/sources/Application/Views/ImportView.h
+++ b/sources/Application/Views/ImportView.h
@@ -47,7 +47,7 @@ protected:
   void refreshFileIndexList(FileSystem *fs);
 
 private:
-  static constexpr uint8_t kDirectoryIndexStackDepth = 32;
+  static const uint8_t DirectoryIndexStackDepth = 32;
 
   bool changeDirectory(FileSystem *fs, const char *name);
   void onConfirmRemoveProjectSample(View &view, ModalView &dialog);
@@ -65,7 +65,7 @@ private:
   bool pendingDirEnterOnRelease_ = false; // Open dir on ENTER release
   bool inProjectSampleDir_ =
       false; // Flag to track if we're in the project's sample directory
-  etl::stack<uint8_t, kDirectoryIndexStackDepth> dirIndexStack_;
+  etl::stack<uint8_t, DirectoryIndexStackDepth> dirIndexStack_;
   FileSystem *pendingDeleteFs_ = nullptr;
   char pendingDeleteFilename_[PFILENAME_SIZE] = {};
   etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexList_;

--- a/sources/Application/Views/ImportView.h
+++ b/sources/Application/Views/ImportView.h
@@ -11,6 +11,7 @@
 #define _IMPORT_VIEW_H_
 
 #include "Application/Views/ScreenView.h"
+#include "Externals/etl/include/etl/stack.h"
 #include "Externals/etl/include/etl/vector.h"
 #include "System/FileSystem/FileSystem.h"
 #include "ViewData.h"
@@ -64,8 +65,7 @@ private:
   bool pendingDirEnterOnRelease_ = false; // Open dir on ENTER release
   bool inProjectSampleDir_ =
       false; // Flag to track if we're in the project's sample directory
-  uint8_t dirDepth_ = 0;
-  uint8_t dirIndexStack_[kDirectoryIndexStackDepth] = {};
+  etl::stack<uint8_t, kDirectoryIndexStackDepth> dirIndexStack_;
   FileSystem *pendingDeleteFs_ = nullptr;
   char pendingDeleteFilename_[PFILENAME_SIZE] = {};
   etl::vector<int, MAX_FILE_INDEX_SIZE> fileIndexList_;


### PR DESCRIPTION
Uses a small stack to track the current position in each dir as we navigate down through a set of samples subdirs, so that we maintain prev position as we go back up the dir tree. 

This makes navigating something like the AKWF subdirs a **much** more pleasent experience.

The stack size is 32, so only support 32 subdirs deep but that should be plenty for even extremely deeply organised sample pack file hierarchies.

Fixes: #334