### PR TITLE
prevent race cond crash on preview playback

### DIFF
--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -181,14 +181,25 @@ bool PlayerMixer::IsChannelMuted(int channel) {
 }
 
 void PlayerMixer::StartStreaming(const char *name, int startSample) {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
   fileStreamer_.Start(name, startSample);
+  ms->Unlock();
 };
 
 void PlayerMixer::StartLoopingStreaming(const char *name) {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
   fileStreamer_.Start(name, 0, true);
+  ms->Unlock();
 };
 
-void PlayerMixer::StopStreaming() { fileStreamer_.Stop(); };
+void PlayerMixer::StopStreaming() {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
+  fileStreamer_.Stop();
+  ms->Unlock();
+};
 
 void PlayerMixer::StartRecordStreaming(uint16_t *srcBuffer, uint32_t size,
                                        bool stereo) {


### PR DESCRIPTION
In sources/Application/Views/ImportView.cpp:582 we stop the current preview and then immediately start a new one. But on pico, sources/Application/Audio/AudioFileStreamer.cpp:170 does not close the WAV on Core0; it only sets stopRequested_ so Core1 can close it later in sources/Application/Audio/AudioFileStreamer.cpp:191.

Repeated previews can do this sequence:

  1. Core0 requests stop.
  2. Core1 has not finished the current render yet.
  3. Core0 starts the next preview and closes/reopens the same WavFile.
  4. Core1 is still using or about to close the old file state.
  5. You eventually fault inside FsBaseFile::close() with a bad internal pointer, which matches your 0x00000000 frame.
