### PR TITLE
Reload pool sample after editor save-as

### DIFF
--- a/sources/Application/Instruments/SamplePool.cpp
+++ b/sources/Application/Instruments/SamplePool.cpp
@@ -365,6 +365,23 @@ int SamplePool::ImportSample(const char *name, const char *projectName) {
   return status ? (count_ - 1) : -1;
 };
 
+int SamplePool::LoadProjectSample(const char *name) {
+  if (count_ == MAX_SAMPLES) {
+    return -1;
+  }
+
+  if (!loadSample(name)) {
+    return -1;
+  }
+
+  SetChanged();
+  SamplePoolEvent ev;
+  ev.index_ = count_ - 1;
+  ev.type_ = SPET_INSERT;
+  NotifyObservers(&ev);
+  return count_ - 1;
+}
+
 void SamplePool::PurgeSample(int i, const char *projectName) {
   auto fs = FileSystem::GetInstance();
 

--- a/sources/Application/Instruments/SamplePool.h
+++ b/sources/Application/Instruments/SamplePool.h
@@ -38,6 +38,7 @@ public:
   uint32_t FindSampleIndexByName(
       const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &name);
   int ImportSample(const char *name, const char *projectName);
+  int LoadProjectSample(const char *name);
   void PurgeSample(int i, const char *projectName);
   virtual bool CheckSampleFits(int sampleSize) = 0;
   virtual uint32_t GetAvailableSampleStorageSpace() = 0;

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -874,7 +874,7 @@ void Player::playCursorPosition(int channel) {
 
         if (note < 128) {
           mixer_.StartInstrument(channel, instrument, note, newInstrument);
-          int instrTable = instrument->GetTable();
+          int8_t instrTable = instrument->GetTable();
 
           // If an instrument number has been specified && instrument has table,
           // we trigger the table.
@@ -953,7 +953,7 @@ void Player::StepAutomationTableForRetrigger(int channel,
 
 void Player::RetriggerChannelInstrument(int channel, int semitoneOffset,
                                         bool stepAutomationTable) {
-  int note = mixer_.GetChannelNote(channel);
+  int8_t note = mixer_.GetChannelNote(channel);
   I_Instrument *instrument = mixer_.GetInstrument(channel);
 
   if ((note > HIGHEST_NOTE) || (instrument == 0)) {

--- a/sources/Application/Player/Player.cpp
+++ b/sources/Application/Player/Player.cpp
@@ -874,7 +874,7 @@ void Player::playCursorPosition(int channel) {
 
         if (note < 128) {
           mixer_.StartInstrument(channel, instrument, note, newInstrument);
-          int8_t instrTable = instrument->GetTable();
+          int instrTable = instrument->GetTable();
 
           // If an instrument number has been specified && instrument has table,
           // we trigger the table.
@@ -953,7 +953,7 @@ void Player::StepAutomationTableForRetrigger(int channel,
 
 void Player::RetriggerChannelInstrument(int channel, int semitoneOffset,
                                         bool stepAutomationTable) {
-  int8_t note = mixer_.GetChannelNote(channel);
+  int note = mixer_.GetChannelNote(channel);
   I_Instrument *instrument = mixer_.GetInstrument(channel);
 
   if ((note > HIGHEST_NOTE) || (instrument == 0)) {

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1268,8 +1268,7 @@ bool SampleEditorView::preflightProjectPoolSaveAs(
 
   uint32_t availableBytes = pool->GetAvailableSampleStorageSpace();
   char message[SCREEN_WIDTH];
-  npf_snprintf(message, sizeof(message), "Only %d bytes free",
-               availableBytes);
+  npf_snprintf(message, sizeof(message), "Only %d bytes free", availableBytes);
   MessageBox *mb =
       MessageBox::Create(*this, "Sample Too Large       ", message, MBBF_OK);
   clearWaveformRegion();

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1294,6 +1294,84 @@ void SampleEditorView::showLoadToPoolFailedDialog() {
               *this));
 }
 
+etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT>
+SampleEditorView::collectSampleUsers(int sampleIndex) const {
+  etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> users;
+  if (!viewData_ || !viewData_->project_ || sampleIndex < 0) {
+    return users;
+  }
+
+  auto *instrumentBank = viewData_->project_->GetInstrumentBank();
+  if (!instrumentBank) {
+    return users;
+  }
+
+  for (I_Instrument *instrument : instrumentBank->InstrumentsList()) {
+    if (!instrument || instrument->GetType() != IT_SAMPLE) {
+      continue;
+    }
+
+    auto *sampleInstrument = static_cast<SampleInstrument *>(instrument);
+    if (sampleInstrument->GetSampleIndex() == sampleIndex) {
+      users.push_back(sampleInstrument);
+    }
+  }
+
+  return users;
+}
+
+void SampleEditorView::retargetSampleUsers(
+    const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
+    int newIndex) {
+  if (newIndex < 0) {
+    return;
+  }
+
+  for (auto *sampleInstrument : users) {
+    if (sampleInstrument) {
+      sampleInstrument->AssignSample(newIndex);
+    }
+  }
+}
+
+bool SampleEditorView::syncSavedAsProjectPoolSample(
+    const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {
+  auto *pool = SamplePool::GetInstance();
+  if (!pool) {
+    Trace::Error("SampleEditorView: SamplePool unavailable");
+    return false;
+  }
+
+  if (!goProjectSamplesDir(viewData_)) {
+    Trace::Error("SampleEditorView: Failed to chdir for pool sync");
+    return false;
+  }
+
+  int32_t existingIndex = pool->FindSampleIndexByName(savedFilename);
+  if (existingIndex < 0) {
+    if (pool->LoadProjectSample(savedFilename.c_str()) < 0) {
+      Trace::Error("SampleEditorView: Failed to add pool sample %s",
+                   savedFilename.c_str());
+      return false;
+    }
+    return true;
+  }
+
+  auto users = collectSampleUsers(existingIndex);
+  int32_t newIndex = pool->ReloadSample(existingIndex, savedFilename.c_str());
+  if (newIndex < 0) {
+    Trace::Error("SampleEditorView: Failed to refresh pool sample %s",
+                 savedFilename.c_str());
+    return false;
+  }
+
+  if (newIndex != existingIndex) {
+    retargetSampleUsers(users, newIndex);
+  }
+
+  return true;
+}
+
 bool SampleEditorView::saveSample(
     etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {
   auto fs = FileSystem::GetInstance();
@@ -1339,6 +1417,11 @@ bool SampleEditorView::saveSample(
     Trace::Error("SampleEditorView: Save committed but failed pool refresh");
   }
 
+  if (viewData_->isShowingSampleEditorProjectPool && !commitToOriginal &&
+      !syncSavedAsProjectPoolSample(savedFilename)) {
+    Trace::Error("SampleEditorView: Save committed but failed pool sync");
+  }
+
   Trace::Log("SampleEditor", "Saved %s->%s", originalFilename.c_str(),
              savedFilename.c_str());
 
@@ -1371,6 +1454,9 @@ bool SampleEditorView::loadSampleToPool(
       return false;
     }
   } else {
+    if (!syncSavedAsProjectPoolSample(savedFilename)) {
+      return false;
+    }
     sampleId = pool->FindSampleIndexByName(savedFilename);
     if (sampleId < 0) {
       Trace::Error("SampleEditorView: Sample %s not found in pool",

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1365,6 +1365,7 @@ void SampleEditorView::showLoadToPoolFailedDialog() {
               *this));
 }
 
+#ifdef ADV
 etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT>
 SampleEditorView::collectSampleUsers(int sampleIndex) const {
   etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> users;
@@ -1394,13 +1395,13 @@ SampleEditorView::collectSampleUsers(int sampleIndex) const {
 void SampleEditorView::retargetSampleUsers(
     const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
     uint16_t newIndex) {
-
   for (auto *sampleInstrument : users) {
     if (sampleInstrument) {
       sampleInstrument->AssignSample(newIndex);
     }
   }
 }
+#endif
 
 bool SampleEditorView::syncSavedAsProjectPoolSample(
     const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -24,6 +24,7 @@
 #include "SampleEditProgressDisplay.h"
 #include "Services/Midi/MidiService.h"
 #include "System/Console/Trace.h"
+#include "System/Console/nanoprintf.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/Profiler/Profiler.h"
 #include "UIController.h"
@@ -1222,10 +1223,71 @@ bool SampleEditorView::fileExists(
   return fs->exists(filename.c_str());
 }
 
+bool SampleEditorView::preflightProjectPoolSaveAs(
+    const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {
+  if (!viewData_ || !viewData_->isShowingSampleEditorProjectPool) {
+    return true;
+  }
+  auto *pool = SamplePool::GetInstance();
+
+  // Existing filenames are already handled by fileExists() and the overwrite
+  // confirmation flow in attemptSave(). Capacity checks below only apply when
+  // Save As would add a new sample pool entry.
+  if (pool->FindSampleIndexByName(savedFilename) >= 0) {
+    return true;
+  }
+
+  if (pool->GetNameListSize() >= MAX_SAMPLES) {
+    char message[SCREEN_WIDTH];
+    npf_snprintf(message, sizeof(message), "Maximum of %d samples reached",
+                 MAX_SAMPLES);
+    MessageBox *mb = MessageBox::Create(*this, "Cannot Save Sample        ",
+                                        message, MBBF_OK);
+    clearWaveformRegion();
+    DoModal(mb,
+            ModalViewCallback::create<SampleEditorView,
+                                      &SampleEditorView::onSimpleModalDismiss>(
+                *this));
+    return false;
+  }
+
+  WavFile wav;
+  auto wavRes = wav.Open(activeFilename().c_str());
+  if (!wavRes) {
+    Trace::Error("SampleEditorView: Failed opening %s for save preflight",
+                 activeFilename().c_str());
+    return false;
+  }
+
+  uint32_t sampleSize = wav.GetDiskSize(-1);
+  wav.Close();
+
+  if (pool->CheckSampleFits(sampleSize)) {
+    return true;
+  }
+
+  uint32_t availableBytes = pool->GetAvailableSampleStorageSpace();
+  char message[SCREEN_WIDTH];
+  npf_snprintf(message, sizeof(message), "Only %d bytes free",
+               availableBytes);
+  MessageBox *mb =
+      MessageBox::Create(*this, "Sample Too Large       ", message, MBBF_OK);
+  clearWaveformRegion();
+  DoModal(mb,
+          ModalViewCallback::create<SampleEditorView,
+                                    &SampleEditorView::onSimpleModalDismiss>(
+              *this));
+  return false;
+}
+
 void SampleEditorView::attemptSave(bool loadToPool) {
   etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> filename;
   if (!resolveSaveFilename(filename)) {
     showSaveFailedDialog();
+    return;
+  }
+
+  if (!preflightProjectPoolSaveAs(filename)) {
     return;
   }
 

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1228,14 +1228,20 @@ bool SampleEditorView::preflightProjectPoolSaveAs(
   if (!viewData_ || !viewData_->isShowingSampleEditorProjectPool) {
     return true;
   }
-  auto *pool = SamplePool::GetInstance();
 
-  // Existing filenames are already handled by fileExists() and the overwrite
-  // confirmation flow in attemptSave(). Capacity checks below only apply when
-  // Save As would add a new sample pool entry.
-  if (pool->FindSampleIndexByName(savedFilename) >= 0) {
-    return true;
+  const auto &originalFilename = viewData_->sampleEditorFilename;
+  if (savedFilename != originalFilename && fileExists(savedFilename)) {
+    MessageBox *mb = MessageBox::Create(*this, "Cannot Save Sample        ",
+                                        "Sample name already used", MBBF_OK);
+    clearWaveformRegion();
+    DoModal(mb,
+            ModalViewCallback::create<SampleEditorView,
+                                      &SampleEditorView::onSimpleModalDismiss>(
+                *this));
+    return false;
   }
+
+  auto *pool = SamplePool::GetInstance();
 
   if (pool->GetNameListSize() >= MAX_SAMPLES) {
     char message[SCREEN_WIDTH];
@@ -1408,26 +1414,10 @@ bool SampleEditorView::syncSavedAsProjectPoolSample(
     return false;
   }
 
-  int32_t existingIndex = pool->FindSampleIndexByName(savedFilename);
-  if (existingIndex < 0) {
-    if (pool->LoadProjectSample(savedFilename.c_str()) < 0) {
-      Trace::Error("SampleEditorView: Failed to add pool sample %s",
-                   savedFilename.c_str());
-      return false;
-    }
-    return true;
-  }
-
-  auto users = collectSampleUsers(existingIndex);
-  int32_t newIndex = pool->ReloadSample(existingIndex, savedFilename.c_str());
-  if (newIndex < 0) {
-    Trace::Error("SampleEditorView: Failed to refresh pool sample %s",
+  if (pool->LoadProjectSample(savedFilename.c_str()) < 0) {
+    Trace::Error("SampleEditorView: Failed to add pool sample %s",
                  savedFilename.c_str());
     return false;
-  }
-
-  if (newIndex != existingIndex) {
-    retargetSampleUsers(users, newIndex);
   }
 
   return true;

--- a/sources/Application/Views/SampleEditorView.cpp
+++ b/sources/Application/Views/SampleEditorView.cpp
@@ -1223,12 +1223,16 @@ bool SampleEditorView::fileExists(
   return fs->exists(filename.c_str());
 }
 
+// check preconditions for doing save-ad in project pool, checking pool
+// available space & size & not overwriting existing file
 bool SampleEditorView::preflightProjectPoolSaveAs(
     const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {
   if (!viewData_ || !viewData_->isShowingSampleEditorProjectPool) {
     return true;
   }
 
+  // Project-pool Save As must create a new pool entry. Reusing another
+  // existing sample filename is not allowed.
   const auto &originalFilename = viewData_->sampleEditorFilename;
   if (savedFilename != originalFilename && fileExists(savedFilename)) {
     MessageBox *mb = MessageBox::Create(*this, "Cannot Save Sample        ",
@@ -1389,10 +1393,7 @@ SampleEditorView::collectSampleUsers(int sampleIndex) const {
 
 void SampleEditorView::retargetSampleUsers(
     const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
-    int newIndex) {
-  if (newIndex < 0) {
-    return;
-  }
+    uint16_t newIndex) {
 
   for (auto *sampleInstrument : users) {
     if (sampleInstrument) {
@@ -1404,10 +1405,6 @@ void SampleEditorView::retargetSampleUsers(
 bool SampleEditorView::syncSavedAsProjectPoolSample(
     const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename) {
   auto *pool = SamplePool::GetInstance();
-  if (!pool) {
-    Trace::Error("SampleEditorView: SamplePool unavailable");
-    return false;
-  }
 
   if (!goProjectSamplesDir(viewData_)) {
     Trace::Error("SampleEditorView: Failed to chdir for pool sync");

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -73,6 +73,8 @@ private:
   bool
   resolveSaveFilename(etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &filename);
   bool fileExists(const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &filename);
+  bool preflightProjectPoolSaveAs(
+      const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename);
   void attemptSave(bool loadToPool);
   void confirmSave(bool loadToPool);
   void showSaveFailedDialog();

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -77,9 +77,18 @@ private:
   void confirmSave(bool loadToPool);
   void showSaveFailedDialog();
   void showLoadToPoolFailedDialog();
+  etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT>
+  collectSampleUsers(int sampleIndex) const;
+  void retargetSampleUsers(
+      const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
+      int newIndex);
   void loadSample(const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> path,
                   bool isProjectSampleFile);
   bool reloadEditedSample();
+  // Save As must only register or refresh the saved filename in the pool.
+  // It must not move instruments away from the source filename.
+  bool syncSavedAsProjectPoolSample(
+      const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename);
   bool saveSample(etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename);
   bool loadSampleToPool(
       const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> &savedFilename);

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -83,7 +83,7 @@ private:
   collectSampleUsers(int sampleIndex) const;
   void retargetSampleUsers(
       const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
-      int newIndex);
+      uint16_t newIndex);
   void loadSample(const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> path,
                   bool isProjectSampleFile);
   bool reloadEditedSample();

--- a/sources/Application/Views/SampleEditorView.h
+++ b/sources/Application/Views/SampleEditorView.h
@@ -79,11 +79,13 @@ private:
   void confirmSave(bool loadToPool);
   void showSaveFailedDialog();
   void showLoadToPoolFailedDialog();
+#ifdef ADV
   etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT>
   collectSampleUsers(int sampleIndex) const;
   void retargetSampleUsers(
       const etl::vector<SampleInstrument *, MAX_INSTRUMENT_COUNT> &users,
       uint16_t newIndex);
+#endif
   void loadSample(const etl::string<MAX_INSTRUMENT_FILENAME_LENGTH> path,
                   bool isProjectSampleFile);
   bool reloadEditedSample();


### PR DESCRIPTION
After doing a "save-as" save operation in the Sample Editor for a sample in the sample pool, the new sample file needs to be loaded into the project.

Also need to add checks that doing the save-as will not exceed project pool size limits and not overwrite existing pool file.

Fixes: #1384