### PR TITLE
Fix/ Missing fixes from 2.3 release

### DIFF
--- a/sources/Application/Player/PlayerMixer.cpp
+++ b/sources/Application/Player/PlayerMixer.cpp
@@ -181,14 +181,25 @@ bool PlayerMixer::IsChannelMuted(int channel) {
 }
 
 void PlayerMixer::StartStreaming(const char *name, int startSample) {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
   fileStreamer_.Start(name, startSample);
+  ms->Unlock();
 };
 
 void PlayerMixer::StartLoopingStreaming(const char *name) {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
   fileStreamer_.Start(name, 0, true);
+  ms->Unlock();
 };
 
-void PlayerMixer::StopStreaming() { fileStreamer_.Stop(); };
+void PlayerMixer::StopStreaming() {
+  MixerService *ms = MixerService::GetInstance();
+  ms->Lock();
+  fileStreamer_.Stop();
+  ms->Unlock();
+};
 
 void PlayerMixer::StartRecordStreaming(uint16_t *srcBuffer, uint32_t size,
                                        bool stereo) {


### PR DESCRIPTION
Hey !

I was working on the master branch and I've noticed that some commits may be missing from the [2.3-release](https://github.com/xiphonics/picoTracker/tree/2.3-release).

- [prevent race cond crash on preview playback](https://github.com/xiphonics/picoTracker/commit/37df82bd76205412bbedf3a7f3543d86b68c4382)

The second one seems to fix a crash during sample loading on my hw. I may have misunderstand something, but it's worth check it I suppose :)

BTW thanks for you work 🙏 
I'm working on rp2350 compatibility so I will send you another PR about that in the incoming weeks if your interested :)